### PR TITLE
Feat/112 create note atomic rpc

### DIFF
--- a/src/features/notes/actions.ts
+++ b/src/features/notes/actions.ts
@@ -2,8 +2,6 @@
 
 import { getNextReviewDate } from "@/lib/constants/reviewIntervals";
 import { createClient } from "@/lib/supabase/server";
-import type { NoteCreateInput } from "@/types/notes.types";
-import type { ReviewLogCreateInput } from "@/types/review-logs.types";
 
 import { type NoteInput, noteSchema } from "./schema";
 
@@ -47,58 +45,25 @@ export async function createNoteAction(
 
   const firstReviewDate = getNextReviewDate(0);
 
-  const noteToCreate = {
-    title: parsed.data.title,
-    content: parsed.data.content,
-    language: parsed.data.language ?? null,
-    next_review_at: firstReviewDate?.toISOString() ?? null,
-    user_id: user.id,
-  } satisfies NoteCreateInput;
-
-  const { data, error } = await supabase
-    .from("notes")
-    .insert(noteToCreate)
-    .select("id")
-    .single();
-
-  if (error || !data) {
+  if (!firstReviewDate) {
     return { error: "노트 저장에 실패했습니다. 잠시 후 다시 시도해주세요." };
   }
 
-  if (firstReviewDate) {
-    const reviewLogToCreate = {
-      note_id: data.id,
-      user_id: user.id,
-      round: 1,
-      scheduled_at: firstReviewDate.toISOString(),
-    } satisfies ReviewLogCreateInput;
+  const { data: newNoteId, error } = await supabase.rpc(
+    "create_note_with_initial_review_log",
+    {
+      p_title: parsed.data.title,
+      p_content: parsed.data.content,
+      p_scheduled_at: firstReviewDate.toISOString(),
+      ...(parsed.data.language ? { p_language: parsed.data.language } : {}),
+    },
+  );
 
-    const { error: reviewLogError } = await supabase
-      .from("review_logs")
-      .insert(reviewLogToCreate);
-
-    if (reviewLogError) {
-      console.error("Failed to create initial review log", {
-        noteId: data.id,
-        userId: user.id,
-        error: reviewLogError,
-      });
-
-      const { error: rollbackError } = await supabase
-        .from("notes")
-        .update({ next_review_at: null })
-        .eq("id", data.id);
-
-      if (rollbackError) {
-        console.error("Failed to rollback next_review_at", {
-          noteId: data.id,
-          error: rollbackError,
-        });
-      }
-    }
+  if (error || !newNoteId) {
+    return { error: "노트 저장에 실패했습니다. 잠시 후 다시 시도해주세요." };
   }
 
-  return { success: true, newNoteId: data.id };
+  return { success: true, newNoteId };
 }
 
 // TODO: deleteNoteAction 구현 시 인증 체크 필수

--- a/src/features/notes/tests/actions.test.ts
+++ b/src/features/notes/tests/actions.test.ts
@@ -12,51 +12,20 @@ import { createNoteAction } from "../actions";
 
 function createSupabaseMock({
   userId = "user-123",
-  insertError = null,
-  insertedNoteId = "note-123",
-  reviewLogInsertError = null,
+  rpcError = null,
+  rpcResult = "note-123",
 }: {
   userId?: string | null;
-  insertError?: { message: string } | null;
-  insertedNoteId?: string;
-  reviewLogInsertError?: { message: string } | null;
+  rpcError?: { message: string } | null;
+  rpcResult?: string | null;
 } = {}) {
-  const noteSingleMock = vi.fn().mockResolvedValue({
-    data: insertError ? null : { id: insertedNoteId },
-    error: insertError,
-  });
-  const noteSelectMock = vi.fn().mockReturnValue({
-    single: noteSingleMock,
-  });
-  const noteInsertMock = vi.fn().mockReturnValue({
-    select: noteSelectMock,
-  });
-  const noteUpdateEqMock = vi.fn().mockResolvedValue({ error: null });
-  const noteUpdateMock = vi.fn().mockReturnValue({ eq: noteUpdateEqMock });
-  const reviewLogInsertMock = vi.fn().mockResolvedValue({
-    error: reviewLogInsertError,
-  });
-  const fromMock = vi.fn((table: string) => {
-    if (table === "review_logs") {
-      return {
-        insert: reviewLogInsertMock,
-      };
-    }
-
-    return {
-      insert: noteInsertMock,
-      update: noteUpdateMock,
-    };
+  const rpcMock = vi.fn().mockResolvedValue({
+    data: rpcError ? null : rpcResult,
+    error: rpcError,
   });
 
   return {
-    noteInsertMock,
-    noteSelectMock,
-    noteSingleMock,
-    noteUpdateMock,
-    noteUpdateEqMock,
-    reviewLogInsertMock,
-    fromMock,
+    rpcMock,
     supabase: {
       auth: {
         getUser: vi.fn().mockResolvedValue({
@@ -65,7 +34,7 @@ function createSupabaseMock({
           },
         }),
       },
-      from: fromMock,
+      rpc: rpcMock,
     },
   };
 }
@@ -116,7 +85,7 @@ describe("createNoteAction", () => {
   });
 
   it("returns an auth error when the user is not logged in", async () => {
-    const { supabase, noteInsertMock } = createSupabaseMock({ userId: null });
+    const { supabase, rpcMock } = createSupabaseMock({ userId: null });
     createClientMock.mockResolvedValue(supabase);
 
     const formData = new FormData();
@@ -126,18 +95,11 @@ describe("createNoteAction", () => {
     const result = await createNoteAction(null, formData);
 
     expect(result).toEqual({ error: "로그인이 필요합니다." });
-    expect(noteInsertMock).not.toHaveBeenCalled();
+    expect(rpcMock).not.toHaveBeenCalled();
   });
 
-  it("inserts a note and returns the new note id when the payload is valid", async () => {
-    const {
-      supabase,
-      noteInsertMock,
-      noteSelectMock,
-      noteSingleMock,
-      reviewLogInsertMock,
-      fromMock,
-    } = createSupabaseMock();
+  it("calls the note creation RPC and returns the new note id when the payload is valid", async () => {
+    const { supabase, rpcMock } = createSupabaseMock();
     createClientMock.mockResolvedValue(supabase);
 
     const formData = new FormData();
@@ -147,28 +109,20 @@ describe("createNoteAction", () => {
 
     const result = await createNoteAction(null, formData);
 
-    expect(fromMock).toHaveBeenCalledWith("notes");
-    expect(noteInsertMock).toHaveBeenCalledWith({
-      title: "Valid title",
-      content: "Valid content",
-      language: "javascript",
-      next_review_at: "2026-01-02T00:00:00.000Z",
-      user_id: "user-123",
-    });
-    expect(noteSelectMock).toHaveBeenCalledWith("id");
-    expect(noteSingleMock).toHaveBeenCalledOnce();
-    expect(fromMock).toHaveBeenCalledWith("review_logs");
-    expect(reviewLogInsertMock).toHaveBeenCalledWith({
-      note_id: "note-123",
-      user_id: "user-123",
-      round: 1,
-      scheduled_at: "2026-01-02T00:00:00.000Z",
-    });
+    expect(rpcMock).toHaveBeenCalledWith(
+      "create_note_with_initial_review_log",
+      {
+        p_title: "Valid title",
+        p_content: "Valid content",
+        p_language: "javascript",
+        p_scheduled_at: "2026-01-02T00:00:00.000Z",
+      },
+    );
     expect(result).toEqual({ success: true, newNoteId: "note-123" });
   });
 
-  it("serializes an empty language as null for the insert payload", async () => {
-    const { supabase, noteInsertMock } = createSupabaseMock();
+  it("omits language from the RPC payload when the language is empty", async () => {
+    const { supabase, rpcMock } = createSupabaseMock();
     createClientMock.mockResolvedValue(supabase);
 
     const formData = new FormData();
@@ -178,52 +132,21 @@ describe("createNoteAction", () => {
 
     const result = await createNoteAction(null, formData);
 
-    expect(noteInsertMock).toHaveBeenCalledWith({
-      title: "Valid title",
-      content: "Valid content",
-      language: null,
-      next_review_at: "2026-01-02T00:00:00.000Z",
-      user_id: "user-123",
-    });
-    expect(result).toEqual({ success: true, newNoteId: "note-123" });
-  });
-
-  it("rolls back next_review_at and still returns success when review log scheduling fails", async () => {
-    const consoleErrorSpy = vi
-      .spyOn(console, "error")
-      .mockImplementation(() => {});
-    const { supabase, reviewLogInsertMock, noteUpdateMock, noteUpdateEqMock } =
-      createSupabaseMock({
-        reviewLogInsertError: { message: "review log failed" },
-      });
-    createClientMock.mockResolvedValue(supabase);
-
-    const formData = new FormData();
-    formData.set("title", "Valid title");
-    formData.set("content", "Valid content");
-    formData.set("language", "markdown");
-
-    const result = await createNoteAction(null, formData);
-
-    expect(reviewLogInsertMock).toHaveBeenCalledOnce();
-    expect(consoleErrorSpy).toHaveBeenCalledWith(
-      "Failed to create initial review log",
-      expect.objectContaining({
-        noteId: "note-123",
-        userId: "user-123",
-        error: { message: "review log failed" },
-      }),
+    expect(rpcMock).toHaveBeenCalledWith(
+      "create_note_with_initial_review_log",
+      {
+        p_title: "Valid title",
+        p_content: "Valid content",
+        p_scheduled_at: "2026-01-02T00:00:00.000Z",
+      },
     );
-    expect(noteUpdateMock).toHaveBeenCalledWith({ next_review_at: null });
-    expect(noteUpdateEqMock).toHaveBeenCalledWith("id", "note-123");
     expect(result).toEqual({ success: true, newNoteId: "note-123" });
   });
 
-  it("returns a general error when the insert fails", async () => {
-    const { supabase, noteInsertMock, reviewLogInsertMock } =
-      createSupabaseMock({
-        insertError: { message: "insert failed" },
-      });
+  it("returns a general error when the RPC fails", async () => {
+    const { supabase, rpcMock } = createSupabaseMock({
+      rpcError: { message: "rpc failed" },
+    });
     createClientMock.mockResolvedValue(supabase);
 
     const formData = new FormData();
@@ -236,7 +159,23 @@ describe("createNoteAction", () => {
     expect(result).toEqual({
       error: "노트 저장에 실패했습니다. 잠시 후 다시 시도해주세요.",
     });
-    expect(noteInsertMock).toHaveBeenCalledOnce();
-    expect(reviewLogInsertMock).not.toHaveBeenCalled();
+    expect(rpcMock).toHaveBeenCalledOnce();
+  });
+
+  it("returns a general error when the RPC returns no note id", async () => {
+    const { supabase, rpcMock } = createSupabaseMock({ rpcResult: null });
+    createClientMock.mockResolvedValue(supabase);
+
+    const formData = new FormData();
+    formData.set("title", "Valid title");
+    formData.set("content", "Valid content");
+    formData.set("language", "markdown");
+
+    const result = await createNoteAction(null, formData);
+
+    expect(result).toEqual({
+      error: "노트 저장에 실패했습니다. 잠시 후 다시 시도해주세요.",
+    });
+    expect(rpcMock).toHaveBeenCalledOnce();
   });
 });

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -7,10 +7,30 @@ export type Json =
   | Json[];
 
 export type Database = {
-  // Allows to automatically instantiate createClient with right options
-  // instead of createClient<Database, { PostgrestVersion: 'XX' }>(URL, KEY)
-  __InternalSupabase: {
-    PostgrestVersion: "14.4";
+  graphql_public: {
+    Tables: {
+      [_ in never]: never;
+    };
+    Views: {
+      [_ in never]: never;
+    };
+    Functions: {
+      graphql: {
+        Args: {
+          extensions?: Json;
+          operationName?: string;
+          query?: string;
+          variables?: Json;
+        };
+        Returns: Json;
+      };
+    };
+    Enums: {
+      [_ in never]: never;
+    };
+    CompositeTypes: {
+      [_ in never]: never;
+    };
   };
   public: {
     Tables: {
@@ -194,7 +214,15 @@ export type Database = {
       [_ in never]: never;
     };
     Functions: {
-      [_ in never]: never;
+      create_note_with_initial_review_log: {
+        Args: {
+          p_content: string;
+          p_language?: string;
+          p_scheduled_at?: string;
+          p_title: string;
+        };
+        Returns: string;
+      };
     };
     Enums: {
       [_ in never]: never;
@@ -326,6 +354,9 @@ export type CompositeTypes<
     : never;
 
 export const Constants = {
+  graphql_public: {
+    Enums: {},
+  },
   public: {
     Enums: {},
   },

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -218,7 +218,7 @@ export type Database = {
         Args: {
           p_content: string;
           p_language?: string;
-          p_scheduled_at?: string;
+          p_scheduled_at: string;
           p_title: string;
         };
         Returns: string;

--- a/supabase/migrations/20260410000000_add_create_note_with_initial_review_log_rpc.sql
+++ b/supabase/migrations/20260410000000_add_create_note_with_initial_review_log_rpc.sql
@@ -1,8 +1,8 @@
 CREATE OR REPLACE FUNCTION public.create_note_with_initial_review_log(
   p_title text,
   p_content text,
-  p_language text DEFAULT NULL,
-  p_scheduled_at timestamptz DEFAULT NULL
+  p_scheduled_at timestamptz,
+  p_language text DEFAULT NULL
 )
 RETURNS uuid
 LANGUAGE plpgsql
@@ -32,5 +32,5 @@ BEGIN
 END;
 $$;
 
-REVOKE ALL ON FUNCTION public.create_note_with_initial_review_log(text, text, text, timestamptz) FROM PUBLIC, anon, authenticated, service_role;
-GRANT EXECUTE ON FUNCTION public.create_note_with_initial_review_log(text, text, text, timestamptz) TO authenticated;
+REVOKE ALL ON FUNCTION public.create_note_with_initial_review_log(text, text, timestamptz, text) FROM PUBLIC, anon, authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.create_note_with_initial_review_log(text, text, timestamptz, text) TO authenticated;

--- a/supabase/migrations/20260410000000_add_create_note_with_initial_review_log_rpc.sql
+++ b/supabase/migrations/20260410000000_add_create_note_with_initial_review_log_rpc.sql
@@ -1,0 +1,36 @@
+CREATE OR REPLACE FUNCTION public.create_note_with_initial_review_log(
+  p_title text,
+  p_content text,
+  p_language text DEFAULT NULL,
+  p_scheduled_at timestamptz DEFAULT NULL
+)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = public
+AS $$
+DECLARE
+  v_user_id uuid := auth.uid();
+  v_note_id uuid;
+BEGIN
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'not authenticated';
+  END IF;
+
+  IF p_scheduled_at IS NULL THEN
+    RAISE EXCEPTION 'scheduled_at is required';
+  END IF;
+
+  INSERT INTO public.notes (user_id, title, content, language, next_review_at)
+  VALUES (v_user_id, p_title, p_content, p_language, p_scheduled_at)
+  RETURNING id INTO v_note_id;
+
+  INSERT INTO public.review_logs (note_id, user_id, round, scheduled_at)
+  VALUES (v_note_id, v_user_id, 1, p_scheduled_at);
+
+  RETURN v_note_id;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.create_note_with_initial_review_log(text, text, text, timestamptz) FROM PUBLIC, anon, authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.create_note_with_initial_review_log(text, text, text, timestamptz) TO authenticated;

--- a/supabase/tests/notes/create_note_with_initial_review_log.sql
+++ b/supabase/tests/notes/create_note_with_initial_review_log.sql
@@ -1,0 +1,266 @@
+-- =========================================
+-- notes / create_note_with_initial_review_log RPC
+-- =========================================
+
+BEGIN;
+
+SELECT plan(15);
+
+SELECT set_config('test.notes_rpc_user_id', gen_random_uuid()::text, true);
+SELECT set_config('test.notes_rpc_atomic_user_id', gen_random_uuid()::text, true);
+SELECT set_config('test.notes_rpc_scheduled_at', '2026-01-02T00:00:00Z', true);
+SELECT set_config('test.notes_rpc_language_scheduled_at', '2026-01-03T00:00:00Z', true);
+
+INSERT INTO auth.users (id, email, raw_user_meta_data)
+VALUES
+  (
+    current_setting('test.notes_rpc_user_id')::uuid,
+    'notes_rpc_user_' || current_setting('test.notes_rpc_user_id') || '@example.com',
+    '{}'::jsonb
+  ),
+  (
+    current_setting('test.notes_rpc_atomic_user_id')::uuid,
+    'notes_rpc_atomic_user_' || current_setting('test.notes_rpc_atomic_user_id') || '@example.com',
+    '{}'::jsonb
+  )
+ON CONFLICT (id) DO NOTHING;
+
+SET LOCAL ROLE authenticated;
+SELECT set_config(
+  'request.jwt.claims',
+  json_build_object(
+    'sub', current_setting('test.notes_rpc_user_id'),
+    'role', 'authenticated'
+  )::text,
+  true
+);
+
+SELECT set_config(
+  'test.notes_rpc_note_id',
+  public.create_note_with_initial_review_log(
+    'rpc title',
+    'rpc content',
+    NULL,
+    current_setting('test.notes_rpc_scheduled_at')::timestamptz
+  )::text,
+  true
+);
+
+SELECT is(
+  (
+    SELECT count(*)
+    FROM public.notes
+    WHERE id = current_setting('test.notes_rpc_note_id')::uuid
+  ),
+  1::bigint,
+  $$authenticated 사용자가 RPC를 호출하면 notes가 1건 생성되어야 한다$$
+);
+
+SELECT is(
+  (
+    SELECT count(*)
+    FROM public.review_logs
+    WHERE note_id = current_setting('test.notes_rpc_note_id')::uuid
+  ),
+  1::bigint,
+  $$같은 RPC 호출에서 review_logs가 1건 생성되어야 한다$$
+);
+
+SELECT is(
+  (
+    SELECT id::text
+    FROM public.notes
+    WHERE id = current_setting('test.notes_rpc_note_id')::uuid
+  ),
+  current_setting('test.notes_rpc_note_id'),
+  $$RPC 반환 uuid는 생성된 note.id와 같아야 한다$$
+);
+
+SELECT is(
+  (
+    SELECT note_id::text
+    FROM public.review_logs
+    WHERE note_id = current_setting('test.notes_rpc_note_id')::uuid
+  ),
+  current_setting('test.notes_rpc_note_id'),
+  $$review_logs.note_id는 생성된 note.id와 같아야 한다$$
+);
+
+SELECT ok(
+  (
+    SELECT n.user_id = auth.uid()
+      AND rl.user_id = auth.uid()
+    FROM public.notes n
+    JOIN public.review_logs rl
+      ON rl.note_id = n.id
+    WHERE n.id = current_setting('test.notes_rpc_note_id')::uuid
+  ),
+  $$notes.user_id와 review_logs.user_id는 auth.uid()와 같아야 한다$$
+);
+
+SELECT ok(
+  (
+    SELECT n.next_review_at = current_setting('test.notes_rpc_scheduled_at')::timestamptz
+      AND rl.scheduled_at = current_setting('test.notes_rpc_scheduled_at')::timestamptz
+    FROM public.notes n
+    JOIN public.review_logs rl
+      ON rl.note_id = n.id
+    WHERE n.id = current_setting('test.notes_rpc_note_id')::uuid
+  ),
+  $$notes.next_review_at과 review_logs.scheduled_at은 p_scheduled_at과 같아야 한다$$
+);
+
+SELECT is(
+  (
+    SELECT round
+    FROM public.review_logs
+    WHERE note_id = current_setting('test.notes_rpc_note_id')::uuid
+  ),
+  1,
+  $$초기 review_logs.round는 1이어야 한다$$
+);
+
+SELECT is(
+  (
+    SELECT review_round
+    FROM public.notes
+    WHERE id = current_setting('test.notes_rpc_note_id')::uuid
+  ),
+  0,
+  $$초기 notes.review_round는 기본값 0이어야 한다$$
+);
+
+SELECT is(
+  (
+    SELECT language
+    FROM public.notes
+    WHERE id = current_setting('test.notes_rpc_note_id')::uuid
+  ),
+  NULL::character varying,
+  $$p_language = NULL 호출은 language를 NULL로 저장해야 한다$$
+);
+
+SELECT set_config(
+  'test.notes_rpc_language_note_id',
+  public.create_note_with_initial_review_log(
+    'rpc language title',
+    'rpc language content',
+    'javascript',
+    current_setting('test.notes_rpc_language_scheduled_at')::timestamptz
+  )::text,
+  true
+);
+
+SELECT is(
+  (
+    SELECT language::text
+    FROM public.notes
+    WHERE id = current_setting('test.notes_rpc_language_note_id')::uuid
+  ),
+  'javascript',
+  $$허용된 language 값은 정상 저장되어야 한다$$
+);
+
+SET LOCAL ROLE anon;
+SELECT set_config('request.jwt.claims', '{}'::text, true);
+
+SELECT throws_ok(
+  $sql$
+    SELECT public.create_note_with_initial_review_log(
+      'anon title',
+      'anon content',
+      NULL::text,
+      '2026-01-04T00:00:00Z'::timestamptz
+    );
+  $sql$,
+  '42501',
+  NULL,
+  $$anon 컨텍스트에서는 RPC 호출이 거부되어야 한다$$
+);
+
+SET LOCAL ROLE authenticated;
+SELECT set_config(
+  'request.jwt.claims',
+  json_build_object(
+    'sub', current_setting('test.notes_rpc_user_id'),
+    'role', 'authenticated'
+  )::text,
+  true
+);
+
+SELECT throws_ok(
+  $sql$
+    SELECT public.create_note_with_initial_review_log(
+      'invalid language title',
+      'invalid language content',
+      'ruby',
+      '2026-01-05T00:00:00Z'::timestamptz
+    );
+  $sql$,
+  '23514',
+  NULL,
+  $$허용되지 않은 language 값은 기존 DB constraint로 거부되어야 한다$$
+);
+
+SELECT throws_ok(
+  $sql$
+    SELECT public.create_note_with_initial_review_log(
+      'null schedule title',
+      'null schedule content',
+      NULL::text,
+      NULL::timestamptz
+    );
+  $sql$,
+  'P0001',
+  NULL,
+  $$p_scheduled_at = NULL 호출은 거부되어야 한다$$
+);
+
+RESET ROLE;
+
+ALTER TABLE public.review_logs
+ADD CONSTRAINT review_logs_test_future_limit
+CHECK (scheduled_at < '2100-01-01T00:00:00Z'::timestamptz);
+
+SET LOCAL ROLE authenticated;
+SELECT set_config(
+  'request.jwt.claims',
+  json_build_object(
+    'sub', current_setting('test.notes_rpc_atomic_user_id'),
+    'role', 'authenticated'
+  )::text,
+  true
+);
+
+SELECT throws_ok(
+  $sql$
+    SELECT public.create_note_with_initial_review_log(
+      'atomic failure marker',
+      'content',
+      NULL::text,
+      '2200-01-01T00:00:00Z'::timestamptz
+    );
+  $sql$,
+  '23514',
+  NULL,
+  $$review_logs INSERT가 실패하면 RPC 호출은 실패해야 한다$$
+);
+
+SELECT is(
+  (
+    SELECT count(*)
+    FROM public.notes
+    WHERE user_id = current_setting('test.notes_rpc_atomic_user_id')::uuid
+      AND title = 'atomic failure marker'
+  ),
+  0::bigint,
+  $$review_logs INSERT 실패 시 해당 호출의 notes 고아 row가 남지 않아야 한다$$
+);
+
+RESET ROLE;
+
+ALTER TABLE public.review_logs
+DROP CONSTRAINT review_logs_test_future_limit;
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/supabase/tests/notes/create_note_with_initial_review_log.sql
+++ b/supabase/tests/notes/create_note_with_initial_review_log.sql
@@ -40,8 +40,8 @@ SELECT set_config(
   public.create_note_with_initial_review_log(
     'rpc title',
     'rpc content',
-    NULL,
-    current_setting('test.notes_rpc_scheduled_at')::timestamptz
+    current_setting('test.notes_rpc_scheduled_at')::timestamptz,
+    NULL
   )::text,
   true
 );
@@ -145,8 +145,8 @@ SELECT set_config(
   public.create_note_with_initial_review_log(
     'rpc language title',
     'rpc language content',
-    'javascript',
-    current_setting('test.notes_rpc_language_scheduled_at')::timestamptz
+    current_setting('test.notes_rpc_language_scheduled_at')::timestamptz,
+    'javascript'
   )::text,
   true
 );
@@ -169,8 +169,8 @@ SELECT throws_ok(
     SELECT public.create_note_with_initial_review_log(
       'anon title',
       'anon content',
-      NULL::text,
-      '2026-01-04T00:00:00Z'::timestamptz
+      '2026-01-04T00:00:00Z'::timestamptz,
+      NULL::text
     );
   $sql$,
   '42501',
@@ -193,8 +193,8 @@ SELECT throws_ok(
     SELECT public.create_note_with_initial_review_log(
       'invalid language title',
       'invalid language content',
-      'ruby',
-      '2026-01-05T00:00:00Z'::timestamptz
+      '2026-01-05T00:00:00Z'::timestamptz,
+      'ruby'
     );
   $sql$,
   '23514',
@@ -207,8 +207,8 @@ SELECT throws_ok(
     SELECT public.create_note_with_initial_review_log(
       'null schedule title',
       'null schedule content',
-      NULL::text,
-      NULL::timestamptz
+      NULL::timestamptz,
+      NULL::text
     );
   $sql$,
   'P0001',
@@ -237,8 +237,8 @@ SELECT throws_ok(
     SELECT public.create_note_with_initial_review_log(
       'atomic failure marker',
       'content',
-      NULL::text,
-      '2200-01-01T00:00:00Z'::timestamptz
+      '2200-01-01T00:00:00Z'::timestamptz,
+      NULL::text
     );
   $sql$,
   '23514',


### PR DESCRIPTION
## 개요

노트 생성과 초기 복습 로그 생성을 하나의 Supabase RPC로 묶어 원자성을 보장합니다.

기존에는 `notes` 생성 후 `review_logs` 생성이 실패하면 보정 로직이 필요했지만, 이제 DB 함수 안에서 함께 처리되어 중간 실패 시 전체 호출이 실패합니다. 리뷰 반영으로 `p_scheduled_at`도 required 인자로 맞춰 generated type과 SQL 의미가 일치하도록 수정했습니다.

## PR 유형

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] UI 디자인 변경
- [ ] 코드 리팩터링
- [x] 테스트 추가/수정
- [ ] 문서 수정
- [ ] 빌드/패키지 설정 변경

## 관련 이슈

closes #112

## 작업 내용

- `create_note_with_initial_review_log` RPC 추가
  - 인증된 사용자만 실행 가능
  - `notes` 생성과 초기 `review_logs` 생성을 같은 DB 트랜잭션에서 처리
  - `auth.uid()`가 없거나 `p_scheduled_at`이 `NULL`이면 실패
- `createNoteAction`이 직접 `notes` / `review_logs`를 순차 insert하지 않고 RPC를 호출하도록 변경
- `p_scheduled_at`의 SQL default를 제거하고 required 인자로 조정
  - `p_language DEFAULT NULL`은 optional 유지
  - generated type에서도 `p_scheduled_at: string`으로 정합성 맞춤
- RPC 동작, 권한, invalid language, null scheduled_at, review_logs 실패 시 원자성을 검증하는 pgTAP 테스트 추가
- 액션 단위 테스트를 RPC 호출 방식에 맞게 갱신
- Supabase type 재생성 과정에서 `graphql_public` schema가 함께 포함됨
  - `supabase/config.toml`의 schema 설정에 따른 generated diff이며 기능 영향 없음

## 테스트 방법

- [x] `npm run type-check`
- [x] `npx vitest run src/features/notes/tests/actions.test.ts`
- [x] `npx supabase db reset`
- [x] `npx supabase test db supabase/tests/notes/create_note_with_initial_review_log.sql`
- [x] `npx supabase test db`

검증 결과:

- notes action Vitest: 7 tests passed
- focused RPC pgTAP: 15 tests passed
- full Supabase pgTAP: 32 files, 830 tests, PASS

## 스크린샷 (FE 변경)

해당 없음

## 리뷰 요구사항

- RPC 시그니처가 앱 호출 방식과 generated type에 맞는지 확인 부탁드립니다.
- `graphql_public` schema diff는 Supabase type 재생성으로 포함된 항목입니다.

## 체크리스트

- [x] 코드 컨벤션 준수
- [x] 커밋 메시지 컨벤션 준수
- [x] lint 통과
- [x] typecheck 통과
- [x] DB 변경 시 migration 포함 및 로컬 재현 확인
- [x] 권한/RLS 영향 및 정책 변경 요약 기재
- [ ] UI 변경 시 스크린샷/지표 설명 첨부
- [x] 자체 리뷰 완료
