### PR TITLE
Feat/105 blank test core

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,7 @@ VAPID_PRIVATE_KEY=your-vapid-private-key
 
 # AEAD 기반 이메일 인증 ticket 암호화/복호화에 사용하는 서버 전용 비밀 키
 EMAIL_TICKET_SECRET=email-ticket-secret
+REVIEW_COMPLETION_TOKEN_SECRET=review-completion-token-secret
 SUPABASE_HOOK_SECRET=supabase-hook-secret
 
 # Resend 이메일 전송 API 키 (이메일 발송에 사용)

--- a/src/app/(main)/notes/[noteId]/page.test.tsx
+++ b/src/app/(main)/notes/[noteId]/page.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { ROUTES } from "@/lib/constants/routes";
+import { getNoteReviewRoute, ROUTES } from "@/lib/constants/routes";
 
 const REDIRECT_ERROR = new Error("NEXT_REDIRECT");
 const NOT_FOUND_ERROR = new Error("NEXT_NOT_FOUND");
@@ -53,6 +53,9 @@ function createSupabaseMock(userId: string | null) {
 
 describe("NoteDetailPage", () => {
   beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-29T12:00:00.000Z"));
+
     createClientMock.mockReset();
     getNoteByIdMock.mockReset();
     redirectMock.mockReset();
@@ -66,6 +69,10 @@ describe("NoteDetailPage", () => {
     });
   });
 
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("redirects to login when the user is not authenticated", async () => {
     createClientMock.mockResolvedValue(createSupabaseMock(null));
 
@@ -77,13 +84,15 @@ describe("NoteDetailPage", () => {
     expect(getNoteByIdMock).not.toHaveBeenCalled();
   });
 
-  it("renders the note when the user owns it", async () => {
+  it("renders a review entry point when the note is due for review", async () => {
     createClientMock.mockResolvedValue(createSupabaseMock("user-123"));
     getNoteByIdMock.mockResolvedValue({
       id: "note-123",
       title: "Test note",
       content: "note body",
       language: "markdown",
+      next_review_at: "2026-03-29T09:00:00.000Z",
+      review_round: 1,
       created_at: "2026-03-29T00:00:00.000Z",
       updated_at: "2026-03-29T01:00:00.000Z",
       user_id: "user-123",
@@ -100,6 +109,36 @@ describe("NoteDetailPage", () => {
     expect(screen.getByTestId("note-viewer")).toHaveTextContent(
       "markdown:note body",
     );
+    expect(
+      screen.getByText("지금 백지 테스트를 진행할 수 있습니다."),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "백지 테스트 시작" }),
+    ).toHaveAttribute("href", getNoteReviewRoute("note-123"));
+  });
+
+  it("shows the next review schedule when the note is not due yet", async () => {
+    createClientMock.mockResolvedValue(createSupabaseMock("user-123"));
+    getNoteByIdMock.mockResolvedValue({
+      id: "note-123",
+      title: "Future review note",
+      content: "note body",
+      language: "markdown",
+      next_review_at: "2026-03-30T09:00:00.000Z",
+      review_round: 1,
+      created_at: "2026-03-29T00:00:00.000Z",
+      updated_at: "2026-03-29T01:00:00.000Z",
+      user_id: "user-123",
+    });
+
+    render(
+      await NoteDetailPage({ params: Promise.resolve({ noteId: "note-123" }) }),
+    );
+
+    expect(screen.getByText(/다음 백지 테스트 예정/)).toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: "백지 테스트 시작" }),
+    ).not.toBeInTheDocument();
   });
 
   it("returns not found when the note does not exist for the current user", async () => {

--- a/src/app/(main)/notes/[noteId]/page.tsx
+++ b/src/app/(main)/notes/[noteId]/page.tsx
@@ -1,9 +1,12 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 import { notFound, redirect } from "next/navigation";
 
+import { Button } from "@/components/ui/button";
 import { NoteViewer } from "@/features/notes/components/NoteViewer";
 import { getNoteById } from "@/features/notes/queries";
-import { ROUTES } from "@/lib/constants/routes";
+import { MAX_REVIEW_ROUND } from "@/lib/constants/reviewIntervals";
+import { getNoteReviewRoute, ROUTES } from "@/lib/constants/routes";
 import { createClient } from "@/lib/supabase/server";
 import { formatDateTime } from "@/lib/utils/formatDate";
 
@@ -33,6 +36,19 @@ export default async function NoteDetailPage({
     notFound();
   }
 
+  const isReviewCompleted = note.review_round >= MAX_REVIEW_ROUND;
+  const isReviewDue =
+    !isReviewCompleted &&
+    note.next_review_at !== null &&
+    new Date(note.next_review_at).getTime() <= Date.now();
+  const reviewStatusMessage = isReviewCompleted
+    ? "1-3-7 복습을 모두 마쳤습니다."
+    : note.next_review_at
+      ? isReviewDue
+        ? "지금 백지 테스트를 진행할 수 있습니다."
+        : `다음 백지 테스트 예정 ${formatDateTime(note.next_review_at)}`
+      : "다음 복습 일정이 아직 준비되지 않았습니다.";
+
   return (
     <div className="mx-auto w-full max-w-4xl px-6 py-10 md:px-12">
       <header className="border-b border-border/60 pb-6">
@@ -40,11 +56,22 @@ export default async function NoteDetailPage({
           <span className="rounded-full bg-muted px-2 py-1 font-medium text-foreground">
             {note.language ?? "markdown"}
           </span>
+          <span className="rounded-full bg-muted px-2 py-1 font-medium text-foreground">
+            복습 {note.review_round} / {MAX_REVIEW_ROUND}
+          </span>
           <span>마지막 수정 {formatDateTime(note.updated_at)}</span>
         </div>
         <h1 className="mt-4 text-3xl font-bold text-foreground">
           {note.title}
         </h1>
+        <div className="mt-4 flex flex-wrap items-center gap-3">
+          <p className="text-sm text-muted-foreground">{reviewStatusMessage}</p>
+          {isReviewDue && (
+            <Button asChild size="sm">
+              <Link href={getNoteReviewRoute(noteId)}>백지 테스트 시작</Link>
+            </Button>
+          )}
+        </div>
       </header>
 
       <NoteViewer

--- a/src/app/(main)/notes/[noteId]/review/page.test.tsx
+++ b/src/app/(main)/notes/[noteId]/review/page.test.tsx
@@ -1,0 +1,178 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ROUTES } from "@/lib/constants/routes";
+
+const REDIRECT_ERROR = new Error("NEXT_REDIRECT");
+const NOT_FOUND_ERROR = new Error("NEXT_NOT_FOUND");
+
+const {
+  createClientMock,
+  getPendingReviewLogMock,
+  getReviewableNoteMock,
+  notFoundMock,
+  redirectMock,
+} = vi.hoisted(() => ({
+  createClientMock: vi.fn(),
+  getPendingReviewLogMock: vi.fn(),
+  getReviewableNoteMock: vi.fn(),
+  notFoundMock: vi.fn(),
+  redirectMock: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: createClientMock,
+}));
+
+vi.mock("@/features/review/queries", () => ({
+  getPendingReviewLog: getPendingReviewLogMock,
+  getReviewableNote: getReviewableNoteMock,
+}));
+
+vi.mock("@/features/review/components/BlankTestPage", () => ({
+  BlankTestPage: ({
+    noteId,
+    noteTitle,
+    reviewLogId,
+    reviewRound,
+  }: {
+    noteId: string;
+    noteTitle: string;
+    reviewLogId: string;
+    reviewRound: number;
+  }) => (
+    <div data-testid="blank-test-page">
+      {`${noteId}|${noteTitle}|${reviewLogId}|${reviewRound}`}
+    </div>
+  ),
+}));
+
+vi.mock("next/navigation", () => ({
+  notFound: notFoundMock,
+  redirect: redirectMock,
+}));
+
+import NoteReviewPage from "./page";
+
+function createSupabaseMock(userId: string | null) {
+  return {
+    auth: {
+      getUser: vi.fn().mockResolvedValue({
+        data: {
+          user: userId ? { id: userId } : null,
+        },
+      }),
+    },
+  };
+}
+
+describe("NoteReviewPage", () => {
+  beforeEach(() => {
+    createClientMock.mockReset();
+    getPendingReviewLogMock.mockReset();
+    getReviewableNoteMock.mockReset();
+    notFoundMock.mockReset();
+    redirectMock.mockReset();
+
+    redirectMock.mockImplementation(() => {
+      throw REDIRECT_ERROR;
+    });
+    notFoundMock.mockImplementation(() => {
+      throw NOT_FOUND_ERROR;
+    });
+  });
+
+  it("redirects to login when the user is not authenticated", async () => {
+    createClientMock.mockResolvedValue(createSupabaseMock(null));
+
+    await expect(
+      NoteReviewPage({
+        params: Promise.resolve({
+          noteId: "11111111-1111-1111-1111-111111111111",
+        }),
+      }),
+    ).rejects.toBe(REDIRECT_ERROR);
+
+    expect(redirectMock).toHaveBeenCalledWith(ROUTES.LOGIN);
+    expect(getReviewableNoteMock).not.toHaveBeenCalled();
+  });
+
+  it("returns not found when the note does not exist for the current user", async () => {
+    createClientMock.mockResolvedValue(createSupabaseMock("user-123"));
+    getReviewableNoteMock.mockResolvedValue(null);
+    getPendingReviewLogMock.mockResolvedValue(null);
+
+    await expect(
+      NoteReviewPage({
+        params: Promise.resolve({
+          noteId: "11111111-1111-1111-1111-111111111111",
+        }),
+      }),
+    ).rejects.toBe(NOT_FOUND_ERROR);
+
+    expect(notFoundMock).toHaveBeenCalledOnce();
+  });
+
+  it("renders an empty state when there is no pending review log", async () => {
+    createClientMock.mockResolvedValue(createSupabaseMock("user-123"));
+    getReviewableNoteMock.mockResolvedValue({
+      title: "테스트 노트",
+      language: "markdown",
+      review_round: 3,
+    });
+    getPendingReviewLogMock.mockResolvedValue(null);
+
+    render(
+      await NoteReviewPage({
+        params: Promise.resolve({
+          noteId: "11111111-1111-1111-1111-111111111111",
+        }),
+      }),
+    );
+
+    expect(
+      screen.getByRole("heading", {
+        name: "이 노트는 모든 복습을 마쳤습니다.",
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "노트로 돌아가기" }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the blank test page when a pending review exists", async () => {
+    createClientMock.mockResolvedValue(createSupabaseMock("user-123"));
+    getReviewableNoteMock.mockResolvedValue({
+      title: "테스트 노트",
+      language: "markdown",
+      review_round: 0,
+    });
+    getPendingReviewLogMock.mockResolvedValue({
+      id: "22222222-2222-2222-2222-222222222222",
+      note_id: "11111111-1111-1111-1111-111111111111",
+      round: 1,
+      scheduled_at: "2026-01-02T00:00:00.000Z",
+      completed_at: null,
+    });
+
+    render(
+      await NoteReviewPage({
+        params: Promise.resolve({
+          noteId: "11111111-1111-1111-1111-111111111111",
+        }),
+      }),
+    );
+
+    expect(getReviewableNoteMock).toHaveBeenCalledWith(
+      "11111111-1111-1111-1111-111111111111",
+      "user-123",
+    );
+    expect(getPendingReviewLogMock).toHaveBeenCalledWith(
+      "11111111-1111-1111-1111-111111111111",
+      "user-123",
+    );
+    expect(screen.getByTestId("blank-test-page")).toHaveTextContent(
+      "11111111-1111-1111-1111-111111111111|테스트 노트|22222222-2222-2222-2222-222222222222|1",
+    );
+  });
+});

--- a/src/app/(main)/notes/[noteId]/review/page.tsx
+++ b/src/app/(main)/notes/[noteId]/review/page.tsx
@@ -1,0 +1,85 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound, redirect } from "next/navigation";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { BlankTestPage } from "@/features/review/components/BlankTestPage";
+import {
+  getPendingReviewLog,
+  getReviewableNote,
+} from "@/features/review/queries";
+import { MAX_REVIEW_ROUND } from "@/lib/constants/reviewIntervals";
+import { getNoteDetailRoute, ROUTES } from "@/lib/constants/routes";
+import { createClient } from "@/lib/supabase/server";
+
+export const metadata: Metadata = {
+  title: "백지 테스트",
+  robots: { index: false, follow: false },
+};
+
+export default async function NoteReviewPage({
+  params,
+}: {
+  params: Promise<{ noteId: string }>;
+}) {
+  const { noteId } = await params;
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect(ROUTES.LOGIN);
+  }
+
+  const [note, pendingReviewLog] = await Promise.all([
+    getReviewableNote(noteId, user.id),
+    getPendingReviewLog(noteId, user.id),
+  ]);
+
+  if (!note) {
+    notFound();
+  }
+
+  if (!pendingReviewLog) {
+    const isCompleted = note.review_round >= MAX_REVIEW_ROUND;
+
+    return (
+      <div className="mx-auto flex min-h-[60vh] w-full max-w-3xl items-center px-6 py-10 md:px-12">
+        <Card className="w-full">
+          <CardHeader>
+            <CardTitle className="text-2xl">
+              {isCompleted
+                ? "이 노트는 모든 복습을 마쳤습니다."
+                : "진행 중인 백지 테스트가 없습니다."}
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <p className="text-sm text-muted-foreground">
+              {isCompleted
+                ? "필요하면 노트 상세 페이지에서 내용을 다시 확인해보세요."
+                : "현재 완료할 수 있는 리뷰 로그를 찾지 못했습니다. 노트 상세로 돌아가 상태를 확인해주세요."}
+            </p>
+
+            <Button asChild>
+              <Link href={getNoteDetailRoute(noteId)}>노트로 돌아가기</Link>
+            </Button>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto w-full max-w-6xl px-6 py-10 md:px-12">
+      <BlankTestPage
+        noteId={noteId}
+        noteTitle={note.title}
+        language={note.language}
+        reviewRound={pendingReviewLog.round}
+        reviewLogId={pendingReviewLog.id}
+      />
+    </div>
+  );
+}

--- a/src/features/editor/components/CodeEditor.tsx
+++ b/src/features/editor/components/CodeEditor.tsx
@@ -7,24 +7,29 @@ import type { SupportedLanguage } from "../supportedLanguages";
 
 type CodeEditorProps = {
   value: string;
-  onChange: (value: string) => void;
+  onChange?: (value: string) => void;
   language: SupportedLanguage;
   className?: string;
+  readOnly?: boolean;
   "aria-label"?: string;
 };
+
+const noop = () => {};
 
 export function CodeEditor({
   value,
   onChange,
   language,
   className,
+  readOnly = false,
   "aria-label": ariaLabel,
 }: CodeEditorProps) {
   const { containerRef } = useCodeMirror({
     doc: value,
     language,
-    onChange,
+    onChange: onChange ?? noop,
     ariaLabel,
+    readOnly,
   });
 
   return (

--- a/src/features/editor/hooks/useCodeMirror.ts
+++ b/src/features/editor/hooks/useCodeMirror.ts
@@ -23,6 +23,10 @@ type UseCodeMirrorOptions = {
   readOnly?: boolean;
 };
 
+function getReadOnlyExtensions(readOnly: boolean) {
+  return [EditorState.readOnly.of(readOnly), EditorView.editable.of(!readOnly)];
+}
+
 export function useCodeMirror({
   doc,
   language,
@@ -34,6 +38,7 @@ export function useCodeMirror({
   const editorViewRef = useRef<EditorView | null>(null);
   const languageCompartment = useRef(new Compartment());
   const ariaLabelCompartment = useRef(new Compartment());
+  const readOnlyCompartment = useRef(new Compartment());
   const onChangeRef = useRef(onChange);
 
   useEffect(() => {
@@ -47,9 +52,9 @@ export function useCodeMirror({
       doc,
       extensions: [
         syntaxHighlighting(defaultHighlightStyle),
-        ...(readOnly
-          ? [EditorState.readOnly.of(true), EditorView.editable.of(false)]
-          : [history(), keymap.of(historyKeymap)]),
+        history(),
+        keymap.of(historyKeymap),
+        readOnlyCompartment.current.of(getReadOnlyExtensions(readOnly)),
         languageCompartment.current.of(getLanguageExtension(language)),
         ariaLabelCompartment.current.of(getAriaLabelExtension(ariaLabel)),
         EditorView.updateListener.of((update) => {
@@ -91,6 +96,14 @@ export function useCodeMirror({
       ),
     });
   }, [language]);
+
+  useEffect(() => {
+    editorViewRef.current?.dispatch({
+      effects: readOnlyCompartment.current.reconfigure(
+        getReadOnlyExtensions(readOnly),
+      ),
+    });
+  }, [readOnly]);
 
   useEffect(() => {
     const view = editorViewRef.current;

--- a/src/features/editor/hooks/useCodeMirror.ts
+++ b/src/features/editor/hooks/useCodeMirror.ts
@@ -20,6 +20,7 @@ type UseCodeMirrorOptions = {
   language: SupportedLanguage;
   onChange: (value: string) => void;
   ariaLabel?: string | undefined;
+  readOnly?: boolean;
 };
 
 export function useCodeMirror({
@@ -27,6 +28,7 @@ export function useCodeMirror({
   language,
   onChange,
   ariaLabel,
+  readOnly = false,
 }: UseCodeMirrorOptions) {
   const containerRef = useRef<HTMLDivElement>(null);
   const editorViewRef = useRef<EditorView | null>(null);
@@ -45,8 +47,9 @@ export function useCodeMirror({
       doc,
       extensions: [
         syntaxHighlighting(defaultHighlightStyle),
-        history(),
-        keymap.of(historyKeymap),
+        ...(readOnly
+          ? [EditorState.readOnly.of(true), EditorView.editable.of(false)]
+          : [history(), keymap.of(historyKeymap)]),
         languageCompartment.current.of(getLanguageExtension(language)),
         ariaLabelCompartment.current.of(getAriaLabelExtension(ariaLabel)),
         EditorView.updateListener.of((update) => {

--- a/src/features/editor/tests/CodeEditor.test.tsx
+++ b/src/features/editor/tests/CodeEditor.test.tsx
@@ -150,4 +150,51 @@ describe("CodeEditor", () => {
       );
     });
   });
+
+  it("updates editability when the readOnly prop changes", async () => {
+    const user = userEvent.setup();
+    const handleChange = vi.fn();
+
+    const { rerender } = render(
+      <CodeEditor
+        value="const lockedValue = 1;"
+        onChange={handleChange}
+        language="javascript"
+        readOnly
+      />,
+    );
+
+    await waitFor(() => {
+      expect(document.querySelector(".cm-editor")).toBeTruthy();
+    });
+
+    const initialContentElement = getEditorContentElement();
+    await user.click(initialContentElement);
+    await user.keyboard("x");
+
+    expect(handleChange).not.toHaveBeenCalled();
+    expect(initialContentElement.textContent).toContain(
+      "const lockedValue = 1;",
+    );
+
+    rerender(
+      <CodeEditor
+        value="const lockedValue = 1;"
+        onChange={handleChange}
+        language="javascript"
+      />,
+    );
+
+    const updatedContentElement = getEditorContentElement();
+    await user.click(updatedContentElement);
+    await user.keyboard("x");
+
+    await waitFor(() => {
+      expect(handleChange).toHaveBeenCalled();
+      expect(updatedContentElement.textContent).toContain(
+        "const lockedValue = 1;",
+      );
+      expect(updatedContentElement.textContent).toContain("x");
+    });
+  });
 });

--- a/src/features/notes/queries.ts
+++ b/src/features/notes/queries.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 import { NOTE_LANGUAGE_VALUES } from "@/lib/constants/noteLanguages";
+import { MAX_REVIEW_ROUND } from "@/lib/constants/reviewIntervals";
 import { createClient } from "@/lib/supabase/server";
 
 const noteDetailSchema = z.object({
@@ -8,6 +9,8 @@ const noteDetailSchema = z.object({
   title: z.string(),
   content: z.string(),
   language: z.enum(NOTE_LANGUAGE_VALUES).nullable(),
+  next_review_at: z.string().nullable(),
+  review_round: z.number().int().min(0).max(MAX_REVIEW_ROUND),
   created_at: z.string(),
   updated_at: z.string(),
   user_id: z.string().uuid(),
@@ -26,7 +29,9 @@ export async function getNoteById(
   const supabase = await createClient();
   const { data } = await supabase
     .from("notes")
-    .select("id, title, content, language, created_at, updated_at, user_id")
+    .select(
+      "id, title, content, language, next_review_at, review_round, created_at, updated_at, user_id",
+    )
     .eq("id", noteId)
     .eq("user_id", userId)
     .maybeSingle();

--- a/src/features/review/actions.ts
+++ b/src/features/review/actions.ts
@@ -1,0 +1,155 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
+
+import type { NoteLanguage } from "@/lib/constants/noteLanguages";
+import {
+  getNextReviewDate,
+  MAX_REVIEW_ROUND,
+} from "@/lib/constants/reviewIntervals";
+import { getNoteDetailRoute, getNoteReviewRoute } from "@/lib/constants/routes";
+import { createClient } from "@/lib/supabase/server";
+
+import {
+  getNoteContentForComparison,
+  getPendingReviewLog,
+  getReviewableNote,
+} from "./queries";
+import {
+  completeReviewSchema,
+  type SubmitAnswerInput,
+  submitAnswerSchema,
+} from "./schema";
+
+type SubmitAnswerFieldErrors = Partial<
+  Record<keyof SubmitAnswerInput, string[]>
+>;
+
+export type SubmitAnswerActionState =
+  | {
+      success: true;
+      originalContent: string;
+      language: NoteLanguage | null;
+      userAnswer: string;
+      error?: never;
+    }
+  | {
+      success?: false;
+      originalContent?: never;
+      language?: never;
+      userAnswer?: never;
+      error: SubmitAnswerFieldErrors | string;
+    }
+  | null;
+
+export type CompleteReviewActionState = {
+  error: string;
+} | null;
+
+export async function submitAnswerAction(
+  _prevState: SubmitAnswerActionState,
+  formData: FormData,
+): Promise<SubmitAnswerActionState> {
+  const parsed = submitAnswerSchema.safeParse({
+    noteId: formData.get("noteId"),
+    answer: formData.get("answer"),
+  });
+
+  if (!parsed.success) {
+    const { fieldErrors } = parsed.error.flatten();
+
+    if (fieldErrors.noteId) {
+      return { error: "요청이 올바르지 않습니다." };
+    }
+
+    return { error: fieldErrors };
+  }
+
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return { error: "로그인이 필요합니다." };
+  }
+
+  const note = await getNoteContentForComparison(parsed.data.noteId, user.id);
+
+  if (!note) {
+    return { error: "비교할 노트를 찾을 수 없습니다." };
+  }
+
+  return {
+    success: true,
+    originalContent: note.content,
+    language: note.language,
+    userAnswer: parsed.data.answer,
+  };
+}
+
+export async function completeReviewAction(
+  _prevState: CompleteReviewActionState,
+  formData: FormData,
+): Promise<CompleteReviewActionState> {
+  const parsed = completeReviewSchema.safeParse({
+    noteId: formData.get("noteId"),
+    reviewLogId: formData.get("reviewLogId"),
+  });
+
+  if (!parsed.success) {
+    return { error: "요청이 올바르지 않습니다." };
+  }
+
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return { error: "로그인이 필요합니다." };
+  }
+
+  const [reviewableNote, pendingReviewLog] = await Promise.all([
+    getReviewableNote(parsed.data.noteId, user.id),
+    getPendingReviewLog(parsed.data.noteId, user.id),
+  ]);
+
+  if (
+    !reviewableNote ||
+    !pendingReviewLog ||
+    pendingReviewLog.id !== parsed.data.reviewLogId
+  ) {
+    return { error: "진행 중인 복습을 찾을 수 없습니다." };
+  }
+
+  const completedRound = pendingReviewLog.round;
+  const nextReviewAt =
+    completedRound >= MAX_REVIEW_ROUND
+      ? null
+      : (getNextReviewDate(completedRound)?.toISOString() ?? null);
+
+  if (completedRound < MAX_REVIEW_ROUND && !nextReviewAt) {
+    return {
+      error: "다음 복습 일정 계산에 실패했습니다. 잠시 후 다시 시도해주세요.",
+    };
+  }
+
+  const { data: completedNoteId, error: completeReviewError } =
+    await supabase.rpc("complete_review_and_schedule_next", {
+      p_note_id: parsed.data.noteId,
+      p_review_log_id: parsed.data.reviewLogId,
+      p_next_review_at: nextReviewAt,
+    });
+
+  if (completeReviewError || !completedNoteId) {
+    return {
+      error: "복습 완료 처리에 실패했습니다. 잠시 후 다시 시도해주세요.",
+    };
+  }
+
+  revalidatePath(getNoteDetailRoute(parsed.data.noteId));
+  revalidatePath(getNoteReviewRoute(parsed.data.noteId));
+  redirect(getNoteDetailRoute(parsed.data.noteId));
+}

--- a/src/features/review/actions.ts
+++ b/src/features/review/actions.ts
@@ -71,10 +71,24 @@ export async function submitAnswerAction(
     return { error: "로그인이 필요합니다." };
   }
 
-  const note = await getNoteContentForComparison(parsed.data.noteId, user.id);
+  let note, pendingReviewLog;
+  try {
+    [note, pendingReviewLog] = await Promise.all([
+      getNoteContentForComparison(parsed.data.noteId, user.id),
+      getPendingReviewLog(parsed.data.noteId, user.id),
+    ]);
+  } catch {
+    return {
+      error: "데이터를 불러오는 데 실패했습니다. 잠시 후 다시 시도해주세요.",
+    };
+  }
 
   if (!note) {
     return { error: "비교할 노트를 찾을 수 없습니다." };
+  }
+
+  if (!pendingReviewLog) {
+    return { error: "진행 중인 복습을 찾을 수 없습니다." };
   }
 
   return {
@@ -107,10 +121,17 @@ export async function completeReviewAction(
     return { error: "로그인이 필요합니다." };
   }
 
-  const [reviewableNote, pendingReviewLog] = await Promise.all([
-    getReviewableNote(parsed.data.noteId, user.id),
-    getPendingReviewLog(parsed.data.noteId, user.id),
-  ]);
+  let reviewableNote, pendingReviewLog;
+  try {
+    [reviewableNote, pendingReviewLog] = await Promise.all([
+      getReviewableNote(parsed.data.noteId, user.id),
+      getPendingReviewLog(parsed.data.noteId, user.id),
+    ]);
+  } catch {
+    return {
+      error: "데이터를 불러오는 데 실패했습니다. 잠시 후 다시 시도해주세요.",
+    };
+  }
 
   if (
     !reviewableNote ||

--- a/src/features/review/actions.ts
+++ b/src/features/review/actions.ts
@@ -4,10 +4,6 @@ import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 
 import type { NoteLanguage } from "@/lib/constants/noteLanguages";
-import {
-  getNextReviewDate,
-  MAX_REVIEW_ROUND,
-} from "@/lib/constants/reviewIntervals";
 import { getNoteDetailRoute, getNoteReviewRoute } from "@/lib/constants/routes";
 import { createClient } from "@/lib/supabase/server";
 
@@ -124,23 +120,10 @@ export async function completeReviewAction(
     return { error: "진행 중인 복습을 찾을 수 없습니다." };
   }
 
-  const completedRound = pendingReviewLog.round;
-  const nextReviewAt =
-    completedRound >= MAX_REVIEW_ROUND
-      ? null
-      : (getNextReviewDate(completedRound)?.toISOString() ?? null);
-
-  if (completedRound < MAX_REVIEW_ROUND && !nextReviewAt) {
-    return {
-      error: "다음 복습 일정 계산에 실패했습니다. 잠시 후 다시 시도해주세요.",
-    };
-  }
-
   const { data: completedNoteId, error: completeReviewError } =
     await supabase.rpc("complete_review_and_schedule_next", {
       p_note_id: parsed.data.noteId,
       p_review_log_id: parsed.data.reviewLogId,
-      p_next_review_at: nextReviewAt,
     });
 
   if (completeReviewError || !completedNoteId) {

--- a/src/features/review/actions.ts
+++ b/src/features/review/actions.ts
@@ -8,6 +8,10 @@ import { getNoteDetailRoute, getNoteReviewRoute } from "@/lib/constants/routes";
 import { createClient } from "@/lib/supabase/server";
 
 import {
+  createReviewCompletionToken,
+  verifyReviewCompletionToken,
+} from "./lib/reviewCompletionToken";
+import {
   getNoteContentForComparison,
   getPendingReviewLog,
   getReviewableNote,
@@ -28,6 +32,7 @@ export type SubmitAnswerActionState =
       originalContent: string;
       language: NoteLanguage | null;
       userAnswer: string;
+      completionToken: string;
       error?: never;
     }
   | {
@@ -91,11 +96,26 @@ export async function submitAnswerAction(
     return { error: "진행 중인 복습을 찾을 수 없습니다." };
   }
 
+  let completionToken: string;
+
+  try {
+    completionToken = createReviewCompletionToken({
+      noteId: parsed.data.noteId,
+      reviewLogId: pendingReviewLog.id,
+      userId: user.id,
+    });
+  } catch {
+    return {
+      error: "비교 준비에 실패했습니다. 잠시 후 다시 시도해주세요.",
+    };
+  }
+
   return {
     success: true,
     originalContent: note.content,
     language: note.language,
     userAnswer: parsed.data.answer,
+    completionToken,
   };
 }
 
@@ -106,6 +126,7 @@ export async function completeReviewAction(
   const parsed = completeReviewSchema.safeParse({
     noteId: formData.get("noteId"),
     reviewLogId: formData.get("reviewLogId"),
+    completionToken: formData.get("completionToken"),
   });
 
   if (!parsed.success) {
@@ -119,6 +140,29 @@ export async function completeReviewAction(
 
   if (!user) {
     return { error: "로그인이 필요합니다." };
+  }
+
+  let isCompletionTokenValid = false;
+
+  try {
+    isCompletionTokenValid = verifyReviewCompletionToken(
+      parsed.data.completionToken,
+      {
+        noteId: parsed.data.noteId,
+        reviewLogId: parsed.data.reviewLogId,
+        userId: user.id,
+      },
+    );
+  } catch {
+    return {
+      error: "복습 완료를 준비하는 데 실패했습니다. 잠시 후 다시 시도해주세요.",
+    };
+  }
+
+  if (!isCompletionTokenValid) {
+    return {
+      error: "답안을 제출한 뒤 원본을 확인하고 복습을 완료해주세요.",
+    };
   }
 
   let reviewableNote, pendingReviewLog;

--- a/src/features/review/components/BlankEditor.tsx
+++ b/src/features/review/components/BlankEditor.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { CodeEditor } from "@/features/editor/components/CodeEditor";
+import { TipTapEditor } from "@/features/editor/components/TipTapEditor";
+import {
+  isCodeLanguage,
+  type NoteLanguage,
+} from "@/lib/constants/noteLanguages";
+
+type BlankEditorProps = {
+  language: NoteLanguage | null;
+  value: string;
+  onChange: (value: string) => void;
+};
+
+export function BlankEditor({ language, value, onChange }: BlankEditorProps) {
+  const effectiveLanguage = language ?? "markdown";
+
+  if (isCodeLanguage(effectiveLanguage)) {
+    return (
+      <CodeEditor
+        value={value}
+        onChange={onChange}
+        language={effectiveLanguage}
+        aria-label="답안"
+        className="min-h-[60vh] rounded-none border-none [&_.cm-editor]:min-h-[60vh] [&_.cm-scroller]:min-h-[60vh] [&_.cm-content]:px-6! [&_.cm-content]:py-5! [&_.cm-gutters]:border-none [&_.cm-gutters]:bg-transparent"
+      />
+    );
+  }
+
+  return (
+    <TipTapEditor
+      value={value}
+      onChange={onChange}
+      placeholder="기억나는 내용을 적어보세요..."
+      autoFocus
+      aria-label="답안"
+      className="rounded-none border-none focus-within:border-none focus-within:ring-0 [&_.tiptap]:min-h-[60vh] [&_.tiptap]:px-6! [&_.tiptap]:py-5!"
+    />
+  );
+}

--- a/src/features/review/components/BlankTestPage.tsx
+++ b/src/features/review/components/BlankTestPage.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import { useActionState, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import type { NoteLanguage } from "@/lib/constants/noteLanguages";
+import { MAX_REVIEW_ROUND } from "@/lib/constants/reviewIntervals";
+
+import { submitAnswerAction } from "../actions";
+import { BlankEditor } from "./BlankEditor";
+import { ComparisonView } from "./ComparisonView";
+import { ReviewCompleteButton } from "./ReviewCompleteButton";
+
+const ANSWER_MAX_LENGTH = 50000;
+
+type BlankTestPageProps = {
+  noteId: string;
+  noteTitle: string;
+  language: NoteLanguage | null;
+  reviewRound: number;
+  reviewLogId: string;
+};
+
+export function BlankTestPage({
+  noteId,
+  noteTitle,
+  language,
+  reviewRound,
+  reviewLogId,
+}: BlankTestPageProps) {
+  const [answer, setAnswer] = useState("");
+  const [state, formAction, isPending] = useActionState(
+    submitAnswerAction,
+    null,
+  );
+
+  const fieldErrors =
+    state?.error && typeof state.error === "object" ? state.error : null;
+  const generalError =
+    state?.error && typeof state.error === "string" ? state.error : null;
+  const comparisonState = state?.success ? state : null;
+
+  return (
+    <div className="space-y-8">
+      <header className="space-y-3">
+        <div className="flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
+          <span className="rounded-full bg-muted px-2.5 py-1 font-medium text-foreground">
+            {reviewRound}차 복습
+          </span>
+          <span>
+            백지 테스트 {reviewRound} / {MAX_REVIEW_ROUND}
+          </span>
+        </div>
+        <h1 className="text-3xl font-bold text-foreground">{noteTitle}</h1>
+        <p className="text-sm text-muted-foreground">
+          먼저 기억나는 내용을 적고 제출한 뒤, 원본과 나란히 비교해보세요.
+        </p>
+      </header>
+
+      {comparisonState ? (
+        <section className="space-y-6">
+          <ComparisonView
+            language={comparisonState.language}
+            userAnswer={comparisonState.userAnswer}
+            originalContent={comparisonState.originalContent}
+          />
+
+          <div className="rounded-xl border border-border/60 bg-muted/30 px-5 py-4">
+            <p className="text-sm text-muted-foreground">
+              비교를 마쳤다면 이번 복습을 완료 처리하고 다음 간격으로
+              넘어가세요.
+            </p>
+            <div className="mt-4">
+              <ReviewCompleteButton noteId={noteId} reviewLogId={reviewLogId} />
+            </div>
+          </div>
+        </section>
+      ) : (
+        <Card className="overflow-hidden">
+          <CardHeader className="border-b border-border/60 pb-4">
+            <CardTitle className="text-base">답안 작성</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4 p-0">
+            <form action={formAction} className="space-y-4">
+              <input type="hidden" name="noteId" value={noteId} />
+              <input type="hidden" name="answer" value={answer} />
+
+              {generalError && (
+                <p role="alert" className="px-6 pt-5 text-sm text-destructive">
+                  {generalError}
+                </p>
+              )}
+
+              {fieldErrors?.answer && (
+                <p role="alert" className="px-6 pt-5 text-sm text-destructive">
+                  {fieldErrors.answer.join(" ")}
+                </p>
+              )}
+
+              <BlankEditor
+                language={language}
+                value={answer}
+                onChange={setAnswer}
+              />
+
+              <div className="flex flex-col gap-3 border-t border-border/60 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
+                <span
+                  aria-live="polite"
+                  className={`text-xs tabular-nums ${
+                    answer.length > ANSWER_MAX_LENGTH
+                      ? "text-destructive"
+                      : answer.length >= ANSWER_MAX_LENGTH * 0.9
+                        ? "text-amber-500"
+                        : "text-muted-foreground/60"
+                  }`}
+                >
+                  {answer.length.toLocaleString()} /{" "}
+                  {ANSWER_MAX_LENGTH.toLocaleString()}
+                </span>
+
+                <Button
+                  type="submit"
+                  size="lg"
+                  disabled={
+                    isPending ||
+                    answer.trim().length === 0 ||
+                    answer.length > ANSWER_MAX_LENGTH
+                  }
+                >
+                  {isPending ? "비교 준비 중..." : "원본과 비교하기"}
+                </Button>
+              </div>
+            </form>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/src/features/review/components/BlankTestPage.tsx
+++ b/src/features/review/components/BlankTestPage.tsx
@@ -8,11 +8,10 @@ import type { NoteLanguage } from "@/lib/constants/noteLanguages";
 import { MAX_REVIEW_ROUND } from "@/lib/constants/reviewIntervals";
 
 import { submitAnswerAction } from "../actions";
+import { ANSWER_MAX_LENGTH } from "../schema";
 import { BlankEditor } from "./BlankEditor";
 import { ComparisonView } from "./ComparisonView";
 import { ReviewCompleteButton } from "./ReviewCompleteButton";
-
-const ANSWER_MAX_LENGTH = 50000;
 
 type BlankTestPageProps = {
   noteId: string;

--- a/src/features/review/components/BlankTestPage.tsx
+++ b/src/features/review/components/BlankTestPage.tsx
@@ -71,7 +71,11 @@ export function BlankTestPage({
               넘어가세요.
             </p>
             <div className="mt-4">
-              <ReviewCompleteButton noteId={noteId} reviewLogId={reviewLogId} />
+              <ReviewCompleteButton
+                noteId={noteId}
+                reviewLogId={reviewLogId}
+                completionToken={comparisonState.completionToken}
+              />
             </div>
           </div>
         </section>

--- a/src/features/review/components/ComparisonView.tsx
+++ b/src/features/review/components/ComparisonView.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import hljs from "highlight.js";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { MarkdownNoteViewerClient } from "@/features/notes/components/MarkdownNoteViewerClient";
+import {
+  isCodeLanguage,
+  type NoteLanguage,
+} from "@/lib/constants/noteLanguages";
+
+type ComparisonViewProps = {
+  language: NoteLanguage | null;
+  userAnswer: string;
+  originalContent: string;
+};
+
+type ComparisonPanelProps = {
+  title: string;
+  content: string;
+  language: NoteLanguage | null;
+};
+
+function ComparisonPanel({ title, content, language }: ComparisonPanelProps) {
+  const effectiveLanguage = language ?? "markdown";
+
+  return (
+    <Card className="overflow-hidden">
+      <CardHeader className="border-b border-border/60 pb-4">
+        <CardTitle className="text-base">{title}</CardTitle>
+      </CardHeader>
+      <CardContent className="p-0">
+        {!content ? (
+          <div className="px-6 py-5 text-sm text-muted-foreground/60">
+            내용이 없습니다.
+          </div>
+        ) : isCodeLanguage(effectiveLanguage) ? (
+          <CodeComparisonPanel content={content} language={effectiveLanguage} />
+        ) : (
+          <MarkdownNoteViewerClient
+            content={content}
+            className="min-h-[50vh] rounded-none border-none focus-within:border-none focus-within:ring-0 [&_.tiptap]:min-h-[50vh] [&_.tiptap]:px-6! [&_.tiptap]:py-5!"
+          />
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function CodeComparisonPanel({
+  content,
+  language,
+}: {
+  content: string;
+  language: Exclude<NoteLanguage, "markdown">;
+}) {
+  const highlighted = hljs.highlight(content, {
+    language,
+    ignoreIllegals: true,
+  });
+
+  return (
+    <pre className="min-h-[50vh] overflow-x-auto bg-zinc-900 px-6 py-5 font-mono text-base leading-relaxed text-zinc-100">
+      <code
+        className={`hljs language-${language}`}
+        dangerouslySetInnerHTML={{ __html: highlighted.value }}
+      />
+    </pre>
+  );
+}
+
+export function ComparisonView({
+  language,
+  userAnswer,
+  originalContent,
+}: ComparisonViewProps) {
+  return (
+    <div className="grid gap-6 lg:grid-cols-2">
+      <ComparisonPanel
+        title="내 답안"
+        content={userAnswer}
+        language={language}
+      />
+      <ComparisonPanel
+        title="원본"
+        content={originalContent}
+        language={language}
+      />
+    </div>
+  );
+}

--- a/src/features/review/components/ComparisonView.tsx
+++ b/src/features/review/components/ComparisonView.tsx
@@ -1,8 +1,7 @@
 "use client";
 
-import hljs from "highlight.js";
-
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { CodeEditor } from "@/features/editor/components/CodeEditor";
 import { MarkdownNoteViewerClient } from "@/features/notes/components/MarkdownNoteViewerClient";
 import {
   isCodeLanguage,
@@ -35,7 +34,13 @@ function ComparisonPanel({ title, content, language }: ComparisonPanelProps) {
             내용이 없습니다.
           </div>
         ) : isCodeLanguage(effectiveLanguage) ? (
-          <CodeComparisonPanel content={content} language={effectiveLanguage} />
+          <CodeEditor
+            value={content}
+            language={effectiveLanguage}
+            readOnly
+            aria-label={title}
+            className="min-h-[50vh] rounded-none border-none [&_.cm-editor]:min-h-[50vh] [&_.cm-scroller]:min-h-[50vh] [&_.cm-content]:px-6! [&_.cm-content]:py-5! [&_.cm-gutters]:border-none [&_.cm-gutters]:bg-transparent"
+          />
         ) : (
           <MarkdownNoteViewerClient
             content={content}
@@ -44,28 +49,6 @@ function ComparisonPanel({ title, content, language }: ComparisonPanelProps) {
         )}
       </CardContent>
     </Card>
-  );
-}
-
-function CodeComparisonPanel({
-  content,
-  language,
-}: {
-  content: string;
-  language: Exclude<NoteLanguage, "markdown">;
-}) {
-  const highlighted = hljs.highlight(content, {
-    language,
-    ignoreIllegals: true,
-  });
-
-  return (
-    <pre className="min-h-[50vh] overflow-x-auto bg-zinc-900 px-6 py-5 font-mono text-base leading-relaxed text-zinc-100">
-      <code
-        className={`hljs language-${language}`}
-        dangerouslySetInnerHTML={{ __html: highlighted.value }}
-      />
-    </pre>
   );
 }
 

--- a/src/features/review/components/ReviewCompleteButton.tsx
+++ b/src/features/review/components/ReviewCompleteButton.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { useActionState } from "react";
+
+import { Button } from "@/components/ui/button";
+
+import { completeReviewAction } from "../actions";
+
+type ReviewCompleteButtonProps = {
+  noteId: string;
+  reviewLogId: string;
+};
+
+export function ReviewCompleteButton({
+  noteId,
+  reviewLogId,
+}: ReviewCompleteButtonProps) {
+  const [state, formAction, isPending] = useActionState(
+    completeReviewAction,
+    null,
+  );
+
+  return (
+    <form action={formAction} className="flex flex-col items-start gap-3">
+      <input type="hidden" name="noteId" value={noteId} />
+      <input type="hidden" name="reviewLogId" value={reviewLogId} />
+
+      {state?.error && (
+        <p role="alert" className="text-sm text-destructive">
+          {state.error}
+        </p>
+      )}
+
+      <Button type="submit" size="lg" disabled={isPending}>
+        {isPending ? "완료 처리 중..." : "복습 완료"}
+      </Button>
+    </form>
+  );
+}

--- a/src/features/review/components/ReviewCompleteButton.tsx
+++ b/src/features/review/components/ReviewCompleteButton.tsx
@@ -9,11 +9,13 @@ import { completeReviewAction } from "../actions";
 type ReviewCompleteButtonProps = {
   noteId: string;
   reviewLogId: string;
+  completionToken: string;
 };
 
 export function ReviewCompleteButton({
   noteId,
   reviewLogId,
+  completionToken,
 }: ReviewCompleteButtonProps) {
   const [state, formAction, isPending] = useActionState(
     completeReviewAction,
@@ -24,6 +26,7 @@ export function ReviewCompleteButton({
     <form action={formAction} className="flex flex-col items-start gap-3">
       <input type="hidden" name="noteId" value={noteId} />
       <input type="hidden" name="reviewLogId" value={reviewLogId} />
+      <input type="hidden" name="completionToken" value={completionToken} />
 
       {state?.error && (
         <p role="alert" className="text-sm text-destructive">

--- a/src/features/review/lib/reviewCompletionToken.ts
+++ b/src/features/review/lib/reviewCompletionToken.ts
@@ -1,0 +1,103 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+import { z } from "zod";
+
+const REVIEW_COMPLETION_TOKEN_PURPOSE = "review-completion.v1";
+
+const reviewCompletionTokenPayloadSchema = z.object({
+  noteId: z.string().uuid(),
+  reviewLogId: z.string().uuid(),
+  userId: z.string().min(1),
+});
+
+type ReviewCompletionTokenPayload = z.infer<
+  typeof reviewCompletionTokenPayloadSchema
+>;
+
+function getReviewCompletionTokenSecret() {
+  const secret =
+    process.env.REVIEW_COMPLETION_TOKEN_SECRET ??
+    process.env.EMAIL_TICKET_SECRET;
+
+  if (!secret) {
+    throw new Error("Review completion token secret is not configured.");
+  }
+
+  return secret;
+}
+
+function signReviewCompletionTokenPayload(encodedPayload: string) {
+  return createHmac("sha256", getReviewCompletionTokenSecret())
+    .update(`${REVIEW_COMPLETION_TOKEN_PURPOSE}:${encodedPayload}`)
+    .digest();
+}
+
+export function createReviewCompletionToken(
+  payload: ReviewCompletionTokenPayload,
+) {
+  const encodedPayload = Buffer.from(JSON.stringify(payload)).toString(
+    "base64url",
+  );
+  const signature =
+    signReviewCompletionTokenPayload(encodedPayload).toString("base64url");
+
+  return `${encodedPayload}.${signature}`;
+}
+
+export function verifyReviewCompletionToken(
+  token: string,
+  expectedPayload: ReviewCompletionTokenPayload,
+) {
+  const parts = token.split(".");
+
+  if (parts.length !== 2) {
+    return false;
+  }
+
+  const [encodedPayload, encodedSignature] = parts;
+
+  if (!encodedPayload || !encodedSignature) {
+    return false;
+  }
+
+  let providedSignature: Buffer;
+
+  try {
+    providedSignature = Buffer.from(encodedSignature, "base64url");
+  } catch {
+    return false;
+  }
+
+  const expectedSignature = signReviewCompletionTokenPayload(encodedPayload);
+
+  if (providedSignature.length !== expectedSignature.length) {
+    return false;
+  }
+
+  if (!timingSafeEqual(providedSignature, expectedSignature)) {
+    return false;
+  }
+
+  let rawPayload: unknown;
+
+  try {
+    rawPayload = JSON.parse(
+      Buffer.from(encodedPayload, "base64url").toString("utf8"),
+    );
+  } catch {
+    return false;
+  }
+
+  const parsedPayload =
+    reviewCompletionTokenPayloadSchema.safeParse(rawPayload);
+
+  if (!parsedPayload.success) {
+    return false;
+  }
+
+  return (
+    parsedPayload.data.noteId === expectedPayload.noteId &&
+    parsedPayload.data.reviewLogId === expectedPayload.reviewLogId &&
+    parsedPayload.data.userId === expectedPayload.userId
+  );
+}

--- a/src/features/review/lib/reviewCompletionToken.ts
+++ b/src/features/review/lib/reviewCompletionToken.ts
@@ -3,27 +3,41 @@ import { createHmac, timingSafeEqual } from "node:crypto";
 import { z } from "zod";
 
 const REVIEW_COMPLETION_TOKEN_PURPOSE = "review-completion.v1";
+export const REVIEW_COMPLETION_TOKEN_TTL_SECONDS = 10 * 60;
 
-const reviewCompletionTokenPayloadSchema = z.object({
+const reviewCompletionTokenBasePayloadSchema = z.object({
   noteId: z.string().uuid(),
   reviewLogId: z.string().uuid(),
   userId: z.string().min(1),
 });
 
+const reviewCompletionTokenPayloadSchema =
+  reviewCompletionTokenBasePayloadSchema
+    .extend({
+      issuedAt: z.number().int().nonnegative(),
+      expiresAt: z.number().int().positive(),
+    })
+    .refine((payload) => payload.expiresAt > payload.issuedAt, {
+      message: "Review completion token expiration must be after issuance.",
+      path: ["expiresAt"],
+    });
+
 type ReviewCompletionTokenPayload = z.infer<
-  typeof reviewCompletionTokenPayloadSchema
+  typeof reviewCompletionTokenBasePayloadSchema
 >;
 
 function getReviewCompletionTokenSecret() {
-  const secret =
-    process.env.REVIEW_COMPLETION_TOKEN_SECRET ??
-    process.env.EMAIL_TICKET_SECRET;
+  const secret = process.env.REVIEW_COMPLETION_TOKEN_SECRET;
 
   if (!secret) {
     throw new Error("Review completion token secret is not configured.");
   }
 
   return secret;
+}
+
+function getCurrentUnixTimestamp() {
+  return Math.floor(Date.now() / 1000);
 }
 
 function signReviewCompletionTokenPayload(encodedPayload: string) {
@@ -35,9 +49,14 @@ function signReviewCompletionTokenPayload(encodedPayload: string) {
 export function createReviewCompletionToken(
   payload: ReviewCompletionTokenPayload,
 ) {
-  const encodedPayload = Buffer.from(JSON.stringify(payload)).toString(
-    "base64url",
-  );
+  const issuedAt = getCurrentUnixTimestamp();
+  const encodedPayload = Buffer.from(
+    JSON.stringify({
+      ...payload,
+      issuedAt,
+      expiresAt: issuedAt + REVIEW_COMPLETION_TOKEN_TTL_SECONDS,
+    }),
+  ).toString("base64url");
   const signature =
     signReviewCompletionTokenPayload(encodedPayload).toString("base64url");
 
@@ -92,6 +111,10 @@ export function verifyReviewCompletionToken(
     reviewCompletionTokenPayloadSchema.safeParse(rawPayload);
 
   if (!parsedPayload.success) {
+    return false;
+  }
+
+  if (parsedPayload.data.expiresAt <= getCurrentUnixTimestamp()) {
     return false;
   }
 

--- a/src/features/review/queries.ts
+++ b/src/features/review/queries.ts
@@ -1,0 +1,82 @@
+import { z } from "zod";
+
+import { NOTE_LANGUAGE_VALUES } from "@/lib/constants/noteLanguages";
+import { MAX_REVIEW_ROUND } from "@/lib/constants/reviewIntervals";
+import { createClient } from "@/lib/supabase/server";
+
+const reviewableNoteSchema = z.object({
+  title: z.string(),
+  language: z.enum(NOTE_LANGUAGE_VALUES).nullable(),
+  review_round: z.number().int().min(0).max(MAX_REVIEW_ROUND),
+});
+
+const pendingReviewLogSchema = z.object({
+  id: z.string().uuid(),
+  note_id: z.string().uuid(),
+  round: z.number().int().min(1).max(MAX_REVIEW_ROUND),
+  scheduled_at: z.string(),
+  completed_at: z.string().nullable(),
+});
+
+const noteContentForComparisonSchema = z.object({
+  content: z.string(),
+  language: z.enum(NOTE_LANGUAGE_VALUES).nullable(),
+});
+
+export type ReviewableNote = z.infer<typeof reviewableNoteSchema>;
+export type PendingReviewLog = z.infer<typeof pendingReviewLogSchema>;
+export type NoteContentForComparison = z.infer<
+  typeof noteContentForComparisonSchema
+>;
+
+export async function getReviewableNote(
+  noteId: string,
+  userId: string,
+): Promise<ReviewableNote | null> {
+  const supabase = await createClient();
+  const { data } = await supabase
+    .from("notes")
+    .select("title, language, review_round")
+    .eq("id", noteId)
+    .eq("user_id", userId)
+    .maybeSingle();
+
+  const parsed = reviewableNoteSchema.safeParse(data);
+  return parsed.success ? parsed.data : null;
+}
+
+export async function getPendingReviewLog(
+  noteId: string,
+  userId: string,
+): Promise<PendingReviewLog | null> {
+  const supabase = await createClient();
+  const { data } = await supabase
+    .from("review_logs")
+    .select("id, note_id, round, scheduled_at, completed_at")
+    .eq("note_id", noteId)
+    .eq("user_id", userId)
+    .is("completed_at", null)
+    .order("round", { ascending: false })
+    .order("scheduled_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  const parsed = pendingReviewLogSchema.safeParse(data);
+  return parsed.success ? parsed.data : null;
+}
+
+export async function getNoteContentForComparison(
+  noteId: string,
+  userId: string,
+): Promise<NoteContentForComparison | null> {
+  const supabase = await createClient();
+  const { data } = await supabase
+    .from("notes")
+    .select("content, language")
+    .eq("id", noteId)
+    .eq("user_id", userId)
+    .maybeSingle();
+
+  const parsed = noteContentForComparisonSchema.safeParse(data);
+  return parsed.success ? parsed.data : null;
+}

--- a/src/features/review/queries.ts
+++ b/src/features/review/queries.ts
@@ -56,6 +56,7 @@ export async function getPendingReviewLog(
     .eq("note_id", noteId)
     .eq("user_id", userId)
     .is("completed_at", null)
+    .lte("scheduled_at", new Date().toISOString())
     .order("round", { ascending: false })
     .order("scheduled_at", { ascending: false })
     .limit(1)

--- a/src/features/review/queries.ts
+++ b/src/features/review/queries.ts
@@ -34,12 +34,14 @@ export async function getReviewableNote(
   userId: string,
 ): Promise<ReviewableNote | null> {
   const supabase = await createClient();
-  const { data } = await supabase
+  const { data, error } = await supabase
     .from("notes")
     .select("title, language, review_round")
     .eq("id", noteId)
     .eq("user_id", userId)
     .maybeSingle();
+
+  if (error) throw error;
 
   const parsed = reviewableNoteSchema.safeParse(data);
   return parsed.success ? parsed.data : null;
@@ -50,7 +52,7 @@ export async function getPendingReviewLog(
   userId: string,
 ): Promise<PendingReviewLog | null> {
   const supabase = await createClient();
-  const { data } = await supabase
+  const { data, error } = await supabase
     .from("review_logs")
     .select("id, note_id, round, scheduled_at, completed_at")
     .eq("note_id", noteId)
@@ -62,6 +64,8 @@ export async function getPendingReviewLog(
     .limit(1)
     .maybeSingle();
 
+  if (error) throw error;
+
   const parsed = pendingReviewLogSchema.safeParse(data);
   return parsed.success ? parsed.data : null;
 }
@@ -71,12 +75,14 @@ export async function getNoteContentForComparison(
   userId: string,
 ): Promise<NoteContentForComparison | null> {
   const supabase = await createClient();
-  const { data } = await supabase
+  const { data, error } = await supabase
     .from("notes")
     .select("content, language")
     .eq("id", noteId)
     .eq("user_id", userId)
     .maybeSingle();
+
+  if (error) throw error;
 
   const parsed = noteContentForComparisonSchema.safeParse(data);
   return parsed.success ? parsed.data : null;

--- a/src/features/review/schema.ts
+++ b/src/features/review/schema.ts
@@ -1,0 +1,17 @@
+import { z } from "zod";
+
+export const submitAnswerSchema = z.object({
+  noteId: z.string().uuid("유효한 노트 ID가 아닙니다"),
+  answer: z
+    .string()
+    .max(50000, "답안이 너무 깁니다")
+    .refine((value) => value.trim().length > 0, "답안을 입력해주세요"),
+});
+
+export const completeReviewSchema = z.object({
+  noteId: z.string().uuid("유효한 노트 ID가 아닙니다"),
+  reviewLogId: z.string().uuid("유효한 리뷰 로그 ID가 아닙니다"),
+});
+
+export type SubmitAnswerInput = z.infer<typeof submitAnswerSchema>;
+export type CompleteReviewInput = z.infer<typeof completeReviewSchema>;

--- a/src/features/review/schema.ts
+++ b/src/features/review/schema.ts
@@ -13,6 +13,7 @@ export const submitAnswerSchema = z.object({
 export const completeReviewSchema = z.object({
   noteId: z.string().uuid("유효한 노트 ID가 아닙니다"),
   reviewLogId: z.string().uuid("유효한 리뷰 로그 ID가 아닙니다"),
+  completionToken: z.string().min(1, "복습 완료 토큰이 필요합니다"),
 });
 
 export type SubmitAnswerInput = z.infer<typeof submitAnswerSchema>;

--- a/src/features/review/schema.ts
+++ b/src/features/review/schema.ts
@@ -1,10 +1,12 @@
 import { z } from "zod";
 
+export const ANSWER_MAX_LENGTH = 50000;
+
 export const submitAnswerSchema = z.object({
   noteId: z.string().uuid("유효한 노트 ID가 아닙니다"),
   answer: z
     .string()
-    .max(50000, "답안이 너무 깁니다")
+    .max(ANSWER_MAX_LENGTH, "답안이 너무 깁니다")
     .refine((value) => value.trim().length > 0, "답안을 입력해주세요"),
 });
 

--- a/src/features/review/tests/actions.test.ts
+++ b/src/features/review/tests/actions.test.ts
@@ -82,6 +82,7 @@ describe("submitAnswerAction", () => {
   beforeEach(() => {
     createClientMock.mockReset();
     getNoteContentForComparisonMock.mockReset();
+    getPendingReviewLogMock.mockReset();
   });
 
   afterEach(() => {
@@ -117,11 +118,53 @@ describe("submitAnswerAction", () => {
     expect(getNoteContentForComparisonMock).not.toHaveBeenCalled();
   });
 
+  it("returns an error when there is no pending review log", async () => {
+    createClientMock.mockResolvedValue(createAuthSupabaseMock("user-123"));
+    getNoteContentForComparisonMock.mockResolvedValue({
+      content: "원본 내용",
+      language: "markdown",
+    });
+    getPendingReviewLogMock.mockResolvedValue(null);
+
+    const formData = new FormData();
+    formData.set("noteId", NOTE_ID);
+    formData.set("answer", "내 답안");
+
+    const result = await submitAnswerAction(null, formData);
+
+    expect(result).toEqual({ error: "진행 중인 복습을 찾을 수 없습니다." });
+  });
+
+  it("returns an error when a query throws", async () => {
+    createClientMock.mockResolvedValue(createAuthSupabaseMock("user-123"));
+    getNoteContentForComparisonMock.mockRejectedValue(
+      new Error("db connection failed"),
+    );
+    getPendingReviewLogMock.mockResolvedValue(null);
+
+    const formData = new FormData();
+    formData.set("noteId", NOTE_ID);
+    formData.set("answer", "내 답안");
+
+    const result = await submitAnswerAction(null, formData);
+
+    expect(result).toEqual({
+      error: "데이터를 불러오는 데 실패했습니다. 잠시 후 다시 시도해주세요.",
+    });
+  });
+
   it("returns the original content for comparison when the note exists", async () => {
     createClientMock.mockResolvedValue(createAuthSupabaseMock("user-123"));
     getNoteContentForComparisonMock.mockResolvedValue({
       content: "원본 내용",
       language: "markdown",
+    });
+    getPendingReviewLogMock.mockResolvedValue({
+      id: REVIEW_LOG_ID,
+      note_id: NOTE_ID,
+      round: 1,
+      scheduled_at: "2026-01-02T00:00:00.000Z",
+      completed_at: null,
     });
 
     const formData = new FormData();
@@ -134,6 +177,7 @@ describe("submitAnswerAction", () => {
       NOTE_ID,
       "user-123",
     );
+    expect(getPendingReviewLogMock).toHaveBeenCalledWith(NOTE_ID, "user-123");
     expect(result).toEqual({
       success: true,
       originalContent: "원본 내용",
@@ -299,6 +343,23 @@ describe("completeReviewAction", () => {
       error: "복습 완료 처리에 실패했습니다. 잠시 후 다시 시도해주세요.",
     });
     expect(rpcMock).toHaveBeenCalledOnce();
+    expect(redirectMock).not.toHaveBeenCalled();
+  });
+
+  it("returns an error when a query throws", async () => {
+    createClientMock.mockResolvedValue(createAuthSupabaseMock("user-123"));
+    getReviewableNoteMock.mockRejectedValue(new Error("db connection failed"));
+    getPendingReviewLogMock.mockResolvedValue(null);
+
+    const formData = new FormData();
+    formData.set("noteId", NOTE_ID);
+    formData.set("reviewLogId", REVIEW_LOG_ID);
+
+    const result = await completeReviewAction(null, formData);
+
+    expect(result).toEqual({
+      error: "데이터를 불러오는 데 실패했습니다. 잠시 후 다시 시도해주세요.",
+    });
     expect(redirectMock).not.toHaveBeenCalled();
   });
 

--- a/src/features/review/tests/actions.test.ts
+++ b/src/features/review/tests/actions.test.ts
@@ -49,6 +49,7 @@ vi.mock("../queries", () => ({
 import { completeReviewAction, submitAnswerAction } from "../actions";
 import {
   createReviewCompletionToken,
+  REVIEW_COMPLETION_TOKEN_TTL_SECONDS,
   verifyReviewCompletionToken,
 } from "../lib/reviewCompletionToken";
 
@@ -118,6 +119,9 @@ function createCompleteReviewFormData({
 
 describe("submitAnswerAction", () => {
   beforeEach(() => {
+    process.env["REVIEW_COMPLETION_TOKEN_SECRET"] = "test-review-secret";
+    delete process.env["EMAIL_TICKET_SECRET"];
+
     createClientMock.mockReset();
     getNoteContentForComparisonMock.mockReset();
     getPendingReviewLogMock.mockReset();
@@ -237,12 +241,41 @@ describe("submitAnswerAction", () => {
       }),
     ).toBe(true);
   });
+
+  it("fails closed when the review completion secret is missing", async () => {
+    createClientMock.mockResolvedValue(createAuthSupabaseMock(TEST_USER_ID));
+    getNoteContentForComparisonMock.mockResolvedValue({
+      content: "original content",
+      language: "markdown",
+    });
+    getPendingReviewLogMock.mockResolvedValue({
+      id: REVIEW_LOG_ID,
+      note_id: NOTE_ID,
+      round: 1,
+      scheduled_at: "2026-01-02T00:00:00.000Z",
+      completed_at: null,
+    });
+    delete process.env["REVIEW_COMPLETION_TOKEN_SECRET"];
+    process.env["EMAIL_TICKET_SECRET"] = "legacy-ticket-secret";
+
+    const formData = new FormData();
+    formData.set("noteId", NOTE_ID);
+    formData.set("answer", "user answer");
+
+    const result = await submitAnswerAction(null, formData);
+
+    expect(result).toMatchObject({
+      error: expect.any(String),
+    });
+  });
 });
 
 describe("completeReviewAction", () => {
   beforeEach(() => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+    process.env["REVIEW_COMPLETION_TOKEN_SECRET"] = "test-review-secret";
+    delete process.env["EMAIL_TICKET_SECRET"];
 
     createClientMock.mockReset();
     getPendingReviewLogMock.mockReset();
@@ -282,6 +315,21 @@ describe("completeReviewAction", () => {
 
     expect(result).toEqual({
       error: "답안을 제출한 뒤 원본을 확인하고 복습을 완료해주세요.",
+    });
+    expect(getReviewableNoteMock).not.toHaveBeenCalled();
+    expect(getPendingReviewLogMock).not.toHaveBeenCalled();
+  });
+
+  it("returns an error when the completion token has expired", async () => {
+    createClientMock.mockResolvedValue(createAuthSupabaseMock(TEST_USER_ID));
+
+    const formData = createCompleteReviewFormData();
+    vi.advanceTimersByTime((REVIEW_COMPLETION_TOKEN_TTL_SECONDS + 1) * 1000);
+
+    const result = await completeReviewAction(null, formData);
+
+    expect(result).toMatchObject({
+      error: expect.any(String),
     });
     expect(getReviewableNoteMock).not.toHaveBeenCalled();
     expect(getPendingReviewLogMock).not.toHaveBeenCalled();

--- a/src/features/review/tests/actions.test.ts
+++ b/src/features/review/tests/actions.test.ts
@@ -6,6 +6,7 @@ const REDIRECT_ERROR = new Error("NEXT_REDIRECT");
 const NOTE_ID = "11111111-1111-4111-8111-111111111111";
 const REVIEW_LOG_ID = "22222222-2222-4222-8222-222222222222";
 const NEXT_REVIEW_LOG_ID = "33333333-3333-4333-8333-333333333333";
+const TEST_USER_ID = "user-123";
 
 const {
   createClientMock,
@@ -14,14 +15,18 @@ const {
   getReviewableNoteMock,
   redirectMock,
   revalidatePathMock,
-} = vi.hoisted(() => ({
-  createClientMock: vi.fn(),
-  getNoteContentForComparisonMock: vi.fn(),
-  getPendingReviewLogMock: vi.fn(),
-  getReviewableNoteMock: vi.fn(),
-  redirectMock: vi.fn(),
-  revalidatePathMock: vi.fn(),
-}));
+} = vi.hoisted(() => {
+  process.env["REVIEW_COMPLETION_TOKEN_SECRET"] = "test-review-secret";
+
+  return {
+    createClientMock: vi.fn(),
+    getNoteContentForComparisonMock: vi.fn(),
+    getPendingReviewLogMock: vi.fn(),
+    getReviewableNoteMock: vi.fn(),
+    redirectMock: vi.fn(),
+    revalidatePathMock: vi.fn(),
+  };
+});
 
 vi.mock("@/lib/supabase/server", () => ({
   createClient: createClientMock,
@@ -42,6 +47,10 @@ vi.mock("../queries", () => ({
 }));
 
 import { completeReviewAction, submitAnswerAction } from "../actions";
+import {
+  createReviewCompletionToken,
+  verifyReviewCompletionToken,
+} from "../lib/reviewCompletionToken";
 
 function createAuthSupabaseMock(userId: string | null) {
   return {
@@ -56,7 +65,7 @@ function createAuthSupabaseMock(userId: string | null) {
 }
 
 function createCompleteReviewSupabaseMock({
-  userId = "user-123",
+  userId = TEST_USER_ID,
   rpcResult = NOTE_ID,
   rpcError = null,
 }: {
@@ -76,6 +85,35 @@ function createCompleteReviewSupabaseMock({
       rpc: rpcMock,
     },
   };
+}
+
+function createCompleteReviewFormData({
+  noteId = NOTE_ID,
+  reviewLogId = REVIEW_LOG_ID,
+  tokenNoteId = noteId,
+  tokenReviewLogId = reviewLogId,
+  tokenUserId = TEST_USER_ID,
+}: {
+  noteId?: string;
+  reviewLogId?: string;
+  tokenNoteId?: string;
+  tokenReviewLogId?: string;
+  tokenUserId?: string;
+} = {}) {
+  const formData = new FormData();
+
+  formData.set("noteId", noteId);
+  formData.set("reviewLogId", reviewLogId);
+  formData.set(
+    "completionToken",
+    createReviewCompletionToken({
+      noteId: tokenNoteId,
+      reviewLogId: tokenReviewLogId,
+      userId: tokenUserId,
+    }),
+  );
+
+  return formData;
 }
 
 describe("submitAnswerAction", () => {
@@ -119,7 +157,7 @@ describe("submitAnswerAction", () => {
   });
 
   it("returns an error when there is no pending review log", async () => {
-    createClientMock.mockResolvedValue(createAuthSupabaseMock("user-123"));
+    createClientMock.mockResolvedValue(createAuthSupabaseMock(TEST_USER_ID));
     getNoteContentForComparisonMock.mockResolvedValue({
       content: "원본 내용",
       language: "markdown",
@@ -136,7 +174,7 @@ describe("submitAnswerAction", () => {
   });
 
   it("returns an error when a query throws", async () => {
-    createClientMock.mockResolvedValue(createAuthSupabaseMock("user-123"));
+    createClientMock.mockResolvedValue(createAuthSupabaseMock(TEST_USER_ID));
     getNoteContentForComparisonMock.mockRejectedValue(
       new Error("db connection failed"),
     );
@@ -153,8 +191,8 @@ describe("submitAnswerAction", () => {
     });
   });
 
-  it("returns the original content for comparison when the note exists", async () => {
-    createClientMock.mockResolvedValue(createAuthSupabaseMock("user-123"));
+  it("returns the original content and completion token when the note exists", async () => {
+    createClientMock.mockResolvedValue(createAuthSupabaseMock(TEST_USER_ID));
     getNoteContentForComparisonMock.mockResolvedValue({
       content: "원본 내용",
       language: "markdown",
@@ -175,15 +213,29 @@ describe("submitAnswerAction", () => {
 
     expect(getNoteContentForComparisonMock).toHaveBeenCalledWith(
       NOTE_ID,
-      "user-123",
+      TEST_USER_ID,
     );
-    expect(getPendingReviewLogMock).toHaveBeenCalledWith(NOTE_ID, "user-123");
-    expect(result).toEqual({
+    expect(getPendingReviewLogMock).toHaveBeenCalledWith(NOTE_ID, TEST_USER_ID);
+
+    expect(result).toMatchObject({
       success: true,
       originalContent: "원본 내용",
       language: "markdown",
       userAnswer: "내 답안",
+      completionToken: expect.any(String),
     });
+
+    if (!result || !result.success) {
+      throw new Error("expected a successful comparison result");
+    }
+
+    expect(
+      verifyReviewCompletionToken(result.completionToken, {
+        noteId: NOTE_ID,
+        reviewLogId: REVIEW_LOG_ID,
+        userId: TEST_USER_ID,
+      }),
+    ).toBe(true);
   });
 });
 
@@ -211,18 +263,32 @@ describe("completeReviewAction", () => {
   it("returns an auth error when the user is not logged in", async () => {
     createClientMock.mockResolvedValue(createAuthSupabaseMock(null));
 
-    const formData = new FormData();
-    formData.set("noteId", NOTE_ID);
-    formData.set("reviewLogId", REVIEW_LOG_ID);
-
-    const result = await completeReviewAction(null, formData);
+    const result = await completeReviewAction(
+      null,
+      createCompleteReviewFormData(),
+    );
 
     expect(result).toEqual({ error: "로그인이 필요합니다." });
     expect(getReviewableNoteMock).not.toHaveBeenCalled();
   });
 
+  it("returns an error when the completion token is invalid", async () => {
+    createClientMock.mockResolvedValue(createAuthSupabaseMock(TEST_USER_ID));
+
+    const formData = createCompleteReviewFormData();
+    formData.set("completionToken", "forged-token");
+
+    const result = await completeReviewAction(null, formData);
+
+    expect(result).toEqual({
+      error: "답안을 제출한 뒤 원본을 확인하고 복습을 완료해주세요.",
+    });
+    expect(getReviewableNoteMock).not.toHaveBeenCalled();
+    expect(getPendingReviewLogMock).not.toHaveBeenCalled();
+  });
+
   it("returns an error when the pending review log does not match", async () => {
-    createClientMock.mockResolvedValue(createAuthSupabaseMock("user-123"));
+    createClientMock.mockResolvedValue(createAuthSupabaseMock(TEST_USER_ID));
     getReviewableNoteMock.mockResolvedValue({
       title: "테스트 노트",
       language: "markdown",
@@ -236,11 +302,10 @@ describe("completeReviewAction", () => {
       completed_at: null,
     });
 
-    const formData = new FormData();
-    formData.set("noteId", NOTE_ID);
-    formData.set("reviewLogId", REVIEW_LOG_ID);
-
-    const result = await completeReviewAction(null, formData);
+    const result = await completeReviewAction(
+      null,
+      createCompleteReviewFormData(),
+    );
 
     expect(result).toEqual({ error: "진행 중인 복습을 찾을 수 없습니다." });
   });
@@ -262,13 +327,9 @@ describe("completeReviewAction", () => {
       completed_at: null,
     });
 
-    const formData = new FormData();
-    formData.set("noteId", NOTE_ID);
-    formData.set("reviewLogId", REVIEW_LOG_ID);
-
-    await expect(completeReviewAction(null, formData)).rejects.toBe(
-      REDIRECT_ERROR,
-    );
+    await expect(
+      completeReviewAction(null, createCompleteReviewFormData()),
+    ).rejects.toBe(REDIRECT_ERROR);
 
     expect(rpcMock).toHaveBeenCalledWith("complete_review_and_schedule_next", {
       p_note_id: NOTE_ID,
@@ -300,13 +361,9 @@ describe("completeReviewAction", () => {
       completed_at: null,
     });
 
-    const formData = new FormData();
-    formData.set("noteId", NOTE_ID);
-    formData.set("reviewLogId", REVIEW_LOG_ID);
-
-    await expect(completeReviewAction(null, formData)).rejects.toBe(
-      REDIRECT_ERROR,
-    );
+    await expect(
+      completeReviewAction(null, createCompleteReviewFormData()),
+    ).rejects.toBe(REDIRECT_ERROR);
 
     expect(rpcMock).toHaveBeenCalledWith("complete_review_and_schedule_next", {
       p_note_id: NOTE_ID,
@@ -333,11 +390,10 @@ describe("completeReviewAction", () => {
       completed_at: null,
     });
 
-    const formData = new FormData();
-    formData.set("noteId", NOTE_ID);
-    formData.set("reviewLogId", REVIEW_LOG_ID);
-
-    const result = await completeReviewAction(null, formData);
+    const result = await completeReviewAction(
+      null,
+      createCompleteReviewFormData(),
+    );
 
     expect(result).toEqual({
       error: "복습 완료 처리에 실패했습니다. 잠시 후 다시 시도해주세요.",
@@ -347,15 +403,14 @@ describe("completeReviewAction", () => {
   });
 
   it("returns an error when a query throws", async () => {
-    createClientMock.mockResolvedValue(createAuthSupabaseMock("user-123"));
+    createClientMock.mockResolvedValue(createAuthSupabaseMock(TEST_USER_ID));
     getReviewableNoteMock.mockRejectedValue(new Error("db connection failed"));
     getPendingReviewLogMock.mockResolvedValue(null);
 
-    const formData = new FormData();
-    formData.set("noteId", NOTE_ID);
-    formData.set("reviewLogId", REVIEW_LOG_ID);
-
-    const result = await completeReviewAction(null, formData);
+    const result = await completeReviewAction(
+      null,
+      createCompleteReviewFormData(),
+    );
 
     expect(result).toEqual({
       error: "데이터를 불러오는 데 실패했습니다. 잠시 후 다시 시도해주세요.",
@@ -382,11 +437,10 @@ describe("completeReviewAction", () => {
       completed_at: null,
     });
 
-    const formData = new FormData();
-    formData.set("noteId", NOTE_ID);
-    formData.set("reviewLogId", REVIEW_LOG_ID);
-
-    const result = await completeReviewAction(null, formData);
+    const result = await completeReviewAction(
+      null,
+      createCompleteReviewFormData(),
+    );
 
     expect(result).toEqual({
       error: "복습 완료 처리에 실패했습니다. 잠시 후 다시 시도해주세요.",

--- a/src/features/review/tests/actions.test.ts
+++ b/src/features/review/tests/actions.test.ts
@@ -229,7 +229,6 @@ describe("completeReviewAction", () => {
     expect(rpcMock).toHaveBeenCalledWith("complete_review_and_schedule_next", {
       p_note_id: NOTE_ID,
       p_review_log_id: REVIEW_LOG_ID,
-      p_next_review_at: "2026-01-04T00:00:00.000Z",
     });
     expect(revalidatePathMock).toHaveBeenCalledWith(
       getNoteDetailRoute(NOTE_ID),
@@ -268,7 +267,6 @@ describe("completeReviewAction", () => {
     expect(rpcMock).toHaveBeenCalledWith("complete_review_and_schedule_next", {
       p_note_id: NOTE_ID,
       p_review_log_id: REVIEW_LOG_ID,
-      p_next_review_at: null,
     });
   });
 

--- a/src/features/review/tests/actions.test.ts
+++ b/src/features/review/tests/actions.test.ts
@@ -1,0 +1,338 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { getNoteDetailRoute, getNoteReviewRoute } from "@/lib/constants/routes";
+
+const REDIRECT_ERROR = new Error("NEXT_REDIRECT");
+const NOTE_ID = "11111111-1111-4111-8111-111111111111";
+const REVIEW_LOG_ID = "22222222-2222-4222-8222-222222222222";
+const NEXT_REVIEW_LOG_ID = "33333333-3333-4333-8333-333333333333";
+
+const {
+  createClientMock,
+  getNoteContentForComparisonMock,
+  getPendingReviewLogMock,
+  getReviewableNoteMock,
+  redirectMock,
+  revalidatePathMock,
+} = vi.hoisted(() => ({
+  createClientMock: vi.fn(),
+  getNoteContentForComparisonMock: vi.fn(),
+  getPendingReviewLogMock: vi.fn(),
+  getReviewableNoteMock: vi.fn(),
+  redirectMock: vi.fn(),
+  revalidatePathMock: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: createClientMock,
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: revalidatePathMock,
+}));
+
+vi.mock("next/navigation", () => ({
+  redirect: redirectMock,
+}));
+
+vi.mock("../queries", () => ({
+  getNoteContentForComparison: getNoteContentForComparisonMock,
+  getPendingReviewLog: getPendingReviewLogMock,
+  getReviewableNote: getReviewableNoteMock,
+}));
+
+import { completeReviewAction, submitAnswerAction } from "../actions";
+
+function createAuthSupabaseMock(userId: string | null) {
+  return {
+    auth: {
+      getUser: vi.fn().mockResolvedValue({
+        data: {
+          user: userId ? { id: userId } : null,
+        },
+      }),
+    },
+  };
+}
+
+function createCompleteReviewSupabaseMock({
+  userId = "user-123",
+  rpcResult = NOTE_ID,
+  rpcError = null,
+}: {
+  userId?: string | null;
+  rpcResult?: string | null;
+  rpcError?: { message: string } | null;
+} = {}) {
+  const rpcMock = vi.fn().mockResolvedValue({
+    data: rpcError ? null : rpcResult,
+    error: rpcError,
+  });
+
+  return {
+    rpcMock,
+    supabase: {
+      ...createAuthSupabaseMock(userId),
+      rpc: rpcMock,
+    },
+  };
+}
+
+describe("submitAnswerAction", () => {
+  beforeEach(() => {
+    createClientMock.mockReset();
+    getNoteContentForComparisonMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns field errors for invalid answer input", async () => {
+    const formData = new FormData();
+    formData.set("noteId", NOTE_ID);
+    formData.set("answer", "   ");
+
+    const result = await submitAnswerAction(null, formData);
+
+    expect(result).toMatchObject({
+      error: expect.objectContaining({
+        answer: expect.any(Array),
+      }),
+    });
+    expect(createClientMock).not.toHaveBeenCalled();
+  });
+
+  it("returns an auth error when the user is not logged in", async () => {
+    const supabase = createAuthSupabaseMock(null);
+    createClientMock.mockResolvedValue(supabase);
+
+    const formData = new FormData();
+    formData.set("noteId", NOTE_ID);
+    formData.set("answer", "기억나는 내용");
+
+    const result = await submitAnswerAction(null, formData);
+
+    expect(result).toEqual({ error: "로그인이 필요합니다." });
+    expect(getNoteContentForComparisonMock).not.toHaveBeenCalled();
+  });
+
+  it("returns the original content for comparison when the note exists", async () => {
+    createClientMock.mockResolvedValue(createAuthSupabaseMock("user-123"));
+    getNoteContentForComparisonMock.mockResolvedValue({
+      content: "원본 내용",
+      language: "markdown",
+    });
+
+    const formData = new FormData();
+    formData.set("noteId", NOTE_ID);
+    formData.set("answer", "내 답안");
+
+    const result = await submitAnswerAction(null, formData);
+
+    expect(getNoteContentForComparisonMock).toHaveBeenCalledWith(
+      NOTE_ID,
+      "user-123",
+    );
+    expect(result).toEqual({
+      success: true,
+      originalContent: "원본 내용",
+      language: "markdown",
+      userAnswer: "내 답안",
+    });
+  });
+});
+
+describe("completeReviewAction", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+
+    createClientMock.mockReset();
+    getPendingReviewLogMock.mockReset();
+    getReviewableNoteMock.mockReset();
+    redirectMock.mockReset();
+    revalidatePathMock.mockReset();
+
+    redirectMock.mockImplementation(() => {
+      throw REDIRECT_ERROR;
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("returns an auth error when the user is not logged in", async () => {
+    createClientMock.mockResolvedValue(createAuthSupabaseMock(null));
+
+    const formData = new FormData();
+    formData.set("noteId", NOTE_ID);
+    formData.set("reviewLogId", REVIEW_LOG_ID);
+
+    const result = await completeReviewAction(null, formData);
+
+    expect(result).toEqual({ error: "로그인이 필요합니다." });
+    expect(getReviewableNoteMock).not.toHaveBeenCalled();
+  });
+
+  it("returns an error when the pending review log does not match", async () => {
+    createClientMock.mockResolvedValue(createAuthSupabaseMock("user-123"));
+    getReviewableNoteMock.mockResolvedValue({
+      title: "테스트 노트",
+      language: "markdown",
+      review_round: 0,
+    });
+    getPendingReviewLogMock.mockResolvedValue({
+      id: NEXT_REVIEW_LOG_ID,
+      note_id: NOTE_ID,
+      round: 1,
+      scheduled_at: "2026-01-02T00:00:00.000Z",
+      completed_at: null,
+    });
+
+    const formData = new FormData();
+    formData.set("noteId", NOTE_ID);
+    formData.set("reviewLogId", REVIEW_LOG_ID);
+
+    const result = await completeReviewAction(null, formData);
+
+    expect(result).toEqual({ error: "진행 중인 복습을 찾을 수 없습니다." });
+  });
+
+  it("completes a non-final review and schedules the next one", async () => {
+    const { rpcMock, supabase } = createCompleteReviewSupabaseMock();
+
+    createClientMock.mockResolvedValue(supabase);
+    getReviewableNoteMock.mockResolvedValue({
+      title: "테스트 노트",
+      language: "markdown",
+      review_round: 0,
+    });
+    getPendingReviewLogMock.mockResolvedValue({
+      id: REVIEW_LOG_ID,
+      note_id: NOTE_ID,
+      round: 1,
+      scheduled_at: "2026-01-02T00:00:00.000Z",
+      completed_at: null,
+    });
+
+    const formData = new FormData();
+    formData.set("noteId", NOTE_ID);
+    formData.set("reviewLogId", REVIEW_LOG_ID);
+
+    await expect(completeReviewAction(null, formData)).rejects.toBe(
+      REDIRECT_ERROR,
+    );
+
+    expect(rpcMock).toHaveBeenCalledWith("complete_review_and_schedule_next", {
+      p_note_id: NOTE_ID,
+      p_review_log_id: REVIEW_LOG_ID,
+      p_next_review_at: "2026-01-04T00:00:00.000Z",
+    });
+    expect(revalidatePathMock).toHaveBeenCalledWith(
+      getNoteDetailRoute(NOTE_ID),
+    );
+    expect(revalidatePathMock).toHaveBeenCalledWith(
+      getNoteReviewRoute(NOTE_ID),
+    );
+    expect(redirectMock).toHaveBeenCalledWith(getNoteDetailRoute(NOTE_ID));
+  });
+
+  it("marks the note as completed on the final review round", async () => {
+    const { rpcMock, supabase } = createCompleteReviewSupabaseMock();
+
+    createClientMock.mockResolvedValue(supabase);
+    getReviewableNoteMock.mockResolvedValue({
+      title: "테스트 노트",
+      language: "markdown",
+      review_round: 2,
+    });
+    getPendingReviewLogMock.mockResolvedValue({
+      id: REVIEW_LOG_ID,
+      note_id: NOTE_ID,
+      round: 3,
+      scheduled_at: "2026-01-08T00:00:00.000Z",
+      completed_at: null,
+    });
+
+    const formData = new FormData();
+    formData.set("noteId", NOTE_ID);
+    formData.set("reviewLogId", REVIEW_LOG_ID);
+
+    await expect(completeReviewAction(null, formData)).rejects.toBe(
+      REDIRECT_ERROR,
+    );
+
+    expect(rpcMock).toHaveBeenCalledWith("complete_review_and_schedule_next", {
+      p_note_id: NOTE_ID,
+      p_review_log_id: REVIEW_LOG_ID,
+      p_next_review_at: null,
+    });
+  });
+
+  it("returns an error when completing the review log fails", async () => {
+    const { rpcMock, supabase } = createCompleteReviewSupabaseMock({
+      rpcError: { message: "rpc failed" },
+    });
+
+    createClientMock.mockResolvedValue(supabase);
+    getReviewableNoteMock.mockResolvedValue({
+      title: "테스트 노트",
+      language: "markdown",
+      review_round: 0,
+    });
+    getPendingReviewLogMock.mockResolvedValue({
+      id: REVIEW_LOG_ID,
+      note_id: NOTE_ID,
+      round: 1,
+      scheduled_at: "2026-01-02T00:00:00.000Z",
+      completed_at: null,
+    });
+
+    const formData = new FormData();
+    formData.set("noteId", NOTE_ID);
+    formData.set("reviewLogId", REVIEW_LOG_ID);
+
+    const result = await completeReviewAction(null, formData);
+
+    expect(result).toEqual({
+      error: "복습 완료 처리에 실패했습니다. 잠시 후 다시 시도해주세요.",
+    });
+    expect(rpcMock).toHaveBeenCalledOnce();
+    expect(redirectMock).not.toHaveBeenCalled();
+  });
+
+  it("returns an error when the RPC returns no note id", async () => {
+    const { rpcMock, supabase } = createCompleteReviewSupabaseMock({
+      rpcResult: null,
+    });
+
+    createClientMock.mockResolvedValue(supabase);
+    getReviewableNoteMock.mockResolvedValue({
+      title: "테스트 노트",
+      language: "markdown",
+      review_round: 0,
+    });
+    getPendingReviewLogMock.mockResolvedValue({
+      id: REVIEW_LOG_ID,
+      note_id: NOTE_ID,
+      round: 1,
+      scheduled_at: "2026-01-02T00:00:00.000Z",
+      completed_at: null,
+    });
+
+    const formData = new FormData();
+    formData.set("noteId", NOTE_ID);
+    formData.set("reviewLogId", REVIEW_LOG_ID);
+
+    const result = await completeReviewAction(null, formData);
+
+    expect(result).toEqual({
+      error: "복습 완료 처리에 실패했습니다. 잠시 후 다시 시도해주세요.",
+    });
+    expect(rpcMock).toHaveBeenCalledOnce();
+    expect(redirectMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/review/tests/queries.test.ts
+++ b/src/features/review/tests/queries.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { createClientMock } = vi.hoisted(() => ({
+  createClientMock: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: createClientMock,
+}));
+
+import { getPendingReviewLog } from "../queries";
+
+function createReviewLogsQueryMock(data: unknown) {
+  const chain = {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    is: vi.fn().mockReturnThis(),
+    lte: vi.fn().mockReturnThis(),
+    order: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockReturnThis(),
+    maybeSingle: vi.fn().mockResolvedValue({ data }),
+  };
+
+  return {
+    chain,
+    supabase: {
+      from: vi.fn().mockReturnValue(chain),
+    },
+  };
+}
+
+describe("getPendingReviewLog", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-05T12:00:00.000Z"));
+    createClientMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("filters pending review logs to only those that are due", async () => {
+    const { chain, supabase } = createReviewLogsQueryMock({
+      id: "22222222-2222-4222-8222-222222222222",
+      note_id: "11111111-1111-4111-8111-111111111111",
+      round: 1,
+      scheduled_at: "2026-01-05T09:00:00.000Z",
+      completed_at: null,
+    });
+
+    createClientMock.mockResolvedValue(supabase);
+
+    const result = await getPendingReviewLog(
+      "11111111-1111-4111-8111-111111111111",
+      "user-123",
+    );
+
+    expect(supabase.from).toHaveBeenCalledWith("review_logs");
+    expect(chain.lte).toHaveBeenCalledWith(
+      "scheduled_at",
+      "2026-01-05T12:00:00.000Z",
+    );
+    expect(result).toEqual({
+      id: "22222222-2222-4222-8222-222222222222",
+      note_id: "11111111-1111-4111-8111-111111111111",
+      round: 1,
+      scheduled_at: "2026-01-05T09:00:00.000Z",
+      completed_at: null,
+    });
+  });
+});

--- a/src/features/review/tests/reviewCompletionToken.test.ts
+++ b/src/features/review/tests/reviewCompletionToken.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  createReviewCompletionToken,
+  REVIEW_COMPLETION_TOKEN_TTL_SECONDS,
+  verifyReviewCompletionToken,
+} from "../lib/reviewCompletionToken";
+
+const REVIEW_TOKEN_PAYLOAD = {
+  noteId: "11111111-1111-4111-8111-111111111111",
+  reviewLogId: "22222222-2222-4222-8222-222222222222",
+  userId: "user-123",
+};
+
+describe("reviewCompletionToken", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+    process.env["REVIEW_COMPLETION_TOKEN_SECRET"] = "test-review-secret";
+    delete process.env["EMAIL_TICKET_SECRET"];
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("verifies a freshly issued token", () => {
+    const token = createReviewCompletionToken(REVIEW_TOKEN_PAYLOAD);
+
+    expect(verifyReviewCompletionToken(token, REVIEW_TOKEN_PAYLOAD)).toBe(true);
+  });
+
+  it("rejects an expired token", () => {
+    const token = createReviewCompletionToken(REVIEW_TOKEN_PAYLOAD);
+
+    vi.advanceTimersByTime((REVIEW_COMPLETION_TOKEN_TTL_SECONDS + 1) * 1000);
+
+    expect(verifyReviewCompletionToken(token, REVIEW_TOKEN_PAYLOAD)).toBe(
+      false,
+    );
+  });
+
+  it("does not fall back to the email ticket secret", () => {
+    delete process.env["REVIEW_COMPLETION_TOKEN_SECRET"];
+    process.env["EMAIL_TICKET_SECRET"] = "legacy-ticket-secret";
+
+    expect(() => createReviewCompletionToken(REVIEW_TOKEN_PAYLOAD)).toThrow(
+      "Review completion token secret is not configured.",
+    );
+  });
+});

--- a/src/features/review/tests/schema.test.ts
+++ b/src/features/review/tests/schema.test.ts
@@ -38,6 +38,7 @@ describe("completeReviewSchema", () => {
     const parsed = completeReviewSchema.safeParse({
       noteId: NOTE_ID,
       reviewLogId: REVIEW_LOG_ID,
+      completionToken: "valid-token",
     });
 
     expect(parsed.success).toBe(true);
@@ -47,6 +48,7 @@ describe("completeReviewSchema", () => {
     const parsed = completeReviewSchema.safeParse({
       noteId: "note-123",
       reviewLogId: "log-123",
+      completionToken: "",
     });
 
     expect(parsed.success).toBe(false);

--- a/src/features/review/tests/schema.test.ts
+++ b/src/features/review/tests/schema.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+
+import { completeReviewSchema, submitAnswerSchema } from "../schema";
+
+const NOTE_ID = "11111111-1111-4111-8111-111111111111";
+const REVIEW_LOG_ID = "22222222-2222-4222-8222-222222222222";
+
+describe("submitAnswerSchema", () => {
+  it("accepts a valid answer payload", () => {
+    const parsed = submitAnswerSchema.safeParse({
+      noteId: NOTE_ID,
+      answer: "기억나는 내용을 적었습니다.",
+    });
+
+    expect(parsed.success).toBe(true);
+  });
+
+  it("rejects blank answers", () => {
+    const parsed = submitAnswerSchema.safeParse({
+      noteId: NOTE_ID,
+      answer: "   ",
+    });
+
+    expect(parsed.success).toBe(false);
+
+    if (parsed.success) {
+      throw new Error("blank answers must be rejected");
+    }
+
+    expect(parsed.error.flatten().fieldErrors.answer).toContain(
+      "답안을 입력해주세요",
+    );
+  });
+});
+
+describe("completeReviewSchema", () => {
+  it("accepts valid ids", () => {
+    const parsed = completeReviewSchema.safeParse({
+      noteId: NOTE_ID,
+      reviewLogId: REVIEW_LOG_ID,
+    });
+
+    expect(parsed.success).toBe(true);
+  });
+
+  it("rejects invalid ids", () => {
+    const parsed = completeReviewSchema.safeParse({
+      noteId: "note-123",
+      reviewLogId: "log-123",
+    });
+
+    expect(parsed.success).toBe(false);
+  });
+});


### PR DESCRIPTION
## 개요

백지 테스트(Blank Page Test) 핵심 기능 구현. 사용자가 노트 내용을 기억에서 인출하여 작성하고, 원본과 나란히 비교한 뒤 복습을 완료하는 플로우를 추가한다.

## PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] UI 디자인 변경
- [ ] 코드 리팩토링
- [ ] 테스트 추가/수정
- [ ] 문서 수정
- [ ] 빌드/패키지 설정 변경

## 관련 이슈

refs #105

## 작업 내용

- src/features/review/ 피처 모듈 신규 생성
   - schema.ts — 답안 제출(submitAnswerSchema), 복습 완료(completeReviewSchema) Zod 스키마
   - queries.ts — getReviewableNote, getPendingReviewLog, getNoteContentForComparison 쿼리
   - actions.ts — submitAnswerAction(답안 제출 후 원본 반환), completeReviewAction(복습 완료 처리 + DB RPC)
   - lib/reviewCompletionToken.ts — HMAC 기반 완료 토큰 생성/검증 (답안 제출 없이 복습 완료 방지)
- 백지 테스트 UI 컴포넌트
   - BlankTestPage — writing → comparison 2단계 상태 전환
   - BlankEditor — 언어에 따라 CodeEditor / TipTapEditor 분기
   - ComparisonView — 내 답안 / 원본 나란히 비교 (반응형 2컬럼)
   - ReviewCompleteButton — 복습 완료 액션 호출
   - src/app/(main)/notes/[noteId]/review/page.tsx 라우트 페이지 추가
- 기존 코드 수정
   - CodeEditor / useCodeMirror — readOnly prop 지원 추가
   - getNoteById — review_round, next_review_at 필드 추가
   - 노트 상세 페이지 — 복습 상태 표시 + "백지 테스트 시작" 버튼 진입점
   - env.example — REVIEW_COMPLETION_TOKEN_SECRET 환경변수 추가

## 테스트 방법
실제 화면 작동은 로그인 기능 구현 후 확인 하겠습니다.
npm run typecheck 통과
npm run test 통과

## 스크린샷 (FE 변경 시)

## 리뷰 요구사항 (선택)

reviewCompletionToken.ts의 HMAC 토큰 방식이 답안 미제출 우회를 충분히 방어하는지 확인 부탁드립니다
completeReviewAction에서 complete_review_and_schedule_next RPC 호출 흐름이 적절한지 확인 부탁드립니다

## 체크리스트

- [x] 코드 컨벤션 준수
- [x] 커밋 메시지 컨벤션 준수
- [x] lint 통과
- [x] typecheck 통과
- [ ] (DB 변경 시) migration 포함 및 로컬 재현 확인
- [ ] (권한/RLS 영향 시) 정책 변경 요약 기재
- [ ] UI 변경 시 스크린샷/짧은 설명 첨부
- [x] 셀프 리뷰 완료
