### PR TITLE
feat: #115 - review completion RPC와 pending review_log 제약 추가

### DIFF
--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -214,6 +214,13 @@ export type Database = {
       [_ in never]: never;
     };
     Functions: {
+      complete_review_and_schedule_next: {
+        Args: {
+          p_note_id: string;
+          p_review_log_id: string;
+        };
+        Returns: string;
+      };
       create_note_with_initial_review_log: {
         Args: {
           p_content: string;

--- a/supabase/migrations/20260412000000_add_complete_review_and_schedule_next_rpc.sql
+++ b/supabase/migrations/20260412000000_add_complete_review_and_schedule_next_rpc.sql
@@ -1,3 +1,44 @@
+DO $$
+DECLARE
+  v_duplicate_note_count integer;
+  v_duplicate_note_ids text;
+BEGIN
+  SELECT count(*)
+    INTO v_duplicate_note_count
+  FROM (
+    SELECT rl.note_id
+    FROM public.review_logs rl
+    WHERE rl.completed_at IS NULL
+    GROUP BY rl.note_id
+    HAVING count(*) > 1
+  ) duplicate_pending_notes;
+
+  SELECT string_agg(duplicate_pending_notes.note_id::text, ', ' ORDER BY duplicate_pending_notes.note_id::text)
+    INTO v_duplicate_note_ids
+  FROM (
+    SELECT rl.note_id
+    FROM public.review_logs rl
+    WHERE rl.completed_at IS NULL
+    GROUP BY rl.note_id
+    HAVING count(*) > 1
+    ORDER BY rl.note_id
+    LIMIT 10
+  ) duplicate_pending_notes;
+
+  -- Fail with an actionable error before the index build hides which note rows need cleanup.
+  IF v_duplicate_note_count > 0 THEN
+    RAISE EXCEPTION USING
+      MESSAGE = 'Cannot add review_logs_one_pending_per_note_idx while duplicate pending review_logs exist.',
+      DETAIL = format(
+        'Found %s note_id(s) with more than one pending review_log. Sample note_id(s): %s',
+        v_duplicate_note_count,
+        coalesce(v_duplicate_note_ids, '(none)')
+      ),
+      HINT = 'Deduplicate rows where completed_at IS NULL so each note_id has at most one pending review_log, then rerun this migration.';
+  END IF;
+END
+$$;
+
 CREATE UNIQUE INDEX IF NOT EXISTS review_logs_one_pending_per_note_idx
 ON public.review_logs (note_id)
 WHERE completed_at IS NULL;

--- a/supabase/migrations/20260412000000_add_complete_review_and_schedule_next_rpc.sql
+++ b/supabase/migrations/20260412000000_add_complete_review_and_schedule_next_rpc.sql
@@ -1,0 +1,82 @@
+CREATE UNIQUE INDEX IF NOT EXISTS review_logs_one_pending_per_note_idx
+ON public.review_logs (note_id)
+WHERE completed_at IS NULL;
+
+CREATE OR REPLACE FUNCTION public.complete_review_and_schedule_next(
+  p_note_id uuid,
+  p_review_log_id uuid
+)
+RETURNS uuid
+LANGUAGE plpgsql
+-- review_logs intentionally has no UPDATE policy, so this RPC performs the
+-- ownership check explicitly and updates the locked row within the same transaction.
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_user_id uuid := auth.uid();
+  v_current_round integer;
+  v_note_review_round integer;
+  v_next_review_at timestamptz;
+  -- Use wall-clock time so completion and the next schedule share the same actual timestamp.
+  v_now timestamptz := clock_timestamp();
+BEGIN
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'not authenticated';
+  END IF;
+
+  IF p_note_id IS NULL OR p_review_log_id IS NULL THEN
+    RAISE EXCEPTION 'note_id and review_log_id are required';
+  END IF;
+
+  SELECT rl.round, n.review_round
+    INTO v_current_round, v_note_review_round
+  FROM public.review_logs rl
+  JOIN public.notes n
+    ON n.id = rl.note_id
+  WHERE rl.id = p_review_log_id
+    AND rl.note_id = p_note_id
+    AND rl.user_id = v_user_id
+    AND rl.completed_at IS NULL
+    AND n.user_id = v_user_id
+  FOR UPDATE OF rl, n;
+
+  IF v_current_round IS NULL THEN
+    RAISE EXCEPTION 'pending review log not found';
+  END IF;
+
+  IF v_current_round <> v_note_review_round + 1 THEN
+    RAISE EXCEPTION 'review log round does not match current note state';
+  END IF;
+
+  -- Keep this in sync with REVIEW_INTERVALS_DAYS ([1, 3, 7]) so callers
+  -- cannot bypass the spaced-repetition cadence by supplying arbitrary dates.
+  v_next_review_at := CASE v_current_round
+    WHEN 1 THEN v_now + interval '3 days'
+    WHEN 2 THEN v_now + interval '7 days'
+    ELSE NULL
+  END;
+
+  UPDATE public.review_logs
+  SET completed_at = v_now
+  WHERE id = p_review_log_id
+    AND note_id = p_note_id
+    AND user_id = v_user_id;
+
+  UPDATE public.notes
+  SET review_round = v_current_round,
+      next_review_at = v_next_review_at
+  WHERE id = p_note_id
+    AND user_id = v_user_id;
+
+  IF v_current_round < 3 THEN
+    INSERT INTO public.review_logs (note_id, user_id, round, scheduled_at)
+    VALUES (p_note_id, v_user_id, v_current_round + 1, v_next_review_at);
+  END IF;
+
+  RETURN p_note_id;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.complete_review_and_schedule_next(uuid, uuid) FROM PUBLIC, anon, authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.complete_review_and_schedule_next(uuid, uuid) TO authenticated;

--- a/supabase/tests/review_logs/complete_review_and_schedule_next.sql
+++ b/supabase/tests/review_logs/complete_review_and_schedule_next.sql
@@ -1,0 +1,327 @@
+-- =========================================
+-- review_logs / complete_review_and_schedule_next RPC
+-- =========================================
+
+BEGIN;
+
+SELECT plan(17);
+
+SELECT set_config('test.review_complete_user_a_id', gen_random_uuid()::text, true);
+SELECT set_config('test.review_complete_user_b_id', gen_random_uuid()::text, true);
+SELECT set_config('test.review_complete_note_round1_id', gen_random_uuid()::text, true);
+SELECT set_config('test.review_complete_note_round2_id', gen_random_uuid()::text, true);
+SELECT set_config('test.review_complete_note_round3_id', gen_random_uuid()::text, true);
+SELECT set_config('test.review_complete_note_other_id', gen_random_uuid()::text, true);
+SELECT set_config('test.review_complete_note_mismatch_id', gen_random_uuid()::text, true);
+SELECT set_config('test.review_complete_log_round1_id', gen_random_uuid()::text, true);
+SELECT set_config('test.review_complete_log_round2_id', gen_random_uuid()::text, true);
+SELECT set_config('test.review_complete_log_round3_id', gen_random_uuid()::text, true);
+SELECT set_config('test.review_complete_log_other_id', gen_random_uuid()::text, true);
+SELECT set_config('test.review_complete_log_mismatch_id', gen_random_uuid()::text, true);
+
+INSERT INTO auth.users (id, email, raw_user_meta_data)
+VALUES
+  (
+    current_setting('test.review_complete_user_a_id')::uuid,
+    'review_complete_user_a_' || current_setting('test.review_complete_user_a_id') || '@example.com',
+    '{}'::jsonb
+  ),
+  (
+    current_setting('test.review_complete_user_b_id')::uuid,
+    'review_complete_user_b_' || current_setting('test.review_complete_user_b_id') || '@example.com',
+    '{}'::jsonb
+  )
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO public.notes (id, user_id, title, content, review_round, next_review_at)
+VALUES
+  (
+    current_setting('test.review_complete_note_round1_id')::uuid,
+    current_setting('test.review_complete_user_a_id')::uuid,
+    'round1 note',
+    'round1 content',
+    0,
+    '2026-01-02T00:00:00Z'::timestamptz
+  ),
+  (
+    current_setting('test.review_complete_note_round2_id')::uuid,
+    current_setting('test.review_complete_user_a_id')::uuid,
+    'round2 note',
+    'round2 content',
+    1,
+    '2026-01-05T00:00:00Z'::timestamptz
+  ),
+  (
+    current_setting('test.review_complete_note_round3_id')::uuid,
+    current_setting('test.review_complete_user_a_id')::uuid,
+    'round3 note',
+    'round3 content',
+    2,
+    '2026-01-08T00:00:00Z'::timestamptz
+  ),
+  (
+    current_setting('test.review_complete_note_other_id')::uuid,
+    current_setting('test.review_complete_user_b_id')::uuid,
+    'other note',
+    'other content',
+    0,
+    '2026-01-03T00:00:00Z'::timestamptz
+  ),
+  (
+    current_setting('test.review_complete_note_mismatch_id')::uuid,
+    current_setting('test.review_complete_user_a_id')::uuid,
+    'mismatch note',
+    'mismatch content',
+    0,
+    '2026-01-06T00:00:00Z'::timestamptz
+  );
+
+INSERT INTO public.review_logs (id, note_id, user_id, round, scheduled_at)
+VALUES
+  (
+    current_setting('test.review_complete_log_round1_id')::uuid,
+    current_setting('test.review_complete_note_round1_id')::uuid,
+    current_setting('test.review_complete_user_a_id')::uuid,
+    1,
+    '2026-01-02T00:00:00Z'::timestamptz
+  ),
+  (
+    current_setting('test.review_complete_log_round2_id')::uuid,
+    current_setting('test.review_complete_note_round2_id')::uuid,
+    current_setting('test.review_complete_user_a_id')::uuid,
+    2,
+    '2026-01-05T00:00:00Z'::timestamptz
+  ),
+  (
+    current_setting('test.review_complete_log_round3_id')::uuid,
+    current_setting('test.review_complete_note_round3_id')::uuid,
+    current_setting('test.review_complete_user_a_id')::uuid,
+    3,
+    '2026-01-08T00:00:00Z'::timestamptz
+  ),
+  (
+    current_setting('test.review_complete_log_other_id')::uuid,
+    current_setting('test.review_complete_note_other_id')::uuid,
+    current_setting('test.review_complete_user_b_id')::uuid,
+    1,
+    '2026-01-03T00:00:00Z'::timestamptz
+  ),
+  (
+    current_setting('test.review_complete_log_mismatch_id')::uuid,
+    current_setting('test.review_complete_note_mismatch_id')::uuid,
+    current_setting('test.review_complete_user_a_id')::uuid,
+    2,
+    '2026-01-06T00:00:00Z'::timestamptz
+  );
+
+SET LOCAL ROLE anon;
+SELECT set_config('request.jwt.claims', '{}'::text, true);
+
+SELECT throws_ok(
+  $sql$
+    SELECT public.complete_review_and_schedule_next(
+      current_setting('test.review_complete_note_round1_id')::uuid,
+      current_setting('test.review_complete_log_round1_id')::uuid
+    );
+  $sql$,
+  '42501',
+  NULL,
+  $$anon callers should be blocked before the RPC body runs$$
+);
+
+SET LOCAL ROLE authenticated;
+SELECT set_config('request.jwt.claims', '{}'::text, true);
+
+SELECT throws_ok(
+  $sql$
+    SELECT public.complete_review_and_schedule_next(
+      current_setting('test.review_complete_note_round1_id')::uuid,
+      current_setting('test.review_complete_log_round1_id')::uuid
+    );
+  $sql$,
+  'P0001',
+  'not authenticated',
+  $$authenticated role without a JWT subject should be rejected$$
+);
+
+SELECT set_config(
+  'request.jwt.claims',
+  json_build_object(
+    'sub', current_setting('test.review_complete_user_a_id'),
+    'role', 'authenticated'
+  )::text,
+  true
+);
+
+SELECT throws_ok(
+  $sql$
+    SELECT public.complete_review_and_schedule_next(
+      NULL::uuid,
+      current_setting('test.review_complete_log_round1_id')::uuid
+    );
+  $sql$,
+  'P0001',
+  'note_id and review_log_id are required',
+  $$NULL note_id should be rejected$$
+);
+
+SELECT throws_ok(
+  $sql$
+    SELECT public.complete_review_and_schedule_next(
+      current_setting('test.review_complete_note_round1_id')::uuid,
+      NULL::uuid
+    );
+  $sql$,
+  'P0001',
+  'note_id and review_log_id are required',
+  $$NULL review_log_id should be rejected$$
+);
+
+SELECT is(
+  public.complete_review_and_schedule_next(
+    current_setting('test.review_complete_note_round1_id')::uuid,
+    current_setting('test.review_complete_log_round1_id')::uuid
+  )::text,
+  current_setting('test.review_complete_note_round1_id'),
+  $$round 1 RPC should return the note id$$
+);
+
+SELECT ok(
+  (
+    SELECT completed_at IS NOT NULL
+    FROM public.review_logs
+    WHERE id = current_setting('test.review_complete_log_round1_id')::uuid
+  ),
+  $$round 1 log should be marked as completed$$
+);
+
+SELECT ok(
+  (
+    SELECT n.review_round = 1
+      AND n.next_review_at = rl.completed_at + interval '3 days'
+    FROM public.notes n
+    JOIN public.review_logs rl
+      ON rl.id = current_setting('test.review_complete_log_round1_id')::uuid
+    WHERE n.id = current_setting('test.review_complete_note_round1_id')::uuid
+  ),
+  $$round 1 completion should schedule the next review three days later$$
+);
+
+SELECT is(
+  (
+    SELECT count(*)
+    FROM public.review_logs rl
+    JOIN public.review_logs completed
+      ON completed.id = current_setting('test.review_complete_log_round1_id')::uuid
+    WHERE rl.note_id = current_setting('test.review_complete_note_round1_id')::uuid
+      AND rl.round = 2
+      AND rl.scheduled_at = completed.completed_at + interval '3 days'
+      AND rl.completed_at IS NULL
+  ),
+  1::bigint,
+  $$round 1 completion should create exactly one pending round 2 log$$
+);
+
+SELECT throws_ok(
+  $sql$
+    SELECT public.complete_review_and_schedule_next(
+      current_setting('test.review_complete_note_round1_id')::uuid,
+      current_setting('test.review_complete_log_round1_id')::uuid
+    );
+  $sql$,
+  'P0001',
+  'pending review log not found',
+  $$completed review logs should not be completable twice$$
+);
+
+SELECT is(
+  public.complete_review_and_schedule_next(
+    current_setting('test.review_complete_note_round2_id')::uuid,
+    current_setting('test.review_complete_log_round2_id')::uuid
+  )::text,
+  current_setting('test.review_complete_note_round2_id'),
+  $$round 2 RPC should return the note id$$
+);
+
+SELECT ok(
+  (
+    SELECT n.review_round = 2
+      AND n.next_review_at = rl.completed_at + interval '7 days'
+    FROM public.notes n
+    JOIN public.review_logs rl
+      ON rl.id = current_setting('test.review_complete_log_round2_id')::uuid
+    WHERE n.id = current_setting('test.review_complete_note_round2_id')::uuid
+  ),
+  $$round 2 completion should schedule the next review seven days later$$
+);
+
+SELECT is(
+  (
+    SELECT count(*)
+    FROM public.review_logs rl
+    JOIN public.review_logs completed
+      ON completed.id = current_setting('test.review_complete_log_round2_id')::uuid
+    WHERE rl.note_id = current_setting('test.review_complete_note_round2_id')::uuid
+      AND rl.round = 3
+      AND rl.scheduled_at = completed.completed_at + interval '7 days'
+      AND rl.completed_at IS NULL
+  ),
+  1::bigint,
+  $$round 2 completion should create exactly one pending round 3 log$$
+);
+
+SELECT is(
+  public.complete_review_and_schedule_next(
+    current_setting('test.review_complete_note_round3_id')::uuid,
+    current_setting('test.review_complete_log_round3_id')::uuid
+  )::text,
+  current_setting('test.review_complete_note_round3_id'),
+  $$round 3 RPC should return the note id$$
+);
+
+SELECT ok(
+  (
+    SELECT review_round = 3
+      AND next_review_at IS NULL
+    FROM public.notes
+    WHERE id = current_setting('test.review_complete_note_round3_id')::uuid
+  ),
+  $$round 3 completion should clear next_review_at$$
+);
+
+SELECT is(
+  (
+    SELECT count(*)
+    FROM public.review_logs
+    WHERE note_id = current_setting('test.review_complete_note_round3_id')::uuid
+  ),
+  1::bigint,
+  $$round 3 completion should not create an extra review log$$
+);
+
+SELECT throws_ok(
+  $sql$
+    SELECT public.complete_review_and_schedule_next(
+      current_setting('test.review_complete_note_other_id')::uuid,
+      current_setting('test.review_complete_log_other_id')::uuid
+    );
+  $sql$,
+  'P0001',
+  'pending review log not found',
+  $$another user's review log should not be completable$$
+);
+
+SELECT throws_ok(
+  $sql$
+    SELECT public.complete_review_and_schedule_next(
+      current_setting('test.review_complete_note_mismatch_id')::uuid,
+      current_setting('test.review_complete_log_mismatch_id')::uuid
+    );
+  $sql$,
+  'P0001',
+  'review log round does not match current note state',
+  $$out-of-order review logs should be rejected$$
+);
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/supabase/tests/review_logs/constraints_check.sql
+++ b/supabase/tests/review_logs/constraints_check.sql
@@ -33,14 +33,15 @@ VALUES
   )
 ON CONFLICT (id) DO NOTHING;
 
-INSERT INTO public.review_logs (id, note_id, user_id, round, scheduled_at)
+INSERT INTO public.review_logs (id, note_id, user_id, round, scheduled_at, completed_at)
 VALUES
   (
     current_setting('test.constraints_round_log_valid')::uuid,
     current_setting('test.constraints_round_note_a1')::uuid,
     current_setting('test.constraints_round_user_a')::uuid,
     2,
-    now() + interval '1 day'
+    now() + interval '1 day',
+    now()
   )
 ON CONFLICT (id) DO NOTHING;
 

--- a/supabase/tests/review_logs/constraints_not_null.sql
+++ b/supabase/tests/review_logs/constraints_not_null.sql
@@ -62,14 +62,14 @@ VALUES
   (current_setting('test.constraints_not_null_created_note_a1')::uuid, current_setting('test.constraints_not_null_created_user_a')::uuid, 'not null created a1', 'content', 1)
 ON CONFLICT (id) DO NOTHING;
 
-INSERT INTO public.review_logs (id, note_id, user_id, round, scheduled_at)
+INSERT INTO public.review_logs (id, note_id, user_id, round, scheduled_at, completed_at)
 VALUES
-  (current_setting('test.constraints_round_log_valid')::uuid, current_setting('test.constraints_round_note_a1')::uuid, current_setting('test.constraints_round_user_a')::uuid, 2, now() + interval '1 day'),
-  (current_setting('test.constraints_not_null_note_log_valid')::uuid, current_setting('test.constraints_not_null_note_note_a1')::uuid, current_setting('test.constraints_not_null_note_user_a')::uuid, 1, now() + interval '2 days'),
-  (current_setting('test.constraints_not_null_user_log_valid')::uuid, current_setting('test.constraints_not_null_user_note_a1')::uuid, current_setting('test.constraints_not_null_user_user_a')::uuid, 1, now() + interval '3 days'),
-  (current_setting('test.constraints_not_null_round_log_valid')::uuid, current_setting('test.constraints_not_null_round_note_a1')::uuid, current_setting('test.constraints_not_null_round_user_a')::uuid, 1, now() + interval '4 days'),
-  (current_setting('test.constraints_not_null_scheduled_log_valid')::uuid, current_setting('test.constraints_not_null_scheduled_note_a1')::uuid, current_setting('test.constraints_not_null_scheduled_user_a')::uuid, 1, now() + interval '5 days'),
-  (current_setting('test.constraints_not_null_created_log_valid')::uuid, current_setting('test.constraints_not_null_created_note_a1')::uuid, current_setting('test.constraints_not_null_created_user_a')::uuid, 1, now() + interval '6 days')
+  (current_setting('test.constraints_round_log_valid')::uuid, current_setting('test.constraints_round_note_a1')::uuid, current_setting('test.constraints_round_user_a')::uuid, 2, now() + interval '1 day', now()),
+  (current_setting('test.constraints_not_null_note_log_valid')::uuid, current_setting('test.constraints_not_null_note_note_a1')::uuid, current_setting('test.constraints_not_null_note_user_a')::uuid, 1, now() + interval '2 days', now()),
+  (current_setting('test.constraints_not_null_user_log_valid')::uuid, current_setting('test.constraints_not_null_user_note_a1')::uuid, current_setting('test.constraints_not_null_user_user_a')::uuid, 1, now() + interval '3 days', now()),
+  (current_setting('test.constraints_not_null_round_log_valid')::uuid, current_setting('test.constraints_not_null_round_note_a1')::uuid, current_setting('test.constraints_not_null_round_user_a')::uuid, 1, now() + interval '4 days', now()),
+  (current_setting('test.constraints_not_null_scheduled_log_valid')::uuid, current_setting('test.constraints_not_null_scheduled_note_a1')::uuid, current_setting('test.constraints_not_null_scheduled_user_a')::uuid, 1, now() + interval '5 days', now()),
+  (current_setting('test.constraints_not_null_created_log_valid')::uuid, current_setting('test.constraints_not_null_created_note_a1')::uuid, current_setting('test.constraints_not_null_created_user_a')::uuid, 1, now() + interval '6 days', now())
 ON CONFLICT (id) DO NOTHING;
 
 -- =====================================================================
@@ -597,11 +597,11 @@ SELECT throws_ok(
 -- 과거/현재/미래 시각 자체는 스키마에 금지 규칙이 없으므로 NULL이 아니면 허용되어야 한다
 SAVEPOINT constraints_not_null_scheduled_boundary_times;
 WITH inserted AS (
-  INSERT INTO public.review_logs (id, note_id, user_id, round, scheduled_at)
+  INSERT INTO public.review_logs (id, note_id, user_id, round, scheduled_at, completed_at)
   VALUES
-    (gen_random_uuid(), current_setting('test.constraints_not_null_scheduled_note_a1')::uuid, current_setting('test.constraints_not_null_scheduled_user_a')::uuid, 1, now() - interval '1 day'),
-    (gen_random_uuid(), current_setting('test.constraints_not_null_scheduled_note_a1')::uuid, current_setting('test.constraints_not_null_scheduled_user_a')::uuid, 1, now()),
-    (gen_random_uuid(), current_setting('test.constraints_not_null_scheduled_note_a1')::uuid, current_setting('test.constraints_not_null_scheduled_user_a')::uuid, 1, now() + interval '1 day')
+    (gen_random_uuid(), current_setting('test.constraints_not_null_scheduled_note_a1')::uuid, current_setting('test.constraints_not_null_scheduled_user_a')::uuid, 1, now() - interval '1 day', now()),
+    (gen_random_uuid(), current_setting('test.constraints_not_null_scheduled_note_a1')::uuid, current_setting('test.constraints_not_null_scheduled_user_a')::uuid, 1, now(), now()),
+    (gen_random_uuid(), current_setting('test.constraints_not_null_scheduled_note_a1')::uuid, current_setting('test.constraints_not_null_scheduled_user_a')::uuid, 1, now() + interval '1 day', now())
   RETURNING 1
 )
 SELECT is(

--- a/supabase/tests/review_logs/fk.sql
+++ b/supabase/tests/review_logs/fk.sql
@@ -94,22 +94,22 @@ VALUES
   (current_setting('test.user_fk_cascade_note_other')::uuid, current_setting('test.user_fk_cascade_user_other')::uuid, 'user fk cascade other', 'content', 0)
 ON CONFLICT (id) DO NOTHING;
 
-INSERT INTO public.review_logs (id, note_id, user_id, round, scheduled_at)
+INSERT INTO public.review_logs (id, note_id, user_id, round, scheduled_at, completed_at)
 VALUES
-  (current_setting('test.note_fk_ref_log_a1')::uuid, current_setting('test.note_fk_ref_note_a1')::uuid, current_setting('test.note_fk_ref_user_a')::uuid, 1, now() + interval '1 day'),
-  (current_setting('test.note_fk_cascade_log_1a')::uuid, current_setting('test.note_fk_cascade_note_1child')::uuid, current_setting('test.note_fk_cascade_user_a')::uuid, 1, now() + interval '2 days'),
-  (current_setting('test.note_fk_cascade_log_n1')::uuid, current_setting('test.note_fk_cascade_note_nchild')::uuid, current_setting('test.note_fk_cascade_user_a')::uuid, 2, now() + interval '3 days'),
-  (current_setting('test.note_fk_cascade_log_n2')::uuid, current_setting('test.note_fk_cascade_note_nchild')::uuid, current_setting('test.note_fk_cascade_user_a')::uuid, 3, now() + interval '4 days'),
-  (current_setting('test.note_fk_cascade_log_n3')::uuid, current_setting('test.note_fk_cascade_note_nchild2')::uuid, current_setting('test.note_fk_cascade_user_a')::uuid, 2, now() + interval '5 days'),
-  (current_setting('test.note_fk_cascade_log_n4')::uuid, current_setting('test.note_fk_cascade_note_nchild2')::uuid, current_setting('test.note_fk_cascade_user_a')::uuid, 3, now() + interval '6 days'),
-  (current_setting('test.note_fk_cascade_log_other')::uuid, current_setting('test.note_fk_cascade_other_note')::uuid, current_setting('test.note_fk_cascade_user_a')::uuid, 1, now() + interval '5 days'),
-  (current_setting('test.user_fk_ref_log_a1')::uuid, current_setting('test.user_fk_ref_note_a1')::uuid, current_setting('test.user_fk_ref_user_a')::uuid, 1, now() + interval '6 days'),
-  (current_setting('test.user_fk_cascade_log_1a')::uuid, current_setting('test.user_fk_cascade_note_1child')::uuid, current_setting('test.user_fk_cascade_user_1child')::uuid, 1, now() + interval '7 days'),
-  (current_setting('test.user_fk_cascade_log_n1')::uuid, current_setting('test.user_fk_cascade_note_n1')::uuid, current_setting('test.user_fk_cascade_user_nchild')::uuid, 2, now() + interval '8 days'),
-  (current_setting('test.user_fk_cascade_log_n2')::uuid, current_setting('test.user_fk_cascade_note_n2')::uuid, current_setting('test.user_fk_cascade_user_nchild')::uuid, 3, now() + interval '9 days'),
-  (current_setting('test.user_fk_cascade_log_n3')::uuid, current_setting('test.user_fk_cascade_note_n3')::uuid, current_setting('test.user_fk_cascade_user_nchild2')::uuid, 2, now() + interval '10 days'),
-  (current_setting('test.user_fk_cascade_log_n4')::uuid, current_setting('test.user_fk_cascade_note_n4')::uuid, current_setting('test.user_fk_cascade_user_nchild2')::uuid, 3, now() + interval '11 days'),
-  (current_setting('test.user_fk_cascade_log_other')::uuid, current_setting('test.user_fk_cascade_note_other')::uuid, current_setting('test.user_fk_cascade_user_other')::uuid, 1, now() + interval '10 days')
+  (current_setting('test.note_fk_ref_log_a1')::uuid, current_setting('test.note_fk_ref_note_a1')::uuid, current_setting('test.note_fk_ref_user_a')::uuid, 1, now() + interval '1 day', now()),
+  (current_setting('test.note_fk_cascade_log_1a')::uuid, current_setting('test.note_fk_cascade_note_1child')::uuid, current_setting('test.note_fk_cascade_user_a')::uuid, 1, now() + interval '2 days', now()),
+  (current_setting('test.note_fk_cascade_log_n1')::uuid, current_setting('test.note_fk_cascade_note_nchild')::uuid, current_setting('test.note_fk_cascade_user_a')::uuid, 2, now() + interval '3 days', now()),
+  (current_setting('test.note_fk_cascade_log_n2')::uuid, current_setting('test.note_fk_cascade_note_nchild')::uuid, current_setting('test.note_fk_cascade_user_a')::uuid, 3, now() + interval '4 days', now()),
+  (current_setting('test.note_fk_cascade_log_n3')::uuid, current_setting('test.note_fk_cascade_note_nchild2')::uuid, current_setting('test.note_fk_cascade_user_a')::uuid, 2, now() + interval '5 days', now()),
+  (current_setting('test.note_fk_cascade_log_n4')::uuid, current_setting('test.note_fk_cascade_note_nchild2')::uuid, current_setting('test.note_fk_cascade_user_a')::uuid, 3, now() + interval '6 days', now()),
+  (current_setting('test.note_fk_cascade_log_other')::uuid, current_setting('test.note_fk_cascade_other_note')::uuid, current_setting('test.note_fk_cascade_user_a')::uuid, 1, now() + interval '5 days', now()),
+  (current_setting('test.user_fk_ref_log_a1')::uuid, current_setting('test.user_fk_ref_note_a1')::uuid, current_setting('test.user_fk_ref_user_a')::uuid, 1, now() + interval '6 days', now()),
+  (current_setting('test.user_fk_cascade_log_1a')::uuid, current_setting('test.user_fk_cascade_note_1child')::uuid, current_setting('test.user_fk_cascade_user_1child')::uuid, 1, now() + interval '7 days', now()),
+  (current_setting('test.user_fk_cascade_log_n1')::uuid, current_setting('test.user_fk_cascade_note_n1')::uuid, current_setting('test.user_fk_cascade_user_nchild')::uuid, 2, now() + interval '8 days', now()),
+  (current_setting('test.user_fk_cascade_log_n2')::uuid, current_setting('test.user_fk_cascade_note_n2')::uuid, current_setting('test.user_fk_cascade_user_nchild')::uuid, 3, now() + interval '9 days', now()),
+  (current_setting('test.user_fk_cascade_log_n3')::uuid, current_setting('test.user_fk_cascade_note_n3')::uuid, current_setting('test.user_fk_cascade_user_nchild2')::uuid, 2, now() + interval '10 days', now()),
+  (current_setting('test.user_fk_cascade_log_n4')::uuid, current_setting('test.user_fk_cascade_note_n4')::uuid, current_setting('test.user_fk_cascade_user_nchild2')::uuid, 3, now() + interval '11 days', now()),
+  (current_setting('test.user_fk_cascade_log_other')::uuid, current_setting('test.user_fk_cascade_note_other')::uuid, current_setting('test.user_fk_cascade_user_other')::uuid, 1, now() + interval '10 days', now())
 ON CONFLICT (id) DO NOTHING;
 
 -- =====================================================================

--- a/supabase/tests/review_logs/rls.sql
+++ b/supabase/tests/review_logs/rls.sql
@@ -4,7 +4,7 @@
 -- TODO: confirm whether review_logs should remain immutable (no UPDATE/DELETE policies)
 BEGIN;
 
-SELECT plan(32);
+SELECT plan(33);
 
 -- 테스트용 UUID 준비
 SELECT set_config('test.user_a_id', gen_random_uuid()::text, true);
@@ -42,11 +42,11 @@ VALUES
   (current_setting('test.note_b1_id')::uuid, current_setting('test.user_b_id')::uuid, 'note b1', 'content b1', 0)
 ON CONFLICT (id) DO NOTHING;
 
-INSERT INTO public.review_logs (id, note_id, user_id, round, scheduled_at)
+INSERT INTO public.review_logs (id, note_id, user_id, round, scheduled_at, completed_at)
 VALUES
-  (current_setting('test.review_log_a1_id')::uuid, current_setting('test.note_a1_id')::uuid, current_setting('test.user_a_id')::uuid, 1, now() + interval '1 day'),
-  (current_setting('test.review_log_a2_id')::uuid, current_setting('test.note_a2_id')::uuid, current_setting('test.user_a_id')::uuid, 2, now() + interval '2 days'),
-  (current_setting('test.review_log_b1_id')::uuid, current_setting('test.note_b1_id')::uuid, current_setting('test.user_b_id')::uuid, 1, now() + interval '3 days')
+  (current_setting('test.review_log_a1_id')::uuid, current_setting('test.note_a1_id')::uuid, current_setting('test.user_a_id')::uuid, 1, now() + interval '1 day', now()),
+  (current_setting('test.review_log_a2_id')::uuid, current_setting('test.note_a2_id')::uuid, current_setting('test.user_a_id')::uuid, 2, now() + interval '2 days', now()),
+  (current_setting('test.review_log_b1_id')::uuid, current_setting('test.note_b1_id')::uuid, current_setting('test.user_b_id')::uuid, 1, now() + interval '3 days', now())
 ON CONFLICT (id) DO NOTHING;
 
 -- =====================================================================
@@ -237,6 +237,31 @@ SELECT lives_ok(
   $$본인 note에 대한 첫 review_log INSERT는 성공해야 한다$$
 );
 ROLLBACK TO SAVEPOINT review_logs_insert_first;
+
+SAVEPOINT review_logs_insert_duplicate_pending;
+INSERT INTO public.review_logs (id, note_id, user_id, round, scheduled_at)
+VALUES (
+  gen_random_uuid(),
+  current_setting('test.note_a3_id')::uuid,
+  current_setting('test.user_a_id')::uuid,
+  1,
+  now() + interval '12 days'
+);
+
+SELECT throws_ok(
+  format(
+    $sql$
+      INSERT INTO public.review_logs (id, note_id, user_id, round, scheduled_at)
+      VALUES (gen_random_uuid(), '%s'::uuid, '%s'::uuid, 2, now() + interval '13 days');
+    $sql$,
+    current_setting('test.note_a3_id'),
+    current_setting('test.user_a_id')
+  ),
+  '23505',
+  NULL,
+  $$the same note cannot have two pending review logs$$
+);
+ROLLBACK TO SAVEPOINT review_logs_insert_duplicate_pending;
 
 -- 여러 note에 대한 반복 INSERT도 각각 성공해야 한다
 SAVEPOINT review_logs_insert_multiple;


### PR DESCRIPTION
## 작업 내용

- `complete_review_and_schedule_next` RPC 마이그레이션을 추가했습니다.
- `review_logs`에 note당 pending row를 1개만 허용하는 partial unique index를 추가했습니다.
- RPC가 pending review log를 완료 처리하고, 다음 복습 일정을 계산해 다음 round의 review log를 생성하도록 구현했습니다.
- `src/types/database.types.ts`에 신규 RPC 타입을 반영했습니다.
- `review_logs` 관련 기존 SQL 테스트 seed를 partial unique index와 충돌하지 않도록 조정했습니다.
- `review_logs` RLS 테스트에 동일 note의 중복 pending log 삽입 실패 케이스를 추가했습니다.
- `complete_review_and_schedule_next` 전용 SQL 테스트를 추가해 정상 완료, 중복 완료 방지, 타 사용자 접근 방지, round mismatch, 인증/인자 검증 케이스를 보강했습니다.
- 리뷰 반영으로 불필요한 `DROP FUNCTION IF EXISTS`를 제거하고, RPC 내부 dead code를 정리했습니다.

## 변경 이유

- 복습 완료 시 note 상태와 다음 복습 스케줄을 DB 레벨에서 원자적으로 갱신할 수 있어야 했습니다.
- note별 pending review log가 여러 개 생기지 않도록 데이터 정합성을 강제할 필요가 있었습니다.
- 신규 RPC와 제약 조건 도입에 맞춰 기존 `review_logs` 테스트 데이터를 실제 스키마 규칙과 일치하도록 정리해야 했습니다.

## 영향 범위

- Supabase migration
- `review_logs` SQL 테스트
- generated database types

## 테스트

- `supabase/tests/review_logs/complete_review_and_schedule_next.sql`
- `supabase/tests/review_logs/rls.sql`
- `supabase/tests/review_logs/constraints_check.sql`
- `supabase/tests/review_logs/constraints_not_null.sql`

## 참고 사항

closes #115
