### PR TITLE
feat: #119 이미지 url 변환 추가, 툴바 삭제 버튼 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "@tailwindcss/typography": "^0.5.19",
         "@tanstack/react-query": "^5.90.21",
         "@tiptap/extension-code-block-lowlight": "^3.21.0",
+        "@tiptap/extension-image": "^3.22.3",
         "@tiptap/extension-link": "^3.21.0",
         "@tiptap/extension-placeholder": "^3.21.0",
         "@tiptap/extension-table": "^3.21.0",
@@ -2577,9 +2578,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "15.5.14",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.14.tgz",
-      "integrity": "sha512-aXeirLYuASxEgi4X4WhfXsShCFxWDfNn/8ZeC5YXAS2BB4A8FJi1kwwGL6nvMVboE7fZCzmJPNdMvVHc8JpaiA==",
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.15.tgz",
+      "integrity": "sha512-vcmyu5/MyFzN7CdqRHO3uHO44p/QPCZkuTUXroeUmhNP8bL5PHFEhik22JUazt+CDDoD6EpBYRCaS2pISL+/hg==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -2593,9 +2594,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "15.5.14",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.14.tgz",
-      "integrity": "sha512-Y9K6SPzobnZvrRDPO2s0grgzC+Egf0CqfbdvYmQVaztV890zicw8Z8+4Vqw8oPck8r1TjUHxVh8299Cg4TrxXg==",
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.15.tgz",
+      "integrity": "sha512-6PvFO2Tzt10GFK2Ro9tAVEtacMqRmTarYMFKAnV2vYMdwWc73xzmDQyAV7SwEdMhzmiRoo7+m88DuiXlJlGeaw==",
       "cpu": [
         "arm64"
       ],
@@ -2609,9 +2610,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "15.5.14",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.14.tgz",
-      "integrity": "sha512-aNnkSMjSFRTOmkd7qoNI2/rETQm/vKD6c/Ac9BZGa9CtoOzy3c2njgz7LvebQJ8iPxdeTuGnAjagyis8a9ifBw==",
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.15.tgz",
+      "integrity": "sha512-G+YNV+z6FDZTp/+IdGyIMFqalBTaQSnvAA+X/hrt+eaTRFSznRMz9K7rTmzvM6tDmKegNtyzgufZW0HwVzEqaQ==",
       "cpu": [
         "x64"
       ],
@@ -2625,11 +2626,14 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "15.5.14",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.14.tgz",
-      "integrity": "sha512-tjlpia+yStPRS//6sdmlVwuO1Rioern4u2onafa5n+h2hCS9MAvMXqpVbSrjgiEOoCs0nJy7oPOmWgtRRNSM5Q==",
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.15.tgz",
+      "integrity": "sha512-eVkrMcVIBqGfXB+QUC7jjZ94Z6uX/dNStbQFabewAnk13Uy18Igd1YZ/GtPRzdhtm7QwC0e6o7zOQecul4iC1w==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -2641,11 +2645,14 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "15.5.14",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.14.tgz",
-      "integrity": "sha512-8B8cngBaLadl5lbDRdxGCP1Lef8ipD6KlxS3v0ElDAGil6lafrAM3B258p1KJOglInCVFUjk751IXMr2ixeQOQ==",
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.15.tgz",
+      "integrity": "sha512-RwSHKMQ7InLy5GfkY2/n5PcFycKA08qI1VST78n09nN36nUPqCvGSMiLXlfUmzmpQpF6XeBYP2KRWHi0UW3uNg==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2657,11 +2664,14 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "15.5.14",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.14.tgz",
-      "integrity": "sha512-bAS6tIAg8u4Gn3Nz7fCPpSoKAexEt2d5vn1mzokcqdqyov6ZJ6gu6GdF9l8ORFrBuRHgv3go/RfzYz5BkZ6YSQ==",
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.15.tgz",
+      "integrity": "sha512-nplqvY86LakS+eeiuWsNWvfmK8pFcOEW7ZtVRt4QH70lL+0x6LG/m1OpJ/tvrbwjmR8HH9/fH2jzW1GlL03TIg==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -2673,11 +2683,14 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "15.5.14",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.14.tgz",
-      "integrity": "sha512-mMxv/FcrT7Gfaq4tsR22l17oKWXZmH/lVqcvjX0kfp5I0lKodHYLICKPoX1KRnnE+ci6oIUdriUhuA3rBCDiSw==",
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.15.tgz",
+      "integrity": "sha512-eAgl9NKQ84/sww0v81DQINl/vL2IBxD7sMybd0cWRw6wqgouVI53brVRBrggqBRP/NWeIAE1dm5cbKYoiMlqDQ==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2689,9 +2702,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "15.5.14",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.14.tgz",
-      "integrity": "sha512-OTmiBlYThppnvnsqx0rBqjDRemlmIeZ8/o4zI7veaXoeO1PVHoyj2lfTfXTiiGjCyRDhA10y4h6ZvZvBiynr2g==",
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.15.tgz",
+      "integrity": "sha512-GJVZC86lzSquh0MtvZT+L7G8+jMnJcldloOjA8Kf3wXvBrvb6OGe2MzPuALxFshSm/IpwUtD2mIoof39ymf52A==",
       "cpu": [
         "arm64"
       ],
@@ -2705,9 +2718,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "15.5.14",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.14.tgz",
-      "integrity": "sha512-+W7eFf3RS7m4G6tppVTOSyP9Y6FsJXfOuKzav1qKniiFm3KFByQfPEcouHdjlZmysl4zJGuGLQ/M9XyVeyeNEg==",
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.15.tgz",
+      "integrity": "sha512-nFucjVdwlFqxh/JG3hWSJ4p8+YJV7Ii8aPDuBQULB6DzUF4UNZETXLfEUk+oI2zEznWWULPt7MeuTE6xtK1HSA==",
       "cpu": [
         "x64"
       ],
@@ -5736,16 +5749,16 @@
       }
     },
     "node_modules/@tiptap/core": {
-      "version": "3.22.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.22.1.tgz",
-      "integrity": "sha512-6wPNhkdLIGYiKAGqepDCRtR0TYGJxV40SwOEN2vlPhsXqAgzmyG37UyREj5pGH5xTekugqMCgCnyRg7m5nYoYQ==",
+      "version": "3.22.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.22.3.tgz",
+      "integrity": "sha512-Dv9MKK5BDWCF0N2l6/Pxv3JNCce2kwuWf2cKMBc2bEetx0Pn6o7zlFmSxMvYK4UtG1Tw9Yg/ZHi6QOFWK0Zm9Q==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/pm": "^3.22.1"
+        "@tiptap/pm": "^3.22.3"
       }
     },
     "node_modules/@tiptap/extension-blockquote": {
@@ -5942,6 +5955,19 @@
       "peerDependencies": {
         "@tiptap/core": "^3.22.0",
         "@tiptap/pm": "^3.22.0"
+      }
+    },
+    "node_modules/@tiptap/extension-image": {
+      "version": "3.22.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-image/-/extension-image-3.22.3.tgz",
+      "integrity": "sha512-Qpp8c5LOQaNpHrzjqZtoxtIR+8sSqJ7k8v+8anmYw3nxjvt2kpfT28Vd7aWMX55ZS43LaxMx+MkZqbmgUmMP0w==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.22.3"
       }
     },
     "node_modules/@tiptap/extension-italic": {
@@ -6147,9 +6173,9 @@
       }
     },
     "node_modules/@tiptap/pm": {
-      "version": "3.22.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.22.1.tgz",
-      "integrity": "sha512-OSqSg2974eLJT5PNKFLM7156lBXCUf/dsKTQXWSzsLTf6HOP4dYP6c0YbAk6lgbNI+BdszsHNClmLVLA8H/L9A==",
+      "version": "3.22.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.22.3.tgz",
+      "integrity": "sha512-NjfWjZuvrqmpICT+GZWNIjtOdhPyqFKDMtQy7tsQ5rErM9L2ZQdy/+T/BKSO1JdTeBhdg9OP+0yfsqoYp2aT6A==",
       "license": "MIT",
       "dependencies": {
         "prosemirror-changeset": "^2.3.0",
@@ -13963,12 +13989,12 @@
       }
     },
     "node_modules/next": {
-      "version": "15.5.14",
-      "resolved": "https://registry.npmjs.org/next/-/next-15.5.14.tgz",
-      "integrity": "sha512-M6S+4JyRjmKic2Ssm7jHUPkE6YUJ6lv4507jprsSZLulubz0ihO2E+S4zmQK3JZ2ov81JrugukKU4Tz0ivgqqQ==",
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/next/-/next-15.5.15.tgz",
+      "integrity": "sha512-VSqCrJwtLVGwAVE0Sb/yikrQfkwkZW9p+lL/J4+xe+G3ZA+QnWPqgcfH1tDUEuk9y+pthzzVFp4L/U8JerMfMQ==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "15.5.14",
+        "@next/env": "15.5.15",
         "@swc/helpers": "0.5.15",
         "caniuse-lite": "^1.0.30001579",
         "postcss": "8.4.31",
@@ -13981,14 +14007,14 @@
         "node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "15.5.14",
-        "@next/swc-darwin-x64": "15.5.14",
-        "@next/swc-linux-arm64-gnu": "15.5.14",
-        "@next/swc-linux-arm64-musl": "15.5.14",
-        "@next/swc-linux-x64-gnu": "15.5.14",
-        "@next/swc-linux-x64-musl": "15.5.14",
-        "@next/swc-win32-arm64-msvc": "15.5.14",
-        "@next/swc-win32-x64-msvc": "15.5.14",
+        "@next/swc-darwin-arm64": "15.5.15",
+        "@next/swc-darwin-x64": "15.5.15",
+        "@next/swc-linux-arm64-gnu": "15.5.15",
+        "@next/swc-linux-arm64-musl": "15.5.15",
+        "@next/swc-linux-x64-gnu": "15.5.15",
+        "@next/swc-linux-x64-musl": "15.5.15",
+        "@next/swc-win32-arm64-msvc": "15.5.15",
+        "@next/swc-win32-x64-msvc": "15.5.15",
         "sharp": "^0.34.3"
       },
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@tailwindcss/typography": "^0.5.19",
     "@tanstack/react-query": "^5.90.21",
     "@tiptap/extension-code-block-lowlight": "^3.21.0",
+    "@tiptap/extension-image": "^3.22.3",
     "@tiptap/extension-link": "^3.21.0",
     "@tiptap/extension-placeholder": "^3.21.0",
     "@tiptap/extension-table": "^3.21.0",

--- a/src/features/editor/components/BlockHandleMenu.tsx
+++ b/src/features/editor/components/BlockHandleMenu.tsx
@@ -191,6 +191,25 @@ export function BlockHandleMenu({ editor }: BlockHandleMenuProps) {
     menuRef.current?.offsetWidth ?? null,
     menuRef.current?.offsetHeight ?? null,
   );
+  const handleDeleteBlock = () => {
+    const blockElement = getActiveBlockElement(editor);
+
+    if (!blockElement) {
+      return;
+    }
+
+    const blockRange = getBlockNodeRange(editor, blockElement);
+
+    if (!blockRange) {
+      return;
+    }
+
+    const didDelete = editor.chain().focus().deleteRange(blockRange).run();
+
+    if (didDelete) {
+      setIsMenuOpen(false);
+    }
+  };
 
   return createPortal(
     <>
@@ -233,13 +252,18 @@ export function BlockHandleMenu({ editor }: BlockHandleMenuProps) {
             top: menuPosition.top,
           }}
         >
-          <BubbleMenuBar editor={editor} />
+          <BubbleMenuBar editor={editor} onDeleteBlock={handleDeleteBlock} />
         </div>
       )}
     </>,
     document.body,
   );
 }
+
+type BlockNodeRangeType = {
+  from: number;
+  to: number;
+};
 
 type MenuPositionType = {
   left: number;
@@ -319,20 +343,64 @@ export function getBlockHandleMarkerOffset(blockElement: HTMLElement): number {
   return markerPadding + LIST_MARKER_CLEARANCE;
 }
 
+function getBlockNodeRange(
+  editor: Editor,
+  blockElement: HTMLElement,
+): BlockNodeRangeType | null {
+  let blockRange: BlockNodeRangeType | null = null;
+
+  editor.state.doc.descendants((node, pos) => {
+    if (editor.view.nodeDOM(pos) !== blockElement) {
+      return true;
+    }
+
+    blockRange = { from: pos, to: pos + node.nodeSize };
+
+    return false;
+  });
+
+  return blockRange;
+}
+
 function getActiveBlockElement(editor: Editor): HTMLElement | null {
   const rootElement = editor.view.dom;
   const { from } = editor.state.selection;
+  const selectedNodeDom = editor.view.nodeDOM(from);
   const domAtPos = editor.view.domAtPos(from);
+
+  if (
+    selectedNodeDom instanceof HTMLImageElement &&
+    rootElement.contains(selectedNodeDom)
+  ) {
+    return selectedNodeDom;
+  }
+
+  if (
+    domAtPos.node instanceof HTMLImageElement &&
+    rootElement.contains(domAtPos.node)
+  ) {
+    return domAtPos.node;
+  }
+
+  const selectedElement =
+    selectedNodeDom instanceof HTMLElement
+      ? selectedNodeDom
+      : selectedNodeDom instanceof Text
+        ? selectedNodeDom.parentElement
+        : null;
   const currentElement =
     domAtPos.node instanceof HTMLElement
       ? domAtPos.node
       : domAtPos.node.parentElement;
 
-  if (!(currentElement instanceof HTMLElement)) {
+  const activeElement =
+    selectedElement instanceof HTMLElement ? selectedElement : currentElement;
+
+  if (!(activeElement instanceof HTMLElement)) {
     return null;
   }
 
-  const tableElement = currentElement.closest("table");
+  const tableElement = activeElement.closest("table");
 
   if (
     tableElement instanceof HTMLElement &&
@@ -341,7 +409,7 @@ function getActiveBlockElement(editor: Editor): HTMLElement | null {
     return tableElement;
   }
 
-  const listItemElement = currentElement.closest("li");
+  const listItemElement = activeElement.closest("li");
 
   if (
     listItemElement instanceof HTMLElement &&
@@ -350,8 +418,8 @@ function getActiveBlockElement(editor: Editor): HTMLElement | null {
     return listItemElement;
   }
 
-  const blockElement = currentElement.closest(
-    "p, h1, h2, h3, pre, blockquote, hr",
+  const blockElement = activeElement.closest(
+    "p, h1, h2, h3, pre, blockquote, hr, img",
   );
 
   if (

--- a/src/features/editor/components/BubbleMenuBar.tsx
+++ b/src/features/editor/components/BubbleMenuBar.tsx
@@ -36,9 +36,10 @@ import { LinkEditPopover } from "./LinkEditPopover";
 
 type BubbleMenuBarProps = {
   editor: Editor;
+  onDeleteBlock?: () => void;
 };
 
-export function BubbleMenuBar({ editor }: BubbleMenuBarProps) {
+export function BubbleMenuBar({ editor, onDeleteBlock }: BubbleMenuBarProps) {
   const [showLinkEdit, setShowLinkEdit] = useState(false);
 
   const handleLinkSubmit = useCallback(
@@ -264,6 +265,17 @@ export function BubbleMenuBar({ editor }: BubbleMenuBarProps) {
             aria-label="Insert table"
           >
             <Table className="size-3.5" />
+          </ToolbarButton>
+
+          <Divider />
+
+          <ToolbarButton
+            onClick={onDeleteBlock}
+            data-testid="toolbar-delete-block"
+            aria-label="Delete block"
+            title="Delete block"
+          >
+            <Trash2 className="size-3.5" />
           </ToolbarButton>
 
           {isTable && (

--- a/src/features/editor/styles/tiptap.css
+++ b/src/features/editor/styles/tiptap.css
@@ -155,6 +155,17 @@
   font-style: italic;
 }
 
+/* Images */
+.tiptap-wrapper .tiptap img {
+  display: block;
+  max-width: 100%;
+  max-height: min(600px, 70vh);
+  height: auto;
+  object-fit: contain;
+  margin: 0.75rem auto;
+  border-radius: 0.75rem;
+}
+
 /* Horizontal rule */
 .tiptap-wrapper .tiptap hr {
   border: none;

--- a/src/features/editor/tests/BubbleMenuBar.test.tsx
+++ b/src/features/editor/tests/BubbleMenuBar.test.tsx
@@ -159,6 +159,7 @@ describe("BubbleMenuBar", () => {
     expect(screen.getByTestId("toolbar-code-block")).toBeInTheDocument();
     expect(screen.getByTestId("toolbar-divider")).toBeInTheDocument();
     expect(screen.getByTestId("toolbar-insert-table")).toBeInTheDocument();
+    expect(screen.getByTestId("toolbar-delete-block")).toBeInTheDocument();
     expect(screen.getByTestId("toolbar-add-link")).toBeInTheDocument();
   });
 
@@ -202,6 +203,22 @@ describe("BubbleMenuBar", () => {
     await user.click(screen.getByTestId("toolbar-add-link"));
 
     expect(screen.getByPlaceholderText("https://...")).toBeInTheDocument();
+  });
+
+  it("calls the block delete handler when the delete button is clicked", async () => {
+    const user = userEvent.setup();
+    const handleDeleteBlock = vi.fn();
+
+    render(
+      <BubbleMenuBar
+        editor={createMockEditor()}
+        onDeleteBlock={handleDeleteBlock}
+      />,
+    );
+
+    await user.click(screen.getByTestId("toolbar-delete-block"));
+
+    expect(handleDeleteBlock).toHaveBeenCalledTimes(1);
   });
 
   it("extends the active link range before updating the URL", async () => {

--- a/src/features/editor/tests/TipTapEditor.test.tsx
+++ b/src/features/editor/tests/TipTapEditor.test.tsx
@@ -1,6 +1,6 @@
 import "./setup";
 
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 
@@ -15,6 +15,32 @@ function getEditorContentElement() {
   }
 
   return contentElement;
+}
+
+type ClipboardDataMockType = {
+  files: { length: number };
+  getData: (type: string) => string;
+  items: { length: number };
+  types: string[];
+};
+
+function dispatchPaste(text: string) {
+  const pasteEvent = new Event("paste", {
+    bubbles: true,
+    cancelable: true,
+  });
+  const clipboardData: ClipboardDataMockType = {
+    files: { length: 0 },
+    getData: (type: string) => (type === "text/plain" ? text : ""),
+    items: { length: 0 },
+    types: ["text/plain"],
+  };
+
+  Object.defineProperty(pasteEvent, "clipboardData", {
+    value: clipboardData,
+  });
+
+  getEditorContentElement().dispatchEvent(pasteEvent);
 }
 
 describe("TipTapEditor", () => {
@@ -132,6 +158,27 @@ describe("TipTapEditor", () => {
     expect(screen.getByTestId("bubble-toolbar")).toBeInTheDocument();
     expect(screen.getByTestId("toolbar-undo")).toBeInTheDocument();
     expect(screen.getByTestId("toolbar-bold")).toBeInTheDocument();
+  });
+
+  it("deletes the current block from the toolbar", async () => {
+    const user = userEvent.setup();
+    const handleChange = vi.fn();
+
+    render(<TipTapEditor value="Delete me" onChange={handleChange} />);
+
+    await waitFor(() => {
+      expect(getEditorContentElement()).toBeTruthy();
+    });
+
+    await user.click(getEditorContentElement());
+    await user.click(await screen.findByLabelText("Open block toolbar"));
+    await user.click(screen.getByTestId("toolbar-delete-block"));
+
+    await waitFor(() => {
+      expect(getEditorContentElement().textContent).not.toContain("Delete me");
+    });
+
+    expect(handleChange).toHaveBeenCalled();
   });
 
   it("shows the language selector after turning the current block into a code block", async () => {
@@ -253,5 +300,78 @@ describe("TipTapEditor", () => {
     );
 
     expect(linkExtension?.options?.openOnClick).toBe(true);
+  });
+
+  it("converts pasted markdown images with angle-bracket destinations", async () => {
+    const user = userEvent.setup();
+    const handleChange = vi.fn();
+
+    render(<TipTapEditor value="" onChange={handleChange} />);
+    await waitFor(() => {
+      expect(getEditorContentElement()).toBeTruthy();
+    });
+
+    await user.click(getEditorContentElement());
+
+    await act(async () => {
+      dispatchPaste(
+        "![Dog](<https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQDBqBsYdSaYjDuQTnKzZG-M-IxDEf8vA0bgA&s>)",
+      );
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole("img", { name: "Dog" })).toBeInTheDocument();
+    });
+
+    expect(handleChange).toHaveBeenLastCalledWith(
+      "![Dog](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQDBqBsYdSaYjDuQTnKzZG-M-IxDEf8vA0bgA&s)",
+    );
+  });
+
+  it("converts pasted markdown images with empty alt text", async () => {
+    const user = userEvent.setup();
+    const handleChange = vi.fn();
+
+    render(<TipTapEditor value="" onChange={handleChange} />);
+    await waitFor(() => {
+      expect(getEditorContentElement()).toBeTruthy();
+    });
+
+    await user.click(getEditorContentElement());
+
+    await act(async () => {
+      dispatchPaste("![](https://example.com/empty-alt.png)");
+    });
+
+    await waitFor(() => {
+      const image = document.querySelector(
+        'img[src="https://example.com/empty-alt.png"]',
+      );
+
+      expect(image).toBeInTheDocument();
+      expect(image).toHaveAttribute("alt", "");
+    });
+
+    expect(handleChange).toHaveBeenLastCalledWith(
+      "![](https://example.com/empty-alt.png)",
+    );
+  });
+
+  it("shows the block handle when an image block is focused", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <TipTapEditor
+        value="![Dog](https://example.com/diagram.png)"
+        onChange={vi.fn()}
+      />,
+    );
+
+    const image = await screen.findByRole("img", { name: "Dog" });
+    await user.click(image);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Open block toolbar")).toBeInTheDocument();
+    });
   });
 });

--- a/src/features/editor/tests/linkValidation.test.ts
+++ b/src/features/editor/tests/linkValidation.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeImageSrc, normalizeLinkHref } from "../utils/linkValidation";
+
+describe("normalizeLinkHref", () => {
+  it("unwraps markdown angle-bracket destinations", () => {
+    expect(normalizeLinkHref("<https://example.com/docs>")).toBe(
+      "https://example.com/docs",
+    );
+  });
+});
+
+describe("normalizeImageSrc", () => {
+  it("unwraps markdown angle-bracket image destinations", () => {
+    expect(normalizeImageSrc("<https://example.com/image.png>")).toBe(
+      "https://example.com/image.png",
+    );
+  });
+
+  it("normalizes scheme-less external image URLs", () => {
+    expect(normalizeImageSrc("example.com/image.png")).toBe(
+      "https://example.com/image.png",
+    );
+  });
+
+  it("normalizes protocol-relative image URLs to https", () => {
+    expect(normalizeImageSrc("//cdn.example.com/image.png")).toBe(
+      "https://cdn.example.com/image.png",
+    );
+  });
+
+  it("rejects relative image paths", () => {
+    expect(normalizeImageSrc("/image.png")).toBeNull();
+    expect(normalizeImageSrc("./image.png")).toBeNull();
+    expect(normalizeImageSrc("../image.png")).toBeNull();
+  });
+
+  it("encodes whitespace in scheme-less image URLs", () => {
+    expect(normalizeImageSrc("  example.com/my image.png  ")).toBe(
+      "https://example.com/my%20image.png",
+    );
+  });
+
+  it("rejects localhost and loopback image URLs", () => {
+    expect(normalizeImageSrc("http://localhost:3000/image.png")).toBeNull();
+    expect(normalizeImageSrc("https://127.0.0.1/image.png")).toBeNull();
+    expect(normalizeImageSrc("//foo.localhost/image.png")).toBeNull();
+  });
+
+  it("rejects IPv6 literal image URLs", () => {
+    expect(normalizeImageSrc("https://[::1]/image.png")).toBeNull();
+    expect(normalizeImageSrc("https://[2001:db8::1]/image.png")).toBeNull();
+  });
+
+  it("rejects unsafe image protocols", () => {
+    expect(normalizeImageSrc("data:image/png;base64,abc")).toBeNull();
+    expect(normalizeImageSrc("javascript:alert(1)")).toBeNull();
+  });
+});

--- a/src/features/editor/tests/linkValidation.test.ts
+++ b/src/features/editor/tests/linkValidation.test.ts
@@ -29,6 +29,13 @@ describe("normalizeImageSrc", () => {
     );
   });
 
+  it("rejects image URLs with embedded credentials", () => {
+    expect(
+      normalizeImageSrc("https://user:pass@example.com/private.png"),
+    ).toBeNull();
+    expect(normalizeImageSrc("//user:pass@example.com/private.png")).toBeNull();
+  });
+
   it("rejects relative image paths", () => {
     expect(normalizeImageSrc("/image.png")).toBeNull();
     expect(normalizeImageSrc("./image.png")).toBeNull();

--- a/src/features/editor/tests/tiptapExtensions.test.ts
+++ b/src/features/editor/tests/tiptapExtensions.test.ts
@@ -26,6 +26,26 @@ describe("MarkdownTaskItem custom extension", () => {
     expect(roundTrip(input).trim()).toBe(input);
   });
 
+  it("round-trips markdown images", () => {
+    const input = "![Architecture diagram](https://example.com/diagram.png)";
+    expect(roundTrip(input).trim()).toBe(input);
+  });
+
+  it("normalizes angle-bracket markdown image destinations during round-trip", () => {
+    const input =
+      "![Dog](<https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQDBqBsYdSaYjDuQTnKzZG-M-IxDEf8vA0bgA&s>)";
+    expect(roundTrip(input).trim()).toBe(
+      "![Dog](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQDBqBsYdSaYjDuQTnKzZG-M-IxDEf8vA0bgA&s)",
+    );
+  });
+
+  it("normalizes bare markdown image hosts to https during round-trip", () => {
+    const input = "![Architecture diagram](example.com/diagram.png)";
+    expect(roundTrip(input).trim()).toBe(
+      "![Architecture diagram](https://example.com/diagram.png)",
+    );
+  });
+
   it("round-trips nested task lists (blank line between different indents)", () => {
     const input = "- [ ] parent\n  - [x] child";
     const result = roundTrip(input).trim();
@@ -174,6 +194,76 @@ describe("getReadOnlyTipTapExtensions", () => {
     });
 
     expect(editor.getHTML()).toContain('data-language="typescript"');
+    editor.destroy();
+  });
+
+  it("renders safe markdown images in readonly mode", () => {
+    const extensions = getReadOnlyTipTapExtensions();
+    const editor = new Editor({
+      extensions,
+      content: "![Architecture diagram](https://example.com/diagram.png)",
+      editable: false,
+    });
+
+    expect(editor.getHTML()).toContain("<img");
+    expect(editor.getHTML()).toContain('src="https://example.com/diagram.png"');
+
+    editor.destroy();
+  });
+
+  it("normalizes scheme-less markdown images in readonly mode", () => {
+    const extensions = getReadOnlyTipTapExtensions();
+    const editor = new Editor({
+      extensions,
+      content: "![Architecture diagram](example.com/diagram.png)",
+      editable: false,
+    });
+
+    expect(editor.getHTML()).toContain('src="https://example.com/diagram.png"');
+
+    editor.destroy();
+  });
+
+  it("renders angle-bracket markdown images in readonly mode", () => {
+    const extensions = getReadOnlyTipTapExtensions();
+    const editor = new Editor({
+      extensions,
+      content:
+        "![Dog](<https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQDBqBsYdSaYjDuQTnKzZG-M-IxDEf8vA0bgA&s>)",
+      editable: false,
+    });
+
+    expect(editor.getHTML()).toContain("<img");
+    expect(editor.getHTML()).toContain(
+      'src="https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQDBqBsYdSaYjDuQTnKzZG-M-IxDEf8vA0bgA&amp;s"',
+    );
+
+    editor.destroy();
+  });
+
+  it("filters localhost markdown images in readonly mode", () => {
+    const extensions = getReadOnlyTipTapExtensions();
+    const editor = new Editor({
+      extensions,
+      content: "![Local image](http://localhost:3000/diagram.png)",
+      editable: false,
+    });
+
+    expect(editor.getHTML()).not.toContain("<img");
+
+    editor.destroy();
+  });
+
+  it("filters unsafe markdown images in readonly mode", () => {
+    const extensions = getReadOnlyTipTapExtensions();
+    const editor = new Editor({
+      extensions,
+      content: "![Unsafe image](javascript:alert(1))",
+      editable: false,
+    });
+
+    expect(editor.getHTML()).not.toContain("<img");
+
     editor.destroy();
   });
 });

--- a/src/features/editor/tests/tiptapExtensions.test.ts
+++ b/src/features/editor/tests/tiptapExtensions.test.ts
@@ -70,6 +70,25 @@ describe("MarkdownTaskItem custom extension", () => {
     const input = "";
     expect(roundTrip(input).trim()).toBe("");
   });
+
+  it("normalizes programmatically inserted image URLs during serialization", () => {
+    const editor = createEditor("");
+
+    editor.commands.insertContent({
+      type: "image",
+      attrs: {
+        src: "example.com/diagram.png",
+        alt: "Architecture diagram",
+        title: null,
+      },
+    });
+
+    expect(serializeTipTapMarkdown(editor).trim()).toBe(
+      "![Architecture diagram](https://example.com/diagram.png)",
+    );
+
+    editor.destroy();
+  });
 });
 
 describe("MarkdownTaskItem — isPureTaskListElement edge cases", () => {

--- a/src/features/editor/utils/linkValidation.ts
+++ b/src/features/editor/utils/linkValidation.ts
@@ -10,9 +10,12 @@ const ALLOWED_PROTOCOLS = new Set([
   "cid:",
   "xmpp:",
 ]);
+const ALLOWED_IMAGE_PROTOCOLS = new Set(["http:", "https:"]);
 
 const RELATIVE_PREFIXES = ["#", "/", "./", "../", "?"];
-const DEFAULT_EXTERNAL_PROTOCOL = "http://";
+const IMAGE_RELATIVE_PREFIXES = ["/", "./", "../"];
+const DEFAULT_EXTERNAL_LINK_PROTOCOL = "http://";
+const DEFAULT_EXTERNAL_IMAGE_PROTOCOL = "https://";
 
 function isRelativeLinkHref(input: string): boolean {
   return RELATIVE_PREFIXES.some((prefix) => input.startsWith(prefix));
@@ -64,8 +67,18 @@ function hasAuthorityUserInfo(input: string): boolean {
   return authority.includes("@");
 }
 
+function unwrapMarkdownLinkDestination(input: string): string {
+  return input.startsWith("<") && input.endsWith(">")
+    ? input.slice(1, -1).trim()
+    : input;
+}
+
+function normalizeHostnameForValidation(hostname: string): string {
+  return hostname.replace(/\.+$/, "").toLowerCase();
+}
+
 export function normalizeLinkHref(input: string): string | null {
-  const trimmed = input.trim();
+  const trimmed = unwrapMarkdownLinkDestination(input.trim());
 
   if (trimmed === "") {
     return null;
@@ -80,7 +93,7 @@ export function normalizeLinkHref(input: string): string | null {
   }
 
   try {
-    const url = new URL(`${DEFAULT_EXTERNAL_PROTOCOL}${trimmed}`);
+    const url = new URL(`${DEFAULT_EXTERNAL_LINK_PROTOCOL}${trimmed}`);
 
     if (!isExternalHostname(url.hostname)) {
       return null;
@@ -94,4 +107,90 @@ export function normalizeLinkHref(input: string): string | null {
 
 export function isSafeLinkHref(input: string): boolean {
   return normalizeLinkHref(input) !== null;
+}
+
+function hasRelativeImagePathPrefix(input: string): boolean {
+  if (input.startsWith("//")) {
+    return false;
+  }
+
+  return IMAGE_RELATIVE_PREFIXES.some((prefix) => input.startsWith(prefix));
+}
+
+function hasAllowedImageHostname(hostname: string): boolean {
+  const normalizedHostname = normalizeHostnameForValidation(hostname);
+
+  if (
+    normalizedHostname === "" ||
+    normalizedHostname === "localhost" ||
+    normalizedHostname.endsWith(".localhost") ||
+    isIpv4Hostname(normalizedHostname) ||
+    normalizedHostname.includes(":")
+  ) {
+    return false;
+  }
+
+  return normalizedHostname.includes(".");
+}
+
+function normalizeAbsoluteImageSrc(input: string): string | null {
+  if (hasAuthorityUserInfo(input)) {
+    return null;
+  }
+
+  try {
+    const url = new URL(input);
+
+    if (
+      !ALLOWED_IMAGE_PROTOCOLS.has(url.protocol) ||
+      !hasAllowedImageHostname(url.hostname)
+    ) {
+      return null;
+    }
+
+    return url.toString();
+  } catch {
+    return null;
+  }
+}
+
+function normalizeSchemeLessImageSrc(input: string): string | null {
+  if (!canNormalizeSchemeLessHref(input) || hasAuthorityUserInfo(input)) {
+    return null;
+  }
+
+  return normalizeAbsoluteImageSrc(
+    `${DEFAULT_EXTERNAL_IMAGE_PROTOCOL}${input}`,
+  );
+}
+
+function normalizeProtocolRelativeImageSrc(input: string): string | null {
+  return normalizeAbsoluteImageSrc(`https:${input}`);
+}
+
+export function normalizeImageSrc(input: string): string | null {
+  const trimmed = unwrapMarkdownLinkDestination(input.trim());
+
+  if (trimmed === "") {
+    return null;
+  }
+
+  if (trimmed.startsWith("//")) {
+    return normalizeProtocolRelativeImageSrc(trimmed);
+  }
+
+  // Markdown images in notes are treated as external resources only. Relative
+  // paths would resolve against the app origin instead of a user-provided host.
+  if (hasRelativeImagePathPrefix(trimmed)) {
+    return null;
+  }
+
+  const absoluteSrc = normalizeAbsoluteImageSrc(trimmed);
+
+  if (absoluteSrc) {
+    return absoluteSrc;
+  }
+
+  // Auto-loaded images should prefer HTTPS when we normalize bare hostnames.
+  return normalizeSchemeLessImageSrc(trimmed);
 }

--- a/src/features/editor/utils/linkValidation.ts
+++ b/src/features/editor/utils/linkValidation.ts
@@ -67,6 +67,10 @@ function hasAuthorityUserInfo(input: string): boolean {
   return authority.includes("@");
 }
 
+function hasUrlUserInfo(url: URL): boolean {
+  return url.username !== "" || url.password !== "";
+}
+
 function unwrapMarkdownLinkDestination(input: string): string {
   return input.startsWith("<") && input.endsWith(">")
     ? input.slice(1, -1).trim()
@@ -142,6 +146,7 @@ function normalizeAbsoluteImageSrc(input: string): string | null {
     const url = new URL(input);
 
     if (
+      hasUrlUserInfo(url) ||
       !ALLOWED_IMAGE_PROTOCOLS.has(url.protocol) ||
       !hasAllowedImageHostname(url.hostname)
     ) {

--- a/src/features/editor/utils/tiptapExtensions.ts
+++ b/src/features/editor/utils/tiptapExtensions.ts
@@ -284,7 +284,16 @@ const SafeImage = Image.extend({
             return;
           }
 
-          serializeImage(state, node, parent, index);
+          const normalizedNode = node.type.create(
+            {
+              ...node.attrs,
+              src,
+            },
+            null,
+            node.marks,
+          );
+
+          serializeImage(state, normalizedNode, parent, index);
         },
         parse: {
           updateDOM(element: HTMLElement) {

--- a/src/features/editor/utils/tiptapExtensions.ts
+++ b/src/features/editor/utils/tiptapExtensions.ts
@@ -1,9 +1,12 @@
 import {
   mergeAttributes,
+  nodeInputRule,
+  nodePasteRule,
   type NodeViewRenderer,
   type NodeViewRendererProps,
 } from "@tiptap/core";
 import CodeBlockLowlight from "@tiptap/extension-code-block-lowlight";
+import Image, { inputRegex as imageInputRegex } from "@tiptap/extension-image";
 import Link from "@tiptap/extension-link";
 import Placeholder from "@tiptap/extension-placeholder";
 import {
@@ -14,6 +17,11 @@ import {
 } from "@tiptap/extension-table";
 import TaskItem from "@tiptap/extension-task-item";
 import TaskList from "@tiptap/extension-task-list";
+import {
+  defaultMarkdownSerializer,
+  type MarkdownSerializerState,
+} from "@tiptap/pm/markdown";
+import { type Node as ProseMirrorNode } from "@tiptap/pm/model";
 import StarterKit from "@tiptap/starter-kit";
 import go from "highlight.js/lib/languages/go";
 import javascript from "highlight.js/lib/languages/javascript";
@@ -24,7 +32,7 @@ import { createLowlight } from "lowlight";
 import { Markdown } from "tiptap-markdown";
 
 import { slashCommandSuggestionRender } from "../components/SlashCommandMenu";
-import { isSafeLinkHref } from "./linkValidation";
+import { isSafeLinkHref, normalizeImageSrc } from "./linkValidation";
 import { SlashCommand } from "./slashCommand";
 
 const lowlight = createLowlight();
@@ -145,6 +153,216 @@ const MarkdownTaskItem = TaskItem.extend({
   },
 });
 
+type SafeImageInputAttributesType = {
+  src: string;
+  alt: string | null;
+  title: string | null;
+};
+
+const safeImagePasteRegex =
+  /(?:^|\s)(!\[(.*?)\]\((<[^>\n]+>|\S+)(?:(?:\s+)["'](\S+)["'])?\))/g;
+
+function getSafeImageAttributes(
+  alt: unknown,
+  rawSrc: unknown,
+  title: unknown,
+): SafeImageInputAttributesType | null {
+  if (typeof rawSrc !== "string") {
+    return null;
+  }
+
+  const src = normalizeImageSrc(rawSrc);
+
+  if (!src) {
+    return null;
+  }
+
+  return {
+    src,
+    alt: typeof alt === "string" ? alt : null,
+    title: typeof title === "string" ? title : null,
+  };
+}
+
+function getSafeImageInputAttributes(match: {
+  data?: Record<string, unknown>;
+}): SafeImageInputAttributesType | false {
+  const src = typeof match.data?.src === "string" ? match.data.src : null;
+
+  if (!src) {
+    return false;
+  }
+
+  return {
+    src,
+    alt: typeof match.data?.alt === "string" ? match.data.alt : null,
+    title: typeof match.data?.title === "string" ? match.data.title : null,
+  };
+}
+
+function findSafeImageInputRuleMatch(text: string) {
+  const match = imageInputRegex.exec(text);
+
+  if (!match) {
+    return null;
+  }
+
+  const [, imageMarkdown, alt, rawSrc, title] = match;
+
+  if (typeof imageMarkdown !== "string" || typeof rawSrc !== "string") {
+    return null;
+  }
+
+  const data = getSafeImageAttributes(alt, rawSrc, title);
+
+  if (!data) {
+    return null;
+  }
+
+  return {
+    index: match.index ?? 0,
+    text: match[0],
+    replaceWith: imageMarkdown,
+    data,
+  };
+}
+
+function findSafeImagePasteRuleMatches(text: string) {
+  const matches = Array.from(text.matchAll(safeImagePasteRegex));
+
+  return matches.flatMap((match) => {
+    const [, imageMarkdown, alt, rawSrc, title] = match;
+
+    if (typeof imageMarkdown !== "string") {
+      return [];
+    }
+
+    const data = getSafeImageAttributes(alt, rawSrc, title);
+
+    if (!data) {
+      return [];
+    }
+
+    const fullMatch = typeof match[0] === "string" ? match[0] : imageMarkdown;
+    const imageMarkdownOffset = fullMatch.lastIndexOf(imageMarkdown);
+
+    return [
+      {
+        index: (match.index ?? 0) + Math.max(0, imageMarkdownOffset),
+        text: imageMarkdown,
+        data,
+      },
+    ];
+  });
+}
+
+const SafeImage = Image.extend({
+  addStorage() {
+    return {
+      markdown: {
+        // tiptap-markdown reads node-specific storage.markdown hooks during
+        // parse/serialize, so image sanitization lives here to cover every
+        // markdown entry point with the same validator.
+        serialize(
+          state: MarkdownSerializerState,
+          node: ProseMirrorNode,
+          parent: ProseMirrorNode,
+          index: number,
+        ) {
+          const src =
+            typeof node.attrs.src === "string"
+              ? normalizeImageSrc(node.attrs.src)
+              : null;
+
+          if (!src) {
+            return;
+          }
+
+          const serializeImage = defaultMarkdownSerializer.nodes.image;
+
+          if (!serializeImage) {
+            return;
+          }
+
+          serializeImage(state, node, parent, index);
+        },
+        parse: {
+          updateDOM(element: HTMLElement) {
+            for (const image of element.querySelectorAll("img[src]")) {
+              if (!(image instanceof HTMLImageElement)) continue;
+
+              const src = image.getAttribute("src");
+              const normalizedSrc =
+                typeof src === "string" ? normalizeImageSrc(src) : null;
+
+              if (!normalizedSrc) {
+                image.remove();
+                continue;
+              }
+
+              image.setAttribute("src", normalizedSrc);
+            }
+          },
+        },
+      },
+    };
+  },
+  renderHTML({ HTMLAttributes }) {
+    const src =
+      typeof HTMLAttributes.src === "string"
+        ? normalizeImageSrc(HTMLAttributes.src)
+        : null;
+
+    if (!src) {
+      return ["span", { "data-invalid-image": "true", hidden: "hidden" }];
+    }
+
+    return [
+      "img",
+      mergeAttributes(this.options.HTMLAttributes, HTMLAttributes, { src }),
+    ];
+  },
+  addCommands() {
+    return {
+      setImage:
+        (options) =>
+        ({ commands }) => {
+          const src = normalizeImageSrc(options.src);
+
+          if (!src) {
+            return false;
+          }
+
+          return commands.insertContent({
+            type: this.name,
+            attrs: {
+              ...options,
+              src,
+            },
+          });
+        },
+    };
+  },
+  addInputRules() {
+    return [
+      nodeInputRule({
+        find: findSafeImageInputRuleMatch,
+        type: this.type,
+        getAttributes: getSafeImageInputAttributes,
+      }),
+    ];
+  },
+  addPasteRules() {
+    return [
+      nodePasteRule({
+        find: findSafeImagePasteRuleMatches,
+        type: this.type,
+        getAttributes: getSafeImageInputAttributes,
+      }),
+    ];
+  },
+});
+
 function getBaseExtensions({ readOnly = false }: { readOnly?: boolean } = {}) {
   return [
     StarterKit.configure({
@@ -169,6 +387,12 @@ function getBaseExtensions({ readOnly = false }: { readOnly?: boolean } = {}) {
         ];
       },
     }).configure({ lowlight }),
+    SafeImage.configure({
+      allowBase64: false,
+      HTMLAttributes: {
+        class: "tiptap-image",
+      },
+    }),
     Link.configure({
       isAllowedUri: (url) => isSafeLinkHref(url),
       openOnClick: readOnly,

--- a/src/features/notes/tests/NoteViewer.test.tsx
+++ b/src/features/notes/tests/NoteViewer.test.tsx
@@ -45,6 +45,57 @@ describe("NoteViewer", () => {
     expect(link).toHaveAttribute("href", "https://openai.com");
   });
 
+  it("renders markdown images in readonly mode", async () => {
+    render(
+      <NoteViewer
+        content="![Architecture diagram](https://example.com/diagram.png)"
+        language="markdown"
+      />,
+    );
+
+    const image = await screen.findByRole("img", {
+      name: "Architecture diagram",
+    });
+
+    expect(image).toHaveAttribute("src", "https://example.com/diagram.png");
+  });
+
+  it("does not render markdown images with unsafe sources", async () => {
+    render(
+      <NoteViewer
+        content="![Unsafe image](javascript:alert(1))"
+        language="markdown"
+      />,
+    );
+
+    await waitFor(() => {
+      const editor = document.querySelector("[contenteditable='false']");
+      expect(editor).toBeTruthy();
+    });
+
+    expect(
+      screen.queryByRole("img", { name: "Unsafe image" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("does not render markdown images with relative sources", async () => {
+    render(
+      <NoteViewer
+        content="![Relative image](../api/internal.png)"
+        language="markdown"
+      />,
+    );
+
+    await waitFor(() => {
+      const editor = document.querySelector("[contenteditable='false']");
+      expect(editor).toBeTruthy();
+    });
+
+    expect(
+      screen.queryByRole("img", { name: "Relative image" }),
+    ).not.toBeInTheDocument();
+  });
+
   it("renders code notes with syntax-highlighted markup", () => {
     const { container } = render(
       <NoteViewer content={"const answer = 42;"} language="typescript" />,

--- a/src/features/review/components/ComparisonView.test.tsx
+++ b/src/features/review/components/ComparisonView.test.tsx
@@ -1,0 +1,34 @@
+import "@/tests/setup";
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { ComparisonView } from "./ComparisonView";
+
+describe("ComparisonView", () => {
+  it("renders markdown images in both readonly panels", async () => {
+    render(
+      <ComparisonView
+        language="markdown"
+        userAnswer="![User answer image](https://example.com/user-answer.png)"
+        originalContent="![Original image](https://example.com/original.png)"
+      />,
+    );
+
+    const userAnswerImage = await screen.findByRole("img", {
+      name: "User answer image",
+    });
+    const originalImage = await screen.findByRole("img", {
+      name: "Original image",
+    });
+
+    expect(userAnswerImage).toHaveAttribute(
+      "src",
+      "https://example.com/user-answer.png",
+    );
+    expect(originalImage).toHaveAttribute(
+      "src",
+      "https://example.com/original.png",
+    );
+  });
+});


### PR DESCRIPTION
## 개요

노트 마크다운 에디터와 읽기 전용 뷰어에서 이미지 URL을 안전하게 렌더링할 수 있도록 처리했습니다.
함께 블록 핸들 툴바에 현재 블록 삭제 액션을 추가해 편집 편의성을 보완했습니다.

## PR 유형

- [x] 새로운 기능 추가
- [x] 버그 수정
- [x] UI/UX 변경
- [ ] 코드 리팩토링
- [x] 테스트 추가/수정
- [ ] 문서 수정
- [x] 빌드/패키지 설정 변경

## 관련 이슈

closes #119

## 작업 내용

- 마크다운 이미지 URL 정규화/검증 로직을 추가했습니다.
- `![alt](<https://...>)`, `//cdn...`, `example.com/image.png` 같은 입력을 안전한 외부 이미지 URL로 정규화하도록 처리했습니다.
- 상대경로 이미지(`/`, `./`, `../`), localhost/loopback, IPv6 literal, `javascript:`/`data:` 등 unsafe source는 차단했습니다.
- TipTap에 `SafeImage` 확장을 추가해 입력, 붙여넣기, readonly 렌더링, markdown serialize 경로에서 동일한 검증 로직을 사용하도록 맞췄습니다.
- 빈 alt(`![](...)`) 이미지도 붙여넣기 시 정상 처리되도록 정규식을 수정했습니다.
- readonly markdown 렌더링에서 안전한 이미지는 표시하고, unsafe/relative 이미지는 렌더링하지 않도록 보강했습니다.
- 블록 핸들 툴바에 현재 블록 삭제 버튼을 추가했습니다.
- 현재 활성 블록의 DOM에 대응하는 ProseMirror range를 찾아 삭제하도록 구현해 문단, 리스트 아이템, 테이블, 이미지 블록까지 동일하게 삭제되도록 반영했습니다.
- 에디터 이미지 스타일을 추가하고 `max-height: min(600px, 70vh)`를 적용했습니다.
- `@tiptap/extension-image` 의존성을 추가했습니다.
- 이미지 렌더링 관련 테스트와 블록 삭제 툴바 테스트를 보강했습니다.
- `ComparisonView`에도 markdown 이미지 렌더링 테스트를 추가했습니다.

## 테스트 방법

- `npx eslint "src/features/editor/components/BubbleMenuBar.tsx" "src/features/editor/components/BlockHandleMenu.tsx" "src/features/editor/tests/BubbleMenuBar.test.tsx" "src/features/editor/tests/TipTapEditor.test.tsx"`
- `npx eslint "src/features/editor/utils/linkValidation.ts" "src/features/editor/utils/tiptapExtensions.ts" "src/features/editor/components/BlockHandleMenu.tsx" "src/features/editor/tests/TipTapEditor.test.tsx" "src/features/editor/tests/linkValidation.test.ts" "src/features/notes/tests/NoteViewer.test.tsx"`
- `npx vitest run "src/features/editor/tests/BubbleMenuBar.test.tsx" "src/features/editor/tests/TipTapEditor.test.tsx" "src/features/editor/tests/BlockHandleMenu.test.tsx"`
- `npx vitest run "src/features/editor/tests/linkValidation.test.ts" "src/features/editor/tests/TipTapEditor.test.tsx" "src/features/editor/tests/tiptapExtensions.test.ts" "src/features/editor/tests/BlockHandleMenu.test.tsx" "src/features/notes/tests/NoteViewer.test.tsx"`

확인 포인트:
- 안전한 외부 이미지 URL이 에디터/readonly 뷰에서 정상 렌더링되는지
- unsafe/relative 이미지 source가 렌더링되지 않는지
- 블록 핸들 툴바의 삭제 버튼으로 현재 블록이 제거되는지

## 리뷰 요구사항 (선택)

- 이미지 URL을 외부 리소스로만 허용하도록 상대경로를 차단한 방향이 의도에 맞는지 확인 부탁드립니다.

## 체크리스트

- [x] 코드 컨벤션 준수
- [x] 커밋 메시지 컨벤션 준수
- [x] lint 통과
- [x] typecheck 통과
- [ ] (DB 변경 시) migration 파일 및 로컬 반영 확인
- [ ] (권한/RLS 영향 시) 정책 변경 요약 기재
- [ ] UI 변경 시 스크린샷/동작 설명 첨부
- [x] self-review 완료
