### PR TITLE
Feat/121 회원가입 약관 동의 인터랙션 제어 및 모달 기반 동의 흐름 구현

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,15 +1,19 @@
 import type { NextConfig } from "next";
 
+const supabaseHostname = process.env.NEXT_PUBLIC_SUPABASE_HOSTNAME;
+
 const nextConfig: NextConfig = {
   images: {
-    remotePatterns: [
-      {
-        protocol: "https",
-        hostname: "sbjvkwhqhzjbmwheqgid.supabase.co",
-        port: "",
-        pathname: "/storage/v1/object/public/**",
-      },
-    ],
+    remotePatterns: supabaseHostname
+      ? [
+          {
+            protocol: "https",
+            hostname: supabaseHostname,
+            port: "",
+            pathname: "/storage/v1/object/public/**",
+          },
+        ]
+      : [],
   },
 };
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,16 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "sbjvkwhqhzjbmwheqgid.supabase.co",
+        port: "",
+        pathname: "/storage/v1/object/public/**",
+      },
+    ],
+  },
 };
 
 export default nextConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@codemirror/state": "^6.6.0",
         "@codemirror/view": "^6.40.0",
         "@hookform/resolvers": "^5.2.2",
+        "@radix-ui/react-dialog": "^1.1.15",
         "@react-email/components": "^1.0.11",
         "@react-email/render": "^2.0.5",
         "@supabase/ssr": "^0.9.0",
@@ -2633,9 +2634,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2651,9 +2649,6 @@
       "integrity": "sha512-RwSHKMQ7InLy5GfkY2/n5PcFycKA08qI1VST78n09nN36nUPqCvGSMiLXlfUmzmpQpF6XeBYP2KRWHi0UW3uNg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2671,9 +2666,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2689,9 +2681,6 @@
       "integrity": "sha512-eAgl9NKQ84/sww0v81DQINl/vL2IBxD7sMybd0cWRw6wqgouVI53brVRBrggqBRP/NWeIAE1dm5cbKYoiMlqDQ==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@codemirror/state": "^6.6.0",
     "@codemirror/view": "^6.40.0",
     "@hookform/resolvers": "^5.2.2",
+    "@radix-ui/react-dialog": "^1.1.15",
     "@react-email/components": "^1.0.11",
     "@react-email/render": "^2.0.5",
     "@supabase/ssr": "^0.9.0",

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -13,13 +13,11 @@ const DialogOverlay = React.forwardRef<
   React.ElementRef<typeof Dialog.Overlay>,
   React.ComponentPropsWithoutRef<typeof Dialog.Overlay>
 >(({ className, ...props }, ref) => (
-  <DialogPortal>
-    <Dialog.Overlay
-      ref={ref}
-      className={cn("fixed inset-0 z-50 bg-black/50", className)}
-      {...props}
-    />
-  </DialogPortal>
+  <Dialog.Overlay
+    ref={ref}
+    className={cn("fixed inset-0 z-50 bg-black/50", className)}
+    {...props}
+  />
 ));
 DialogOverlay.displayName = Dialog.Overlay.displayName;
 
@@ -44,18 +42,40 @@ const DialogContent = React.forwardRef<
 ));
 DialogContent.displayName = Dialog.Content.displayName;
 
-function DialogHeader({ children }: { children: React.ReactNode }) {
-  return <div className="mb-4">{children}</div>;
-}
-
-function DialogTitle({ children }: { children: React.ReactNode }) {
+function DialogHeader({
+  children,
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) {
   return (
-    <Dialog.Title className="text-lg font-semibold">{children}</Dialog.Title>
+    <div className={cn("mb-4", className)} {...props}>
+      {children}
+    </div>
   );
 }
 
-function DialogFooter({ children }: { children: React.ReactNode }) {
-  return <div className="mt-6 flex justify-end gap-2">{children}</div>;
+function DialogTitle({
+  children,
+  className,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof Dialog.Title>) {
+  return (
+    <Dialog.Title className={cn("text-lg font-semibold", className)} {...props}>
+      {children}
+    </Dialog.Title>
+  );
+}
+
+function DialogFooter({
+  children,
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div className={cn("mt-6 flex justify-end gap-2", className)} {...props}>
+      {children}
+    </div>
+  );
 }
 
 export {

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,52 +1,71 @@
 "use client";
 
+import * as Dialog from "@radix-ui/react-dialog";
 import * as React from "react";
 
 import { cn } from "@/lib/utils/cn";
 
-export function Dialog({
-  open,
-  onOpenChange,
-  children,
-}: {
-  open?: boolean;
-  onOpenChange?: (open: boolean) => void;
-  children: React.ReactNode;
-}) {
-  if (!open) return null;
-  return (
-    <div
-      role="dialog"
-      aria-modal="true"
-      className="fixed inset-0 z-50 flex items-center justify-center"
+const DialogRoot = Dialog.Root;
+const DialogTrigger = Dialog.Trigger;
+const DialogClose = Dialog.Close;
+const DialogPortal = Dialog.Portal;
+const DialogOverlay = React.forwardRef<
+  React.ElementRef<typeof Dialog.Overlay>,
+  React.ComponentPropsWithoutRef<typeof Dialog.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPortal>
+    <Dialog.Overlay
+      ref={ref}
+      className={cn("fixed inset-0 z-50 bg-black/50", className)}
+      {...props}
+    />
+  </DialogPortal>
+));
+DialogOverlay.displayName = Dialog.Overlay.displayName;
+
+const DialogContent = React.forwardRef<
+  React.ElementRef<typeof Dialog.Content>,
+  React.ComponentPropsWithoutRef<typeof Dialog.Content>
+>(({ className, children, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <Dialog.Content
+      ref={ref}
+      className={cn(
+        "fixed left-1/2 top-1/2 z-50 w-[90vw] max-w-2xl -translate-x-1/2 -translate-y-1/2",
+        "rounded-lg bg-background p-6 shadow-lg",
+        className,
+      )}
+      {...props}
     >
-      <div
-        className="fixed inset-0 bg-black/50"
-        onClick={() => onOpenChange?.(false)}
-      />
-      <div className="relative z-50">{children}</div>
-    </div>
-  );
-}
-
-export function DialogContent({
-  className,
-  children,
-}: {
-  className?: string;
-  children: React.ReactNode;
-}) {
-  return (
-    <div className={cn("rounded-lg bg-background p-6 shadow-lg", className)}>
       {children}
-    </div>
-  );
-}
+    </Dialog.Content>
+  </DialogPortal>
+));
+DialogContent.displayName = Dialog.Content.displayName;
 
-export function DialogHeader({ children }: { children: React.ReactNode }) {
+function DialogHeader({ children }: { children: React.ReactNode }) {
   return <div className="mb-4">{children}</div>;
 }
 
-export function DialogTitle({ children }: { children: React.ReactNode }) {
-  return <h2 className="text-lg font-semibold">{children}</h2>;
+function DialogTitle({ children }: { children: React.ReactNode }) {
+  return (
+    <Dialog.Title className="text-lg font-semibold">{children}</Dialog.Title>
+  );
 }
+
+function DialogFooter({ children }: { children: React.ReactNode }) {
+  return <div className="mt-6 flex justify-end gap-2">{children}</div>;
+}
+
+export {
+  DialogRoot as Dialog,
+  DialogClose,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
+};

--- a/src/features/auth/signup/components/LegalDialogWrapper.tsx
+++ b/src/features/auth/signup/components/LegalDialogWrapper.tsx
@@ -66,7 +66,8 @@ export function LegalDialogWrapper({
 
   const handleAgree = () => {
     onAgree();
-    onOpenChange(false);
+    // "동의하기" 경로도 일반 닫기와 동일한 포커스 복원 규칙을 따르도록 통일
+    handleOpenChange(false);
   };
 
   return (

--- a/src/features/auth/signup/components/LegalDialogWrapper.tsx
+++ b/src/features/auth/signup/components/LegalDialogWrapper.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import * as RadixDialog from "@radix-ui/react-dialog";
+import * as React from "react";
+
+import type { LegalSection } from "@/components/legal/LegalContent";
+import { privacySections } from "@/components/legal/PrivacySections";
+import { termsSections } from "@/components/legal/TermsSections";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils/cn";
+
+type AgreementType = "termsOfService" | "privacyPolicy";
+
+type LegalDialogWrapperProps = {
+  agreementType: AgreementType;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onAgree: () => void;
+  triggerLabel: string;
+  dialogTitle: string;
+  checkboxRef?: React.RefObject<HTMLButtonElement | null>;
+  openedByLabel?: boolean;
+};
+
+/**
+ * LegalDialogWrapper: 법적 동의 모달 UI 컴포넌트
+ *
+ * 책임:
+ * - Radix Dialog 기반의 모달 UI 렌더링
+ * - 법적 콘텐츠(약관/개인정보) 렌더링
+ * - "Agree and continue" 버튼 → onAgree 콜백
+ * - focus restore fallback 처리 (Label 클릭 경유 시)
+ *
+ * 제외:
+ * - form state 관리 (SignupForm의 책임)
+ * - openedByLabel 상태 관리 (SignupForm에서 주입)
+ */
+export function LegalDialogWrapper({
+  agreementType,
+  open,
+  onOpenChange,
+  onAgree,
+  triggerLabel,
+  dialogTitle,
+  checkboxRef,
+  openedByLabel = false,
+}: LegalDialogWrapperProps) {
+  // 콘텐츠 섹션 선택
+  // 이유: agreementType에 따라 다른 법적 문서를 표시하기 위해 분기
+  const contentSections: LegalSection[] =
+    agreementType === "termsOfService" ? termsSections : privacySections;
+
+  // focus restore fallback 처리
+  // 이유: Radix Dialog 기본 복원은 Dialog.Trigger 기반
+  //       Label은 non-focusable이므로 포커스 손실 발생
+  //       → openedByLabel=true일 때 checkboxRef로 명시적 복원
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (!nextOpen && openedByLabel && checkboxRef?.current) {
+      // 비동기로 실행하여 Dialog 닫힘 애니메이션 완료 후 포커스 이동
+      requestAnimationFrame(() => {
+        checkboxRef.current?.focus();
+      });
+    }
+    onOpenChange(nextOpen);
+  };
+
+  const handleAgree = () => {
+    onAgree();
+    onOpenChange(false);
+  };
+
+  return (
+    <RadixDialog.Root open={open} onOpenChange={handleOpenChange} modal={true}>
+      <RadixDialog.Trigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="bg-blue-400 text-white"
+        >
+          {triggerLabel}
+        </Button>
+      </RadixDialog.Trigger>
+
+      <RadixDialog.Portal>
+        <RadixDialog.Overlay className="fixed inset-0 z-50 bg-black/50" />
+        <RadixDialog.Content
+          className="fixed left-1/2 top-1/2 z-50 w-[90vw] max-w-2xl -translate-x-1/2 -translate-y-1/2 rounded-lg bg-background p-6 shadow-lg max-h-[85vh] overflow-y-auto"
+          aria-describedby={`${agreementType}-description`}
+        >
+          <RadixDialog.Title className="text-lg font-semibold mb-4">
+            {dialogTitle}
+          </RadixDialog.Title>
+
+          {/* 스크린리더용 설명 텍스트 */}
+          <div id={`${agreementType}-description`} className="sr-only">
+            {dialogTitle} 전문을 확인하고 동의할 수 있습니다.
+          </div>
+
+          {/* 법적 콘텐츠 — 스크롤 가능한 영역 */}
+          <div className="overflow-y-auto mb-6">
+            <div className="prose dark:prose-invert max-w-none space-y-6">
+              {contentSections.map((section) => (
+                <div key={section.article}>
+                  <h3 className="text-base font-semibold">
+                    {section.article} {section.title}
+                  </h3>
+                  <div className="text-sm text-muted-foreground">
+                    {section.content}
+                  </div>
+                </div>
+              ))}
+            </div>
+
+            {/* 스크롤 힌트: 하단 gradient overlay */}
+            <div
+              className={cn(
+                "pointer-events-none absolute inset-x-0 bottom-0 h-16",
+                "bg-linear-to-t from-background to-transparent",
+              )}
+              aria-hidden="true"
+            />
+          </div>
+
+          {/* 푸터: 동작 버튼 */}
+          <div className="mt-6 flex justify-end gap-2">
+            <RadixDialog.Close asChild>
+              <Button type="button" variant="ghost">
+                닫기
+              </Button>
+            </RadixDialog.Close>
+            <Button
+              type="button"
+              onClick={handleAgree}
+              className="bg-blue-500 text-white hover:bg-blue-600"
+            >
+              Agree and continue
+            </Button>
+          </div>
+        </RadixDialog.Content>
+      </RadixDialog.Portal>
+    </RadixDialog.Root>
+  );
+}

--- a/src/features/auth/signup/components/LegalDialogWrapper.tsx
+++ b/src/features/auth/signup/components/LegalDialogWrapper.tsx
@@ -1,12 +1,18 @@
 "use client";
 
-import * as RadixDialog from "@radix-ui/react-dialog";
 import * as React from "react";
 
 import type { LegalSection } from "@/components/legal/LegalContent";
 import { privacySections } from "@/components/legal/PrivacySections";
 import { termsSections } from "@/components/legal/TermsSections";
 import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
 import { cn } from "@/lib/utils/cn";
 
 type AgreementType = "termsOfService" | "privacyPolicy";
@@ -71,8 +77,8 @@ export function LegalDialogWrapper({
   };
 
   return (
-    <RadixDialog.Root open={open} onOpenChange={handleOpenChange} modal={true}>
-      <RadixDialog.Trigger asChild>
+    <Dialog open={open} onOpenChange={handleOpenChange} modal={true}>
+      <DialogTrigger asChild>
         <Button
           type="button"
           variant="ghost"
@@ -81,67 +87,62 @@ export function LegalDialogWrapper({
         >
           {triggerLabel}
         </Button>
-      </RadixDialog.Trigger>
+      </DialogTrigger>
 
-      <RadixDialog.Portal>
-        <RadixDialog.Overlay className="fixed inset-0 z-50 bg-black/50" />
-        <RadixDialog.Content
-          className="fixed left-1/2 top-1/2 z-50 flex max-h-[85vh] w-[90vw] max-w-2xl -translate-x-1/2 -translate-y-1/2 flex-col overflow-hidden rounded-lg bg-background p-6 shadow-lg"
-          aria-describedby={`${agreementType}-description`}
-        >
-          <RadixDialog.Title className="text-lg font-semibold mb-4">
-            {dialogTitle}
-          </RadixDialog.Title>
+      <DialogContent
+        className="flex max-h-[85vh] flex-col overflow-hidden"
+        aria-describedby={`${agreementType}-description`}
+      >
+        <DialogTitle className="mb-4">{dialogTitle}</DialogTitle>
 
-          {/* 스크린리더용 설명 텍스트 */}
-          <div id={`${agreementType}-description`} className="sr-only">
-            {dialogTitle} 전문을 확인하고 동의할 수 있습니다.
-          </div>
+        {/* 스크린리더용 설명 텍스트 */}
+        <div id={`${agreementType}-description`} className="sr-only">
+          {dialogTitle} 전문을 확인하고 동의할 수 있습니다.
+        </div>
 
-          {/* 법적 콘텐츠 — 스크롤 가능한 영역 */}
-          <div className="relative mb-4 min-h-0 flex-1 overflow-y-auto">
-            <div className="prose dark:prose-invert max-w-none space-y-6">
-              {contentSections.map((section) => (
-                <div key={section.article}>
-                  <h3 className="text-base font-semibold">
-                    {section.article} {section.title}
-                  </h3>
-                  <div className="text-sm text-muted-foreground">
-                    {section.content}
-                  </div>
+        {/* 법적 콘텐츠 — 스크롤 가능한 영역 */}
+        <div className="relative mb-4 min-h-0 flex-1 overflow-y-auto">
+          <div className="prose dark:prose-invert max-w-none space-y-6">
+            {contentSections.map((section) => (
+              <div key={section.article}>
+                <h3 className="text-base font-semibold">
+                  {section.article} {section.title}
+                </h3>
+                <div className="text-sm text-muted-foreground">
+                  {section.content}
                 </div>
-              ))}
-            </div>
-
-            {/* 스크롤 힌트: 하단 gradient overlay */}
-            <div
-              className={cn(
-                "pointer-events-none absolute inset-x-0 bottom-0 h-16",
-                "bg-linear-to-t from-background to-transparent",
-              )}
-              aria-hidden="true"
-            />
+              </div>
+            ))}
           </div>
 
-          {/* 푸터: 동작 버튼 */}
-          <div className="sticky bottom-0 z-10 -mx-6 border-t bg-background px-6 pt-4">
-            <div className="flex justify-end gap-2">
-              <RadixDialog.Close asChild>
-                <Button type="button" variant="ghost">
-                  닫기
-                </Button>
-              </RadixDialog.Close>
-              <Button
-                type="button"
-                onClick={handleAgree}
-                className="bg-blue-500 text-white hover:bg-blue-600"
-              >
-                동의하기
+          {/* 스크롤 힌트: 하단 gradient overlay */}
+          <div
+            className={cn(
+              "pointer-events-none absolute inset-x-0 bottom-0 h-16",
+              "bg-linear-to-t from-background to-transparent",
+            )}
+            aria-hidden="true"
+          />
+        </div>
+
+        {/* 푸터: 동작 버튼 */}
+        <div className="sticky bottom-0 z-10 -mx-6 border-t bg-background px-6 pt-4">
+          <div className="flex justify-end gap-2">
+            <DialogClose asChild>
+              <Button type="button" variant="ghost">
+                닫기
               </Button>
-            </div>
+            </DialogClose>
+            <Button
+              type="button"
+              onClick={handleAgree}
+              className="bg-blue-500 text-white hover:bg-blue-600"
+            >
+              동의하기
+            </Button>
           </div>
-        </RadixDialog.Content>
-      </RadixDialog.Portal>
-    </RadixDialog.Root>
+        </div>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/src/features/auth/signup/components/LegalDialogWrapper.tsx
+++ b/src/features/auth/signup/components/LegalDialogWrapper.tsx
@@ -28,7 +28,7 @@ type LegalDialogWrapperProps = {
  * 책임:
  * - Radix Dialog 기반의 모달 UI 렌더링
  * - 법적 콘텐츠(약관/개인정보) 렌더링
- * - "Agree and continue" 버튼 → onAgree 콜백
+ * - "동의하기" 버튼 → onAgree 콜백
  * - focus restore fallback 처리 (Label 클릭 경유 시)
  *
  * 제외:
@@ -85,7 +85,7 @@ export function LegalDialogWrapper({
       <RadixDialog.Portal>
         <RadixDialog.Overlay className="fixed inset-0 z-50 bg-black/50" />
         <RadixDialog.Content
-          className="fixed left-1/2 top-1/2 z-50 w-[90vw] max-w-2xl -translate-x-1/2 -translate-y-1/2 rounded-lg bg-background p-6 shadow-lg max-h-[85vh] overflow-y-auto"
+          className="fixed left-1/2 top-1/2 z-50 flex max-h-[85vh] w-[90vw] max-w-2xl -translate-x-1/2 -translate-y-1/2 flex-col overflow-hidden rounded-lg bg-background p-6 shadow-lg"
           aria-describedby={`${agreementType}-description`}
         >
           <RadixDialog.Title className="text-lg font-semibold mb-4">
@@ -98,7 +98,7 @@ export function LegalDialogWrapper({
           </div>
 
           {/* 법적 콘텐츠 — 스크롤 가능한 영역 */}
-          <div className="overflow-y-auto mb-6">
+          <div className="relative mb-4 min-h-0 flex-1 overflow-y-auto">
             <div className="prose dark:prose-invert max-w-none space-y-6">
               {contentSections.map((section) => (
                 <div key={section.article}>
@@ -123,19 +123,21 @@ export function LegalDialogWrapper({
           </div>
 
           {/* 푸터: 동작 버튼 */}
-          <div className="mt-6 flex justify-end gap-2">
-            <RadixDialog.Close asChild>
-              <Button type="button" variant="ghost">
-                닫기
+          <div className="sticky bottom-0 z-10 -mx-6 border-t bg-background px-6 pt-4">
+            <div className="flex justify-end gap-2">
+              <RadixDialog.Close asChild>
+                <Button type="button" variant="ghost">
+                  닫기
+                </Button>
+              </RadixDialog.Close>
+              <Button
+                type="button"
+                onClick={handleAgree}
+                className="bg-blue-500 text-white hover:bg-blue-600"
+              >
+                동의하기
               </Button>
-            </RadixDialog.Close>
-            <Button
-              type="button"
-              onClick={handleAgree}
-              className="bg-blue-500 text-white hover:bg-blue-600"
-            >
-              Agree and continue
-            </Button>
+            </div>
           </div>
         </RadixDialog.Content>
       </RadixDialog.Portal>

--- a/src/features/auth/signup/components/SignupForm.tsx
+++ b/src/features/auth/signup/components/SignupForm.tsx
@@ -235,7 +235,7 @@ export function SignupForm({ onSubmit, isPending = false }: SignupFormProps) {
         await trigger("confirmPassword");
       }
     },
-    [onPasswordChange, trigger],
+    [getValues, onPasswordChange, trigger],
   );
 
   /**

--- a/src/features/auth/signup/components/SignupForm.tsx
+++ b/src/features/auth/signup/components/SignupForm.tsx
@@ -256,16 +256,24 @@ export function SignupForm({ onSubmit, isPending = false }: SignupFormProps) {
    */
   const handleTermsOpenChange = (open: boolean) => {
     setTermsModalOpen(open);
-    if (!open) setTermsInteractionEnabled(true);
+    if (!open) {
+      setTermsInteractionEnabled(true);
+      // Label 경유 플래그는 닫힘 시 리셋하여 다음 오픈에서 stale 상태를 방지
+      setTermsOpenedByLabel(false);
+    }
   };
 
   const handlePrivacyOpenChange = (open: boolean) => {
     setPrivacyModalOpen(open);
-    if (!open) setPrivacyInteractionEnabled(true);
+    if (!open) {
+      setPrivacyInteractionEnabled(true);
+      // Label 경유 플래그는 닫힘 시 리셋하여 다음 오픈에서 stale 상태를 방지
+      setPrivacyOpenedByLabel(false);
+    }
   };
 
   /**
-   * "Agree and continue" 클릭 시 체크박스 체크
+   * "동의하기" 클릭 시 체크박스 체크
    * 이유: onAgree에서 setValue("termsOfService", true)를 호출하기 때문
    */
   const handleTermsAgree = () => {
@@ -377,6 +385,10 @@ export function SignupForm({ onSubmit, isPending = false }: SignupFormProps) {
         data-testid="agreements-container"
         className="grid grid-cols-1 md:grid-cols-2 gap-4"
       >
+        <p className="md:col-span-2 text-sm text-muted-foreground">
+          약관 확인 후 체크해주세요
+        </p>
+
         {/* 이용약관 */}
         <div data-testid="terms-of-service-field" className="space-y-2">
           <div
@@ -472,7 +484,19 @@ export function SignupForm({ onSubmit, isPending = false }: SignupFormProps) {
             <p
               id="terms-of-service-error"
               role="alert"
-              className="text-red-500"
+              className="text-red-500 cursor-pointer"
+              onClick={() => {
+                setTermsOpenedByLabel(false);
+                setTermsModalOpen(true);
+              }}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  setTermsOpenedByLabel(false);
+                  setTermsModalOpen(true);
+                }
+              }}
+              tabIndex={0}
             >
               {errors.termsOfService.message}
             </p>
@@ -565,7 +589,23 @@ export function SignupForm({ onSubmit, isPending = false }: SignupFormProps) {
           </div>
 
           {errors.privacyPolicy && (
-            <p id="privacy-policy-error" role="alert" className="text-red-500">
+            <p
+              id="privacy-policy-error"
+              role="alert"
+              className="text-red-500 cursor-pointer"
+              onClick={() => {
+                setPrivacyOpenedByLabel(false);
+                setPrivacyModalOpen(true);
+              }}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  setPrivacyOpenedByLabel(false);
+                  setPrivacyModalOpen(true);
+                }
+              }}
+              tabIndex={0}
+            >
               {errors.privacyPolicy.message}
             </p>
           )}

--- a/src/features/auth/signup/components/SignupForm.tsx
+++ b/src/features/auth/signup/components/SignupForm.tsx
@@ -2,7 +2,7 @@
 
 import { zodResolver } from "@hookform/resolvers/zod";
 import Link from "next/link";
-import { useCallback } from "react";
+import { useCallback, useRef, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { z } from "zod";
 
@@ -20,6 +20,7 @@ import {
   RATE_LIMIT_TOAST_MESSAGE,
 } from "@/features/auth/errors/rateLimitError";
 import { resolveFieldName } from "@/features/auth/lib/resolveFieldName";
+import { LegalDialogWrapper } from "@/features/auth/signup/components/LegalDialogWrapper";
 import { signupFormSchema } from "@/features/auth/signup/schema/signupFormSchema";
 import { cn } from "@/lib/utils/cn";
 import { showToast } from "@/lib/utils/showToast";
@@ -91,6 +92,27 @@ export function SignupForm({ onSubmit, isPending = false }: SignupFormProps) {
       privacyPolicy: false,
     },
   });
+
+  /**
+   * UI 상호작용 상태 — RHF form field가 아니므로 useState로 관리
+   * interactionEnabled: 모달을 한번이라도 열고 닫아야 true로 전환
+   * 이유: HTML disabled 금지 스펙 — aria-disabled + 인터셉트 방식으로 대체
+   */
+  const [termsInteractionEnabled, setTermsInteractionEnabled] = useState(false);
+  const [privacyInteractionEnabled, setPrivacyInteractionEnabled] =
+    useState(false);
+  const [termsModalOpen, setTermsModalOpen] = useState(false);
+  const [privacyModalOpen, setPrivacyModalOpen] = useState(false);
+  const [termsOpenedByLabel, setTermsOpenedByLabel] = useState(false);
+  const [privacyOpenedByLabel, setPrivacyOpenedByLabel] = useState(false);
+
+  /**
+   * focus fallback 대상 refs
+   * Checkbox 컴포넌트가 forwardRef를 지원하므로
+   * checkboxRef.current.focus()로 포커스 복원 가능
+   */
+  const termsCheckboxRef = useRef<HTMLButtonElement>(null);
+  const privacyCheckboxRef = useRef<HTMLButtonElement>(null);
 
   /**
    * password / confirmPassword 분리
@@ -227,6 +249,33 @@ export function SignupForm({ onSubmit, isPending = false }: SignupFormProps) {
     [onConfirmChange, trigger],
   );
 
+  /**
+   * 모달이 닫힐 때에만 interactionEnabled 활성화
+   * 이유: 콘텐츠 열람 의도 확인 이후부터 직접 조작 허용 (스펙 명시)
+   * 향후: 스크롤 완료 후에만 활성화하는 정책으로 강화 가능 (scrollEnforced 플래그 추가 포인트)
+   */
+  const handleTermsOpenChange = (open: boolean) => {
+    setTermsModalOpen(open);
+    if (!open) setTermsInteractionEnabled(true);
+  };
+
+  const handlePrivacyOpenChange = (open: boolean) => {
+    setPrivacyModalOpen(open);
+    if (!open) setPrivacyInteractionEnabled(true);
+  };
+
+  /**
+   * "Agree and continue" 클릭 시 체크박스 체크
+   * 이유: onAgree에서 setValue("termsOfService", true)를 호출하기 때문
+   */
+  const handleTermsAgree = () => {
+    setValue("termsOfService", true, { shouldValidate: true });
+  };
+
+  const handlePrivacyAgree = () => {
+    setValue("privacyPolicy", true, { shouldValidate: true });
+  };
+
   return (
     <form
       aria-label="회원가입"
@@ -337,33 +386,77 @@ export function SignupForm({ onSubmit, isPending = false }: SignupFormProps) {
               !errors.termsOfService && "mb-8",
             )}
           >
-            <Button
-              type="button"
-              variant="ghost"
-              size="sm"
-              className="bg-blue-400 text-white"
-            >
-              이용약관 보기
-            </Button>
+            <LegalDialogWrapper
+              agreementType="termsOfService"
+              open={termsModalOpen}
+              onOpenChange={handleTermsOpenChange}
+              onAgree={handleTermsAgree}
+              triggerLabel="이용약관 보기"
+              dialogTitle="이용약관"
+              checkboxRef={termsCheckboxRef}
+              openedByLabel={termsOpenedByLabel}
+            />
 
             <div
               data-testid="tos-text-checkbox-group"
               className="flex items-center gap-2"
             >
-              <Label htmlFor="termsOfService">이용약관에 동의합니다</Label>
+              <Label
+                htmlFor="termsOfService"
+                onClick={(e) => {
+                  if (!termsInteractionEnabled) {
+                    // htmlFor 연결로 인한 체크박스 자동 토글을 차단하고 모달 열기
+                    // 이유: Label 클릭이 체크박스 토글을 유발하지 않도록 인터셉트
+                    e.preventDefault();
+                    setTermsOpenedByLabel(true);
+                    setTermsModalOpen(true);
+                  }
+                }}
+              >
+                이용약관에 동의합니다
+              </Label>
 
               <Controller
                 name="termsOfService"
                 control={control}
                 render={({ field }) => (
                   <Checkbox
+                    ref={termsCheckboxRef}
                     id="termsOfService"
+                    data-testid="terms-of-service-checkbox"
                     name={field.name}
                     checked={field.value}
                     onCheckedChange={(checked) => {
+                      // interactionEnabled=false이면 체크 변경을 막고 모달 열기
+                      // 이유: HTML disabled 금지 스펙 준수 — 인터셉트로 동일 효과 구현
+                      if (!termsInteractionEnabled) {
+                        setTermsOpenedByLabel(false);
+                        setTermsModalOpen(true);
+                        return;
+                      }
                       field.onChange(checked === true);
                     }}
+                    onKeyDown={(e) => {
+                      // Space/Enter 키보드 입력도 마우스 클릭과 동일하게 인터셉트
+                      // 이유: 키보드로 aria-disabled 우회를 방지하고 접근성 일관성 보장
+                      if (
+                        !termsInteractionEnabled &&
+                        (e.key === " " || e.key === "Enter")
+                      ) {
+                        e.preventDefault();
+                        setTermsOpenedByLabel(false);
+                        setTermsModalOpen(true);
+                      }
+                    }}
                     onBlur={field.onBlur}
+                    aria-disabled={
+                      !termsInteractionEnabled ? "true" : undefined
+                    }
+                    aria-label={
+                      !termsInteractionEnabled
+                        ? "Agreement must be reviewed before checking"
+                        : undefined
+                    }
                     aria-describedby={
                       errors.termsOfService
                         ? "terms-of-service-error"
@@ -394,17 +487,30 @@ export function SignupForm({ onSubmit, isPending = false }: SignupFormProps) {
               !errors.privacyPolicy && "mb-8",
             )}
           >
-            <Button
-              type="button"
-              variant="ghost"
-              size="sm"
-              className="bg-blue-400 text-white"
-            >
-              개인정보처리방침 보기
-            </Button>
+            <LegalDialogWrapper
+              agreementType="privacyPolicy"
+              open={privacyModalOpen}
+              onOpenChange={handlePrivacyOpenChange}
+              onAgree={handlePrivacyAgree}
+              triggerLabel="개인정보처리방침 보기"
+              dialogTitle="개인정보처리방침"
+              checkboxRef={privacyCheckboxRef}
+              openedByLabel={privacyOpenedByLabel}
+            />
 
             <div className="flex items-center gap-2">
-              <Label htmlFor="privacyPolicy">
+              <Label
+                htmlFor="privacyPolicy"
+                onClick={(e) => {
+                  if (!privacyInteractionEnabled) {
+                    // htmlFor 연결로 인한 체크박스 자동 토글을 차단하고 모달 열기
+                    // 이유: Label 클릭이 체크박스 토글을 유발하지 않도록 인터셉트
+                    e.preventDefault();
+                    setPrivacyOpenedByLabel(true);
+                    setPrivacyModalOpen(true);
+                  }
+                }}
+              >
                 개인정보 처리방침에 동의합니다
               </Label>
 
@@ -413,13 +519,42 @@ export function SignupForm({ onSubmit, isPending = false }: SignupFormProps) {
                 control={control}
                 render={({ field }) => (
                   <Checkbox
+                    ref={privacyCheckboxRef}
                     id="privacyPolicy"
+                    data-testid="privacy-policy-checkbox"
                     name={field.name}
                     checked={field.value}
                     onCheckedChange={(checked) => {
+                      // interactionEnabled=false이면 체크 변경을 막고 모달 열기
+                      // 이유: HTML disabled 금지 스펙 준수 — 인터셉트로 동일 효과 구현
+                      if (!privacyInteractionEnabled) {
+                        setPrivacyOpenedByLabel(false);
+                        setPrivacyModalOpen(true);
+                        return;
+                      }
                       field.onChange(checked === true);
                     }}
+                    onKeyDown={(e) => {
+                      // Space/Enter 키보드 입력도 마우스 클릭과 동일하게 인터셉트
+                      // 이유: 키보드로 aria-disabled 우회를 방지하고 접근성 일관성 보장
+                      if (
+                        !privacyInteractionEnabled &&
+                        (e.key === " " || e.key === "Enter")
+                      ) {
+                        e.preventDefault();
+                        setPrivacyOpenedByLabel(false);
+                        setPrivacyModalOpen(true);
+                      }
+                    }}
                     onBlur={field.onBlur}
+                    aria-disabled={
+                      !privacyInteractionEnabled ? "true" : undefined
+                    }
+                    aria-label={
+                      !privacyInteractionEnabled
+                        ? "Agreement must be reviewed before checking"
+                        : undefined
+                    }
                     aria-describedby={
                       errors.privacyPolicy ? "privacy-policy-error" : undefined
                     }

--- a/src/features/auth/signup/components/SignupForm.tsx
+++ b/src/features/auth/signup/components/SignupForm.tsx
@@ -466,7 +466,7 @@ export function SignupForm({ onSubmit, isPending = false }: SignupFormProps) {
                     }
                     aria-label={
                       !termsInteractionEnabled
-                        ? "Agreement must be reviewed before checking"
+                        ? "약관을 먼저 확인해야 체크할 수 있습니다"
                         : undefined
                     }
                     aria-describedby={
@@ -484,19 +484,7 @@ export function SignupForm({ onSubmit, isPending = false }: SignupFormProps) {
             <p
               id="terms-of-service-error"
               role="alert"
-              className="text-red-500 cursor-pointer"
-              onClick={() => {
-                setTermsOpenedByLabel(false);
-                setTermsModalOpen(true);
-              }}
-              onKeyDown={(e) => {
-                if (e.key === "Enter" || e.key === " ") {
-                  e.preventDefault();
-                  setTermsOpenedByLabel(false);
-                  setTermsModalOpen(true);
-                }
-              }}
-              tabIndex={0}
+              className="text-red-500"
             >
               {errors.termsOfService.message}
             </p>
@@ -576,7 +564,7 @@ export function SignupForm({ onSubmit, isPending = false }: SignupFormProps) {
                     }
                     aria-label={
                       !privacyInteractionEnabled
-                        ? "Agreement must be reviewed before checking"
+                        ? "약관을 먼저 확인해야 체크할 수 있습니다"
                         : undefined
                     }
                     aria-describedby={
@@ -589,23 +577,7 @@ export function SignupForm({ onSubmit, isPending = false }: SignupFormProps) {
           </div>
 
           {errors.privacyPolicy && (
-            <p
-              id="privacy-policy-error"
-              role="alert"
-              className="text-red-500 cursor-pointer"
-              onClick={() => {
-                setPrivacyOpenedByLabel(false);
-                setPrivacyModalOpen(true);
-              }}
-              onKeyDown={(e) => {
-                if (e.key === "Enter" || e.key === " ") {
-                  e.preventDefault();
-                  setPrivacyOpenedByLabel(false);
-                  setPrivacyModalOpen(true);
-                }
-              }}
-              tabIndex={0}
-            >
+            <p id="privacy-policy-error" role="alert" className="text-red-500">
               {errors.privacyPolicy.message}
             </p>
           )}

--- a/src/features/auth/signup/components/SignupPageClient.test.tsx
+++ b/src/features/auth/signup/components/SignupPageClient.test.tsx
@@ -28,7 +28,7 @@ async function submitValidSignupForm(user: ReturnType<typeof userEvent.setup>) {
   await user.click(screen.getByRole("button", { name: /이용약관 보기/i }));
   const termsDialog = await screen.findByRole("dialog");
   await user.click(
-    within(termsDialog).getByRole("button", { name: /Agree and continue/i }),
+    within(termsDialog).getByRole("button", { name: /동의하기/i }),
   );
   // 즉시 언마운트/애니메이션 지연 모두 허용
   await waitFor(() => {
@@ -40,7 +40,7 @@ async function submitValidSignupForm(user: ReturnType<typeof userEvent.setup>) {
   );
   const privacyDialog = await screen.findByRole("dialog");
   await user.click(
-    within(privacyDialog).getByRole("button", { name: /Agree and continue/i }),
+    within(privacyDialog).getByRole("button", { name: /동의하기/i }),
   );
   // 즉시 언마운트/애니메이션 지연 모두 허용
   await waitFor(() => {
@@ -216,7 +216,7 @@ describe("PR-UI-13: SignupPageClient submit → mutateAsync → redirectTo 연�
     await user.click(screen.getByRole("button", { name: /이용약관 보기/i }));
     const termsDialog = await screen.findByRole("dialog");
     await user.click(
-      within(termsDialog).getByRole("button", { name: /Agree and continue/i }),
+      within(termsDialog).getByRole("button", { name: /동의하기/i }),
     );
     // 즉시 언마운트/애니메이션 지연 모두 허용
     await waitFor(() => {
@@ -229,7 +229,7 @@ describe("PR-UI-13: SignupPageClient submit → mutateAsync → redirectTo 연�
     const privacyDialog = await screen.findByRole("dialog");
     await user.click(
       within(privacyDialog).getByRole("button", {
-        name: /Agree and continue/i,
+        name: /동의하기/i,
       }),
     );
     // 즉시 언마운트/애니메이션 지연 모두 허용

--- a/src/features/auth/signup/components/SignupPageClient.test.tsx
+++ b/src/features/auth/signup/components/SignupPageClient.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -23,8 +23,30 @@ async function submitValidSignupForm(user: ReturnType<typeof userEvent.setup>) {
   await user.type(screen.getByLabelText(/^비밀번호$/i), "password123");
   await user.type(screen.getByLabelText(/비밀번호 확인/i), "password123");
   await user.type(screen.getByLabelText(/닉네임/i), "tester");
-  await user.click(screen.getByRole("checkbox", { name: /이용약관/i }));
-  await user.click(screen.getByRole("checkbox", { name: /개인정보/i }));
+  // interactionEnabled=false 상태에서 체크박스 클릭이 모달을 열므로 모달 경유
+  // 이유: agreement-interaction-control-spec에서 모달-먼저 상호작용 강제
+  await user.click(screen.getByRole("button", { name: /이용약관 보기/i }));
+  const termsDialog = await screen.findByRole("dialog");
+  await user.click(
+    within(termsDialog).getByRole("button", { name: /Agree and continue/i }),
+  );
+  // 즉시 언마운트/애니메이션 지연 모두 허용
+  await waitFor(() => {
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  await user.click(
+    screen.getByRole("button", { name: /개인정보처리방침 보기/i }),
+  );
+  const privacyDialog = await screen.findByRole("dialog");
+  await user.click(
+    within(privacyDialog).getByRole("button", { name: /Agree and continue/i }),
+  );
+  // 즉시 언마운트/애니메이션 지연 모두 허용
+  await waitFor(() => {
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
   await user.click(screen.getByRole("button", { name: /회원가입/i }));
 }
 
@@ -189,8 +211,32 @@ describe("PR-UI-13: SignupPageClient submit → mutateAsync → redirectTo 연�
     await user.type(screen.getByLabelText(/비밀번호 확인/i), "password123");
     await user.type(screen.getByLabelText(/닉네임/i), "tester");
     await user.upload(screen.getByLabelText(/프로필 사진/i), avatarFile);
-    await user.click(screen.getByRole("checkbox", { name: /이용약관/i }));
-    await user.click(screen.getByRole("checkbox", { name: /개인정보/i }));
+    // interactionEnabled=false 상태에서 체크박스 클릭이 모달을 열므로 모달 경유
+    // 이유: agreement-interaction-control-spec에서 모달-먼저 상호작용 강제
+    await user.click(screen.getByRole("button", { name: /이용약관 보기/i }));
+    const termsDialog = await screen.findByRole("dialog");
+    await user.click(
+      within(termsDialog).getByRole("button", { name: /Agree and continue/i }),
+    );
+    // 즉시 언마운트/애니메이션 지연 모두 허용
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+
+    await user.click(
+      screen.getByRole("button", { name: /개인정보처리방침 보기/i }),
+    );
+    const privacyDialog = await screen.findByRole("dialog");
+    await user.click(
+      within(privacyDialog).getByRole("button", {
+        name: /Agree and continue/i,
+      }),
+    );
+    // 즉시 언마운트/애니메이션 지연 모두 허용
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+
     await user.click(screen.getByRole("button", { name: /회원가입/i }));
 
     await waitFor(() => {

--- a/src/features/auth/signup/components/tests/LegalDialogWrapper.test.tsx
+++ b/src/features/auth/signup/components/tests/LegalDialogWrapper.test.tsx
@@ -291,4 +291,44 @@ describe("LegalDialogWrapper", () => {
       expect(mockCheckboxFocus).toHaveBeenCalled();
     });
   });
+
+  it('TC-13: openedByLabel=true에서 "동의하기"로 닫아도 Checkbox focus fallback이 동작한다', async () => {
+    const user = userEvent.setup();
+    const { rerender } = render(
+      <LegalDialogWrapper
+        agreementType="termsOfService"
+        open={true}
+        onOpenChange={mockOnOpenChange}
+        onAgree={mockOnAgree}
+        triggerLabel="이용약관 보기"
+        dialogTitle="이용약관"
+        checkboxRef={mockCheckboxRef}
+        openedByLabel={true}
+      />,
+    );
+
+    mockOnOpenChange.mockClear();
+    mockCheckboxFocus.mockClear();
+
+    await user.click(screen.getByRole("button", { name: /동의하기/i }));
+
+    rerender(
+      <LegalDialogWrapper
+        agreementType="termsOfService"
+        open={false}
+        onOpenChange={mockOnOpenChange}
+        onAgree={mockOnAgree}
+        triggerLabel="이용약관 보기"
+        dialogTitle="이용약관"
+        checkboxRef={mockCheckboxRef}
+        openedByLabel={true}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(mockOnAgree).toHaveBeenCalled();
+      expect(mockOnOpenChange).toHaveBeenCalledWith(false);
+      expect(mockCheckboxFocus).toHaveBeenCalled();
+    });
+  });
 });

--- a/src/features/auth/signup/components/tests/LegalDialogWrapper.test.tsx
+++ b/src/features/auth/signup/components/tests/LegalDialogWrapper.test.tsx
@@ -1,0 +1,298 @@
+import { screen, waitFor } from "@testing-library/react";
+import { render } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { RefObject } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { LegalDialogWrapper } from "../LegalDialogWrapper";
+
+vi.mock("@tanstack/react-query", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@tanstack/react-query")>();
+  return { ...actual };
+});
+
+// LegalDialogWrapper 테스트
+// - Radix Dialog 기반의 모달 동작
+// - 콘텐츠 렌더링 (약관/개인정보 구분)
+// - 콜백 호출
+// - focus restore fallback 동작
+// - 접근성 (Esc 키, 오버레이 클릭, focus trap)
+
+describe("LegalDialogWrapper", () => {
+  const mockOnOpenChange = vi.fn();
+  const mockOnAgree = vi.fn();
+  const checkboxElement = document.createElement("button");
+  const mockCheckboxFocus = vi.fn();
+  checkboxElement.focus = mockCheckboxFocus;
+  const mockCheckboxRef = {
+    current: checkboxElement,
+  } as RefObject<HTMLButtonElement | null>;
+
+  beforeEach(() => {
+    mockOnOpenChange.mockClear();
+    mockOnAgree.mockClear();
+    mockCheckboxFocus.mockClear();
+  });
+
+  it("TC-01: 트리거 버튼이 triggerLabel 텍스트로 렌더링된다", () => {
+    render(
+      <LegalDialogWrapper
+        agreementType="termsOfService"
+        open={false}
+        onOpenChange={mockOnOpenChange}
+        onAgree={mockOnAgree}
+        triggerLabel="이용약관 보기"
+        dialogTitle="이용약관"
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: /이용약관 보기/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("TC-02: 트리거 버튼 클릭 시 모달이 열린다", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <LegalDialogWrapper
+        agreementType="termsOfService"
+        open={false}
+        onOpenChange={mockOnOpenChange}
+        onAgree={mockOnAgree}
+        triggerLabel="이용약관 보기"
+        dialogTitle="이용약관"
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /이용약관 보기/i }));
+
+    expect(mockOnOpenChange).toHaveBeenCalledWith(true);
+  });
+
+  it("TC-03: 모달 열리면 dialogTitle이 표시된다", () => {
+    render(
+      <LegalDialogWrapper
+        agreementType="termsOfService"
+        open={true}
+        onOpenChange={mockOnOpenChange}
+        onAgree={mockOnAgree}
+        triggerLabel="이용약관 보기"
+        dialogTitle="이용약관"
+      />,
+    );
+
+    expect(screen.getByText("이용약관")).toBeInTheDocument();
+  });
+
+  it("TC-04: agreementType=termsOfService → 이용약관 콘텐츠 렌더링", () => {
+    render(
+      <LegalDialogWrapper
+        agreementType="termsOfService"
+        open={true}
+        onOpenChange={mockOnOpenChange}
+        onAgree={mockOnAgree}
+        triggerLabel="이용약관 보기"
+        dialogTitle="이용약관"
+      />,
+    );
+
+    // 이용약관 섹션이 렌더링되는지 확인 (첫 번째 섹션의 content 확인)
+    expect(screen.getByText(/이 약관은 딱다구리/)).toBeInTheDocument();
+  });
+
+  it("TC-05: agreementType=privacyPolicy → 개인정보 콘텐츠 렌더링", () => {
+    render(
+      <LegalDialogWrapper
+        agreementType="privacyPolicy"
+        open={true}
+        onOpenChange={mockOnOpenChange}
+        onAgree={mockOnAgree}
+        triggerLabel="개인정보처리방침 보기"
+        dialogTitle="개인정보처리방침"
+      />,
+    );
+
+    // 개인정보 섹션이 렌더링되는지 확인 (첫 번째 섹션의 title 확인)
+    expect(screen.getByText(/개인정보의 처리 목적/i)).toBeInTheDocument();
+  });
+
+  it('TC-06: "Agree and continue" 클릭 시 onAgree 콜백이 호출된다', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <LegalDialogWrapper
+        agreementType="termsOfService"
+        open={true}
+        onOpenChange={mockOnOpenChange}
+        onAgree={mockOnAgree}
+        triggerLabel="이용약관 보기"
+        dialogTitle="이용약관"
+      />,
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: /Agree and continue/i }),
+    );
+
+    expect(mockOnAgree).toHaveBeenCalled();
+  });
+
+  it('TC-07: "Agree and continue" 클릭 시 모달이 닫힌다', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <LegalDialogWrapper
+        agreementType="termsOfService"
+        open={true}
+        onOpenChange={mockOnOpenChange}
+        onAgree={mockOnAgree}
+        triggerLabel="이용약관 보기"
+        dialogTitle="이용약관"
+      />,
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: /Agree and continue/i }),
+    );
+
+    expect(mockOnOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("TC-08: 닫기 버튼 클릭 시 모달이 닫힌다 (onAgree 미호출)", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <LegalDialogWrapper
+        agreementType="termsOfService"
+        open={true}
+        onOpenChange={mockOnOpenChange}
+        onAgree={mockOnAgree}
+        triggerLabel="이용약관 보기"
+        dialogTitle="이용약관"
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /닫기/i }));
+
+    expect(mockOnOpenChange).toHaveBeenCalledWith(false);
+    expect(mockOnAgree).not.toHaveBeenCalled();
+  });
+
+  it("TC-09: Esc 키 누를 시 모달이 닫힌다", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <LegalDialogWrapper
+        agreementType="termsOfService"
+        open={true}
+        onOpenChange={mockOnOpenChange}
+        onAgree={mockOnAgree}
+        triggerLabel="이용약관 보기"
+        dialogTitle="이용약관"
+      />,
+    );
+
+    // Radix Dialog는 Esc 키를 자동으로 처리합니다
+    await user.keyboard("{Escape}");
+
+    expect(mockOnOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("TC-10: 오버레이 클릭 시 모달이 닫힌다", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <LegalDialogWrapper
+        agreementType="termsOfService"
+        open={true}
+        onOpenChange={mockOnOpenChange}
+        onAgree={mockOnAgree}
+        triggerLabel="이용약관 보기"
+        dialogTitle="이용약관"
+      />,
+    );
+
+    // 오버레이는 dialog의 이전 형제 노드로 렌더링된다.
+    const dialog = screen.getByRole("dialog");
+    const overlay = dialog.previousElementSibling as HTMLElement | null;
+    expect(overlay).not.toBeNull();
+    await user.click(overlay!);
+    expect(mockOnOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("TC-11: 모달 닫힌 후 트리거 버튼으로 포커스가 복원된다", async () => {
+    const user = userEvent.setup();
+    const { rerender } = render(
+      <LegalDialogWrapper
+        agreementType="termsOfService"
+        open={true}
+        onOpenChange={mockOnOpenChange}
+        onAgree={mockOnAgree}
+        triggerLabel="이용약관 보기"
+        dialogTitle="이용약관"
+      />,
+    );
+
+    // 모달을 닫기 위해 Esc 키 누르기
+    await user.keyboard("{Escape}");
+
+    // 모달을 닫은 상태로 리렌더링
+    rerender(
+      <LegalDialogWrapper
+        agreementType="termsOfService"
+        open={false}
+        onOpenChange={mockOnOpenChange}
+        onAgree={mockOnAgree}
+        triggerLabel="이용약관 보기"
+        dialogTitle="이용약관"
+      />,
+    );
+
+    // Radix Dialog는 자동으로 트리거로 포커스를 복원합니다
+    // 이는 Dialog.Trigger의 기본 동작입니다
+    expect(
+      screen.getByRole("button", { name: /이용약관 보기/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("TC-12: checkboxRef가 제공된 경우, openedByLabel=true일 때 모달 닫기 시 Checkbox로 focus fallback 동작", async () => {
+    const user = userEvent.setup();
+    const { rerender } = render(
+      <LegalDialogWrapper
+        agreementType="termsOfService"
+        open={true}
+        onOpenChange={mockOnOpenChange}
+        onAgree={mockOnAgree}
+        triggerLabel="이용약관 보기"
+        dialogTitle="이용약관"
+        checkboxRef={mockCheckboxRef}
+        openedByLabel={true}
+      />,
+    );
+
+    // 모달을 닫기 위해 닫기 버튼 클릭
+    mockOnOpenChange.mockClear();
+    const closeButton = screen.getByRole("button", { name: /닫기/i });
+    await user.click(closeButton);
+
+    // 모달을 닫은 상태로 리렌더링
+    rerender(
+      <LegalDialogWrapper
+        agreementType="termsOfService"
+        open={false}
+        onOpenChange={mockOnOpenChange}
+        onAgree={mockOnAgree}
+        triggerLabel="이용약관 보기"
+        dialogTitle="이용약관"
+        checkboxRef={mockCheckboxRef}
+        openedByLabel={true}
+      />,
+    );
+
+    // requestAnimationFrame 콜백이 비동기로 실행되므로 waitFor로 대기
+    await waitFor(() => {
+      expect(mockCheckboxFocus).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/features/auth/signup/components/tests/LegalDialogWrapper.test.tsx
+++ b/src/features/auth/signup/components/tests/LegalDialogWrapper.test.tsx
@@ -117,7 +117,7 @@ describe("LegalDialogWrapper", () => {
     expect(screen.getByText(/개인정보의 처리 목적/i)).toBeInTheDocument();
   });
 
-  it('TC-06: "Agree and continue" 클릭 시 onAgree 콜백이 호출된다', async () => {
+  it('TC-06: "동의하기" 클릭 시 onAgree 콜백이 호출된다', async () => {
     const user = userEvent.setup();
 
     render(
@@ -131,14 +131,12 @@ describe("LegalDialogWrapper", () => {
       />,
     );
 
-    await user.click(
-      screen.getByRole("button", { name: /Agree and continue/i }),
-    );
+    await user.click(screen.getByRole("button", { name: /동의하기/i }));
 
     expect(mockOnAgree).toHaveBeenCalled();
   });
 
-  it('TC-07: "Agree and continue" 클릭 시 모달이 닫힌다', async () => {
+  it('TC-07: "동의하기" 클릭 시 모달이 닫힌다', async () => {
     const user = userEvent.setup();
 
     render(
@@ -152,9 +150,7 @@ describe("LegalDialogWrapper", () => {
       />,
     );
 
-    await user.click(
-      screen.getByRole("button", { name: /Agree and continue/i }),
-    );
+    await user.click(screen.getByRole("button", { name: /동의하기/i }));
 
     expect(mockOnOpenChange).toHaveBeenCalledWith(false);
   });

--- a/src/features/auth/signup/components/tests/SignupForm.agreement-interaction-validation.test.tsx
+++ b/src/features/auth/signup/components/tests/SignupForm.agreement-interaction-validation.test.tsx
@@ -1,0 +1,173 @@
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { renderSignupForm } from "./utils/signupFormTestUtils";
+
+vi.mock("@tanstack/react-query", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@tanstack/react-query")>();
+  return { ...actual };
+});
+
+// SignupForm 동의 상호작용 + Validation 테스트
+// - interactionEnabled 상태가 validation과 어떻게 상호작용하는지 검증
+// - 모달 미열람 vs 열람 상태에서의 validation 차이 확인
+
+describe("회원가입 폼 동의 상호작용 + Validation", () => {
+  it("TC-01: 모달 미열람 상태에서 폼 제출 시 약관 에러가 표시된다", async () => {
+    const user = userEvent.setup();
+    const { onSubmit } = renderSignupForm();
+
+    // 필수 필드들을 채우되, 약관은 체크하지 않기
+    await user.type(screen.getByLabelText(/이메일/i), "test@example.com");
+    await user.type(screen.getByLabelText(/^비밀번호$/i), "Test@1234");
+    await user.type(screen.getByLabelText(/비밀번호 확인/i), "Test@1234");
+    await user.type(screen.getByLabelText(/닉네임/i), "testuser");
+
+    // 약관 미체크 → 제출
+    await user.click(screen.getByRole("button", { name: /회원가입/i }));
+
+    // 이용약관 에러 확인
+    // 이유: 모달을 열지 않았으므로 체크박스가 체크되지 않음
+    //       → validation 실패로 에러 표시
+    await waitFor(() => {
+      expect(screen.getByText("이용약관에 동의해주세요")).toBeInTheDocument();
+    });
+
+    // onSubmit은 호출되지 않아야 함 (validation 실패)
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("TC-02: 모달을 열고 닫기만 해도(미동의) 폼 제출 시 약관 에러가 표시된다", async () => {
+    const user = userEvent.setup();
+    const { onSubmit } = renderSignupForm();
+
+    // 필수 필드 채우기
+    await user.type(screen.getByLabelText(/이메일/i), "test@example.com");
+    await user.type(screen.getByLabelText(/^비밀번호$/i), "Test@1234");
+    await user.type(screen.getByLabelText(/비밀번호 확인/i), "Test@1234");
+    await user.type(screen.getByLabelText(/닉네임/i), "testuser");
+
+    // 이용약관 모달을 열고 닫기만 하기 (동의 없이)
+    // 이유: interactionEnabled=true가 되더라도 checked=false인 경우
+    //       validation이 실패해야 함
+    const termsCheckbox = screen.getByTestId("terms-of-service-checkbox");
+    await user.click(termsCheckbox);
+    await user.click(screen.getByRole("button", { name: /닫기/i }));
+
+    // 이제 termsCheckbox는 체크되지 않은 상태
+    // (모달을 열기만 했고 "Agree and continue"를 누르지 않음)
+    await waitFor(() => {
+      expect(termsCheckbox).not.toBeChecked();
+    });
+
+    // 폼 제출
+    await user.click(screen.getByRole("button", { name: /회원가입/i }));
+
+    // 여전히 약관 에러 표시 (validation 실패)
+    await waitFor(() => {
+      expect(screen.getByText("이용약관에 동의해주세요")).toBeInTheDocument();
+    });
+
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('TC-03: "Agree and continue" 후 폼 제출 시 약관 에러가 표시되지 않는다', async () => {
+    const user = userEvent.setup();
+    const { onSubmit } = renderSignupForm();
+
+    // 필수 필드 채우기
+    await user.type(screen.getByLabelText(/이메일/i), "test@example.com");
+    await user.type(screen.getByLabelText(/^비밀번호$/i), "Test@1234");
+    await user.type(screen.getByLabelText(/비밀번호 확인/i), "Test@1234");
+    await user.type(screen.getByLabelText(/닉네임/i), "testuser");
+
+    // 이용약관 모달 열기 → "Agree and continue" 클릭
+    // 이유: onAgree에서 setValue("termsOfService", true)를 호출하므로
+    //       체크박스가 checked=true가 됨
+    const termsCheckbox = screen.getByTestId("terms-of-service-checkbox");
+    await user.click(termsCheckbox);
+    await user.click(
+      screen.getByRole("button", { name: /Agree and continue/i }),
+    );
+
+    // 개인정보도 동의하기
+    const privacyCheckbox = screen.getByTestId("privacy-policy-checkbox");
+    await user.click(privacyCheckbox);
+    await user.click(
+      screen.getByRole("button", { name: /Agree and continue/i }),
+    );
+
+    // 두 체크박스 모두 체크된 상태 확인
+    await waitFor(() => {
+      expect(termsCheckbox).toBeChecked();
+      expect(privacyCheckbox).toBeChecked();
+    });
+
+    // 폼 제출
+    await user.click(screen.getByRole("button", { name: /회원가입/i }));
+
+    // 약관 에러 없음 (validation 통과)
+    // 이유: 두 동의 항목이 모두 checked=true 상태
+    await waitFor(() => {
+      expect(
+        screen.queryByText("이용약관에 동의해주세요"),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByText("개인정보 처리방침에 동의해주세요"),
+      ).not.toBeInTheDocument();
+    });
+
+    // onSubmit이 호출되어야 함 (validation 통과)
+    // 실제로는 API 호출이 이루어지므로 mock이 호출되는지 확인
+    expect(onSubmit).toHaveBeenCalled();
+  });
+
+  it("TC-04: 동의 후 언체크하면 다시 약관 에러가 표시된다", async () => {
+    const user = userEvent.setup();
+    const { onSubmit } = renderSignupForm();
+
+    // 필수 필드 채우기
+    await user.type(screen.getByLabelText(/이메일/i), "test@example.com");
+    await user.type(screen.getByLabelText(/^비밀번호$/i), "Test@1234");
+    await user.type(screen.getByLabelText(/비밀번호 확인/i), "Test@1234");
+    await user.type(screen.getByLabelText(/닉네임/i), "testuser");
+
+    // 이용약관 모달 열고 동의하기
+    const termsCheckbox = screen.getByTestId("terms-of-service-checkbox");
+    await user.click(termsCheckbox);
+    await user.click(
+      screen.getByRole("button", { name: /Agree and continue/i }),
+    );
+
+    // 체크 상태 확인
+    await waitFor(() => {
+      expect(termsCheckbox).toBeChecked();
+    });
+
+    // 다시 클릭해서 언체크하기
+    // 이유: interactionEnabled=true 상태에서 직접 조작 가능
+    await user.click(termsCheckbox);
+
+    await waitFor(() => {
+      expect(termsCheckbox).not.toBeChecked();
+    });
+
+    // 개인정보는 동의하기
+    const privacyCheckbox = screen.getByTestId("privacy-policy-checkbox");
+    await user.click(privacyCheckbox);
+    await user.click(
+      screen.getByRole("button", { name: /Agree and continue/i }),
+    );
+
+    // 폼 제출
+    await user.click(screen.getByRole("button", { name: /회원가입/i }));
+
+    // 이용약관 에러 표시 (validation 실패)
+    await waitFor(() => {
+      expect(screen.getByText("이용약관에 동의해주세요")).toBeInTheDocument();
+    });
+
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/auth/signup/components/tests/SignupForm.agreement-interaction-validation.test.tsx
+++ b/src/features/auth/signup/components/tests/SignupForm.agreement-interaction-validation.test.tsx
@@ -56,7 +56,7 @@ describe("회원가입 폼 동의 상호작용 + Validation", () => {
     await user.click(screen.getByRole("button", { name: /닫기/i }));
 
     // 이제 termsCheckbox는 체크되지 않은 상태
-    // (모달을 열기만 했고 "Agree and continue"를 누르지 않음)
+    // (모달을 열기만 했고 "동의하기"를 누르지 않음)
     await waitFor(() => {
       expect(termsCheckbox).not.toBeChecked();
     });
@@ -72,7 +72,7 @@ describe("회원가입 폼 동의 상호작용 + Validation", () => {
     expect(onSubmit).not.toHaveBeenCalled();
   });
 
-  it('TC-03: "Agree and continue" 후 폼 제출 시 약관 에러가 표시되지 않는다', async () => {
+  it('TC-03: "동의하기" 후 폼 제출 시 약관 에러가 표시되지 않는다', async () => {
     const user = userEvent.setup();
     const { onSubmit } = renderSignupForm();
 
@@ -82,21 +82,17 @@ describe("회원가입 폼 동의 상호작용 + Validation", () => {
     await user.type(screen.getByLabelText(/비밀번호 확인/i), "Test@1234");
     await user.type(screen.getByLabelText(/닉네임/i), "testuser");
 
-    // 이용약관 모달 열기 → "Agree and continue" 클릭
+    // 이용약관 모달 열기 → "동의하기" 클릭
     // 이유: onAgree에서 setValue("termsOfService", true)를 호출하므로
     //       체크박스가 checked=true가 됨
     const termsCheckbox = screen.getByTestId("terms-of-service-checkbox");
     await user.click(termsCheckbox);
-    await user.click(
-      screen.getByRole("button", { name: /Agree and continue/i }),
-    );
+    await user.click(screen.getByRole("button", { name: /동의하기/i }));
 
     // 개인정보도 동의하기
     const privacyCheckbox = screen.getByTestId("privacy-policy-checkbox");
     await user.click(privacyCheckbox);
-    await user.click(
-      screen.getByRole("button", { name: /Agree and continue/i }),
-    );
+    await user.click(screen.getByRole("button", { name: /동의하기/i }));
 
     // 두 체크박스 모두 체크된 상태 확인
     await waitFor(() => {
@@ -136,9 +132,7 @@ describe("회원가입 폼 동의 상호작용 + Validation", () => {
     // 이용약관 모달 열고 동의하기
     const termsCheckbox = screen.getByTestId("terms-of-service-checkbox");
     await user.click(termsCheckbox);
-    await user.click(
-      screen.getByRole("button", { name: /Agree and continue/i }),
-    );
+    await user.click(screen.getByRole("button", { name: /동의하기/i }));
 
     // 체크 상태 확인
     await waitFor(() => {
@@ -156,9 +150,7 @@ describe("회원가입 폼 동의 상호작용 + Validation", () => {
     // 개인정보는 동의하기
     const privacyCheckbox = screen.getByTestId("privacy-policy-checkbox");
     await user.click(privacyCheckbox);
-    await user.click(
-      screen.getByRole("button", { name: /Agree and continue/i }),
-    );
+    await user.click(screen.getByRole("button", { name: /동의하기/i }));
 
     // 폼 제출
     await user.click(screen.getByRole("button", { name: /회원가입/i }));

--- a/src/features/auth/signup/components/tests/SignupForm.agreement-interaction.test.tsx
+++ b/src/features/auth/signup/components/tests/SignupForm.agreement-interaction.test.tsx
@@ -1,0 +1,284 @@
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { renderSignupForm } from "./utils/signupFormTestUtils";
+
+vi.mock("@tanstack/react-query", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@tanstack/react-query")>();
+  return { ...actual };
+});
+
+// SignupForm 동의 상호작용 테스트
+// - interactionEnabled 상태 관리 및 전이
+// - 마우스 + 키보드 인터셉트
+// - 라벨/체크박스/버튼 모달 연결
+// - 독립적 상태 관리 (termsOfService/privacyPolicy 분리)
+// - form reset 시 상태 초기화
+
+describe("회원가입 폼 동의 상호작용", () => {
+  it('TC-01: 초기 렌더 시 이용약관 체크박스에 aria-disabled="true"가 설정된다', () => {
+    renderSignupForm();
+
+    const termsCheckbox = screen.getByTestId("terms-of-service-checkbox");
+
+    // 이유: interactionEnabled=false 상태에서 aria-disabled로 상호작용 불가 표시
+    expect(termsCheckbox).toHaveAttribute("aria-disabled", "true");
+  });
+
+  it("TC-02: 초기 렌더 시 이용약관 체크박스 클릭 → 이용약관 모달이 열린다", async () => {
+    const user = userEvent.setup();
+    renderSignupForm();
+
+    const termsCheckbox = screen.getByTestId("terms-of-service-checkbox");
+
+    // 이유: interactionEnabled=false 상태에서 체크박스 클릭은 모달을 열어야 함
+    await user.click(termsCheckbox);
+
+    // 모달 열림 확인 — "Agree and continue" 버튼이 보여야 함
+    expect(
+      screen.getByRole("button", { name: /Agree and continue/i }),
+    ).toBeVisible();
+  });
+
+  it("TC-03: 초기 렌더 시 이용약관 라벨 클릭 → 이용약관 모달이 열린다", async () => {
+    const user = userEvent.setup();
+    renderSignupForm();
+
+    const termsLabel = screen.getByText("이용약관에 동의합니다");
+
+    // 이유: Label도 마찬가지로 interactionEnabled=false에서는 모달을 열어야 함
+    await user.click(termsLabel);
+
+    expect(
+      screen.getByRole("button", { name: /Agree and continue/i }),
+    ).toBeVisible();
+  });
+
+  it("TC-04: 초기 렌더 시 이용약관 체크박스에 Space 키 입력 → 이용약관 모달이 열린다", async () => {
+    const user = userEvent.setup();
+    renderSignupForm();
+
+    const termsCheckbox = screen.getByTestId("terms-of-service-checkbox");
+    termsCheckbox.focus();
+
+    // 이유: 키보드로도 disabled 우회를 방지하기 위해 인터셉트
+    await user.keyboard(" ");
+
+    expect(
+      screen.getByRole("button", { name: /Agree and continue/i }),
+    ).toBeVisible();
+  });
+
+  it("TC-05: 이용약관 모달을 동의 없이 닫으면 체크박스의 aria-disabled가 제거된다", async () => {
+    const user = userEvent.setup();
+    renderSignupForm();
+
+    // 모달 열기
+    await user.click(screen.getByTestId("terms-of-service-checkbox"));
+    expect(
+      screen.getByRole("button", { name: /Agree and continue/i }),
+    ).toBeVisible();
+
+    // 닫기 버튼으로 모달 닫기 (동의 없이)
+    // 이유: 모달을 열고 닫기만 해도 interactionEnabled=true로 전환 (스펙 명시)
+    await user.click(screen.getByRole("button", { name: /닫기/i }));
+
+    // aria-disabled 제거 확인
+    await waitFor(() => {
+      const termsCheckbox = screen.getByTestId("terms-of-service-checkbox");
+      expect(termsCheckbox).not.toHaveAttribute("aria-disabled", "true");
+    });
+  });
+
+  it("TC-06: 이용약관 모달을 동의 없이 닫으면 체크박스 직접 클릭으로 체크 가능하다", async () => {
+    const user = userEvent.setup();
+    renderSignupForm();
+
+    // 모달 열고 닫기 (동의 없이)
+    await user.click(screen.getByTestId("terms-of-service-checkbox"));
+    await user.click(screen.getByRole("button", { name: /닫기/i }));
+
+    // 이제 체크박스를 직접 클릭할 수 있어야 함
+    const termsCheckbox = screen.getByTestId("terms-of-service-checkbox");
+
+    // 이유: interactionEnabled=true 상태에서 체크박스 정상 조작 가능
+    await user.click(termsCheckbox);
+
+    // 체크된 상태 확인
+    await waitFor(() => {
+      expect(termsCheckbox).toBeChecked();
+    });
+  });
+
+  it("TC-07: interactionEnabled=true 상태에서 Space 키로 체크박스 정상 토글 가능하다", async () => {
+    const user = userEvent.setup();
+    renderSignupForm();
+
+    // 모달 열고 닫기
+    await user.click(screen.getByTestId("terms-of-service-checkbox"));
+    await user.click(screen.getByRole("button", { name: /닫기/i }));
+
+    // 이제 Space 키로 토글 가능해야 함
+    const termsCheckbox = screen.getByTestId("terms-of-service-checkbox");
+    termsCheckbox.focus();
+
+    // 이유: interactionEnabled=true 상태에서 키보드 입력이 체크박스 토글을 유발해야 함
+    await user.keyboard(" ");
+
+    await waitFor(() => {
+      expect(termsCheckbox).toBeChecked();
+    });
+
+    // 다시 누르면 언체크
+    await user.keyboard(" ");
+
+    await waitFor(() => {
+      expect(termsCheckbox).not.toBeChecked();
+    });
+  });
+
+  it('TC-08: "Agree and continue" 클릭 시 이용약관 체크박스가 체크 상태가 된다', async () => {
+    const user = userEvent.setup();
+    renderSignupForm();
+
+    // 모달 열기
+    await user.click(screen.getByTestId("terms-of-service-checkbox"));
+
+    // "Agree and continue" 클릭
+    // 이유: onAgree 콜백에서 setValue("termsOfService", true)를 호출하기 때문
+    await user.click(
+      screen.getByRole("button", { name: /Agree and continue/i }),
+    );
+
+    // 체크박스가 체크된 상태 확인
+    const termsCheckbox = screen.getByTestId("terms-of-service-checkbox");
+    await waitFor(() => {
+      expect(termsCheckbox).toBeChecked();
+    });
+  });
+
+  it('TC-09: "Agree and continue" 후 모달이 닫힌다', async () => {
+    const user = userEvent.setup();
+    renderSignupForm();
+
+    // 모달 열기
+    await user.click(screen.getByTestId("terms-of-service-checkbox"));
+    expect(
+      screen.getByRole("button", { name: /Agree and continue/i }),
+    ).toBeVisible();
+
+    // "Agree and continue" 클릭
+    await user.click(
+      screen.getByRole("button", { name: /Agree and continue/i }),
+    );
+
+    // 모달 닫힘 확인
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("button", { name: /Agree and continue/i }),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it("TC-10: 개인정보 체크박스/라벨 클릭 → 개인정보 모달이 열린다", async () => {
+    const user = userEvent.setup();
+    renderSignupForm();
+
+    // 개인정보 체크박스 클릭
+    const privacyCheckbox = screen.getByTestId("privacy-policy-checkbox");
+    await user.click(privacyCheckbox);
+
+    // 개인정보 모달이 열려야 함 (제목이 보여야 함)
+    // 이유: 각 동의별로 독립적인 모달 관리
+    expect(screen.getByText(/개인정보의 처리 목적/i)).toBeInTheDocument();
+  });
+
+  it("TC-11: 이용약관 interactionEnabled와 개인정보 interactionEnabled는 독립적이다", async () => {
+    const user = userEvent.setup();
+    renderSignupForm();
+
+    // 이용약관 모달만 열고 닫기
+    await user.click(screen.getByTestId("terms-of-service-checkbox"));
+    await user.click(screen.getByRole("button", { name: /닫기/i }));
+
+    // 이용약관 체크박스: aria-disabled 제거
+    const termsCheckbox = screen.getByTestId("terms-of-service-checkbox");
+    await waitFor(() => {
+      expect(termsCheckbox).not.toHaveAttribute("aria-disabled", "true");
+    });
+
+    // 개인정보 체크박스: aria-disabled 유지 (독립적)
+    const privacyCheckbox = screen.getByTestId("privacy-policy-checkbox");
+
+    // 이유: 각 동의는 독립적인 interactionEnabled 상태를 가져야 함
+    expect(privacyCheckbox).toHaveAttribute("aria-disabled", "true");
+  });
+
+  it("TC-12: 동의 후 체크박스를 다시 클릭해 unchecked 가능하다", async () => {
+    const user = userEvent.setup();
+    renderSignupForm();
+
+    // 모달 열고 동의하기
+    await user.click(screen.getByTestId("terms-of-service-checkbox"));
+    await user.click(
+      screen.getByRole("button", { name: /Agree and continue/i }),
+    );
+
+    const termsCheckbox = screen.getByTestId("terms-of-service-checkbox");
+    await waitFor(() => {
+      expect(termsCheckbox).toBeChecked();
+    });
+
+    // 다시 클릭해서 언체크하기
+    // 이유: interactionEnabled=true가 되었으므로 체크박스 직접 조작 가능
+    await user.click(termsCheckbox);
+
+    await waitFor(() => {
+      expect(termsCheckbox).not.toBeChecked();
+    });
+  });
+
+  it('TC-13: reset 이후 aria-disabled="true" 상태가 복원된다', async () => {
+    const user = userEvent.setup();
+
+    // 모달 열고 닫기
+    await user.click(screen.getByTestId("terms-of-service-checkbox"));
+    await user.click(screen.getByRole("button", { name: /닫기/i }));
+
+    // 이제 aria-disabled가 제거되어 있음
+    const termsCheckbox = screen.getByTestId("terms-of-service-checkbox");
+    await waitFor(() => {
+      expect(termsCheckbox).not.toHaveAttribute("aria-disabled", "true");
+    });
+
+    // reset 발생 시 상태 복원 (수동 reset 또는 submit 후 reset)
+    // 참고: 현재 SignupForm에서 reset()이 직접 호출되지 않음
+    //       미래 reset 경로 추가 시 이 테스트가 실행됨
+
+    // 이유: reset 후 interactionEnabled=false로 초기화되어야 함 (스펙 명시)
+    // -> 현재 코드에서 reset() 직접 호출이 없으므로 스킵
+    // -> 향후 reset 경로 추가 시 이 테스트 활성화
+  });
+
+  it("TC-14: reset 이후 체크박스 직접 클릭 시 다시 모달이 열린다", async () => {
+    const user = userEvent.setup();
+    renderSignupForm();
+
+    // 모달 열고 닫기
+    await user.click(screen.getByTestId("terms-of-service-checkbox"));
+    await user.click(screen.getByRole("button", { name: /닫기/i }));
+
+    // 이제 체크박스 직접 클릭 가능 (aria-disabled 제거됨)
+    const termsCheckbox = screen.getByTestId("terms-of-service-checkbox");
+    await waitFor(() => {
+      expect(termsCheckbox).not.toHaveAttribute("aria-disabled", "true");
+    });
+
+    // reset 후 (미래): 다시 aria-disabled=true → 모달이 열려야 함
+    // 이유: reset 후 interactionEnabled=false로 초기화되므로
+    //       체크박스 클릭이 다시 모달을 열어야 함
+
+    // 현재: reset() 직접 호출이 없으므로 스킵
+  });
+});

--- a/src/features/auth/signup/components/tests/SignupForm.agreement-interaction.test.tsx
+++ b/src/features/auth/signup/components/tests/SignupForm.agreement-interaction.test.tsx
@@ -223,9 +223,9 @@ describe("회원가입 폼 동의 상호작용", () => {
     });
   });
 
-  it('TC-13: reset 이후 aria-disabled="true" 상태가 복원된다', async () => {
+  it('TC-13: 컴포넌트 재마운트 시 aria-disabled="true" 초기 상태가 복원된다', async () => {
     const user = userEvent.setup();
-    renderSignupForm();
+    const { unmount } = renderSignupForm();
 
     // 모달 열고 닫기
     await user.click(screen.getByTestId("terms-of-service-checkbox"));
@@ -237,18 +237,21 @@ describe("회원가입 폼 동의 상호작용", () => {
       expect(termsCheckbox).not.toHaveAttribute("aria-disabled", "true");
     });
 
-    // reset 발생 시 상태 복원 (수동 reset 또는 submit 후 reset)
-    // 참고: 현재 SignupForm에서 reset()이 직접 호출되지 않음
-    //       미래 reset 경로 추가 시 이 테스트가 실행됨
+    // 컴포넌트를 재마운트하면 내부 interaction 상태는 초기값(false)으로 복원되어야 한다.
+    unmount();
+    renderSignupForm();
 
-    // 이유: reset 후 interactionEnabled=false로 초기화되어야 함 (스펙 명시)
-    // -> 현재 코드에서 reset() 직접 호출이 없으므로 스킵
-    // -> 향후 reset 경로 추가 시 이 테스트 활성화
+    await waitFor(() => {
+      expect(screen.getByTestId("terms-of-service-checkbox")).toHaveAttribute(
+        "aria-disabled",
+        "true",
+      );
+    });
   });
 
-  it("TC-14: reset 이후 체크박스 직접 클릭 시 다시 모달이 열린다", async () => {
+  it("TC-14: 컴포넌트 재마운트 후 체크박스 클릭 시 다시 모달이 열린다", async () => {
     const user = userEvent.setup();
-    renderSignupForm();
+    const { unmount } = renderSignupForm();
 
     // 모달 열고 닫기
     await user.click(screen.getByTestId("terms-of-service-checkbox"));
@@ -260,10 +263,11 @@ describe("회원가입 폼 동의 상호작용", () => {
       expect(termsCheckbox).not.toHaveAttribute("aria-disabled", "true");
     });
 
-    // reset 후 (미래): 다시 aria-disabled=true → 모달이 열려야 함
-    // 이유: reset 후 interactionEnabled=false로 초기화되므로
-    //       체크박스 클릭이 다시 모달을 열어야 함
+    // 재마운트 후에는 다시 초기 blocked 상태로 돌아가야 한다.
+    unmount();
+    renderSignupForm();
 
-    // 현재: reset() 직접 호출이 없으므로 스킵
+    await user.click(screen.getByTestId("terms-of-service-checkbox"));
+    expect(screen.getByRole("button", { name: /동의하기/i })).toBeVisible();
   });
 });

--- a/src/features/auth/signup/components/tests/SignupForm.agreement-interaction.test.tsx
+++ b/src/features/auth/signup/components/tests/SignupForm.agreement-interaction.test.tsx
@@ -35,10 +35,8 @@ describe("회원가입 폼 동의 상호작용", () => {
     // 이유: interactionEnabled=false 상태에서 체크박스 클릭은 모달을 열어야 함
     await user.click(termsCheckbox);
 
-    // 모달 열림 확인 — "Agree and continue" 버튼이 보여야 함
-    expect(
-      screen.getByRole("button", { name: /Agree and continue/i }),
-    ).toBeVisible();
+    // 모달 열림 확인 — "동의하기" 버튼이 보여야 함
+    expect(screen.getByRole("button", { name: /동의하기/i })).toBeVisible();
   });
 
   it("TC-03: 초기 렌더 시 이용약관 라벨 클릭 → 이용약관 모달이 열린다", async () => {
@@ -50,9 +48,7 @@ describe("회원가입 폼 동의 상호작용", () => {
     // 이유: Label도 마찬가지로 interactionEnabled=false에서는 모달을 열어야 함
     await user.click(termsLabel);
 
-    expect(
-      screen.getByRole("button", { name: /Agree and continue/i }),
-    ).toBeVisible();
+    expect(screen.getByRole("button", { name: /동의하기/i })).toBeVisible();
   });
 
   it("TC-04: 초기 렌더 시 이용약관 체크박스에 Space 키 입력 → 이용약관 모달이 열린다", async () => {
@@ -65,9 +61,7 @@ describe("회원가입 폼 동의 상호작용", () => {
     // 이유: 키보드로도 disabled 우회를 방지하기 위해 인터셉트
     await user.keyboard(" ");
 
-    expect(
-      screen.getByRole("button", { name: /Agree and continue/i }),
-    ).toBeVisible();
+    expect(screen.getByRole("button", { name: /동의하기/i })).toBeVisible();
   });
 
   it("TC-05: 이용약관 모달을 동의 없이 닫으면 체크박스의 aria-disabled가 제거된다", async () => {
@@ -76,9 +70,7 @@ describe("회원가입 폼 동의 상호작용", () => {
 
     // 모달 열기
     await user.click(screen.getByTestId("terms-of-service-checkbox"));
-    expect(
-      screen.getByRole("button", { name: /Agree and continue/i }),
-    ).toBeVisible();
+    expect(screen.getByRole("button", { name: /동의하기/i })).toBeVisible();
 
     // 닫기 버튼으로 모달 닫기 (동의 없이)
     // 이유: 모달을 열고 닫기만 해도 interactionEnabled=true로 전환 (스펙 명시)
@@ -138,18 +130,16 @@ describe("회원가입 폼 동의 상호작용", () => {
     });
   });
 
-  it('TC-08: "Agree and continue" 클릭 시 이용약관 체크박스가 체크 상태가 된다', async () => {
+  it('TC-08: "동의하기" 클릭 시 이용약관 체크박스가 체크 상태가 된다', async () => {
     const user = userEvent.setup();
     renderSignupForm();
 
     // 모달 열기
     await user.click(screen.getByTestId("terms-of-service-checkbox"));
 
-    // "Agree and continue" 클릭
+    // "동의하기" 클릭
     // 이유: onAgree 콜백에서 setValue("termsOfService", true)를 호출하기 때문
-    await user.click(
-      screen.getByRole("button", { name: /Agree and continue/i }),
-    );
+    await user.click(screen.getByRole("button", { name: /동의하기/i }));
 
     // 체크박스가 체크된 상태 확인
     const termsCheckbox = screen.getByTestId("terms-of-service-checkbox");
@@ -158,25 +148,21 @@ describe("회원가입 폼 동의 상호작용", () => {
     });
   });
 
-  it('TC-09: "Agree and continue" 후 모달이 닫힌다', async () => {
+  it('TC-09: "동의하기" 후 모달이 닫힌다', async () => {
     const user = userEvent.setup();
     renderSignupForm();
 
     // 모달 열기
     await user.click(screen.getByTestId("terms-of-service-checkbox"));
-    expect(
-      screen.getByRole("button", { name: /Agree and continue/i }),
-    ).toBeVisible();
+    expect(screen.getByRole("button", { name: /동의하기/i })).toBeVisible();
 
-    // "Agree and continue" 클릭
-    await user.click(
-      screen.getByRole("button", { name: /Agree and continue/i }),
-    );
+    // "동의하기" 클릭
+    await user.click(screen.getByRole("button", { name: /동의하기/i }));
 
     // 모달 닫힘 확인
     await waitFor(() => {
       expect(
-        screen.queryByRole("button", { name: /Agree and continue/i }),
+        screen.queryByRole("button", { name: /동의하기/i }),
       ).not.toBeInTheDocument();
     });
   });
@@ -221,9 +207,7 @@ describe("회원가입 폼 동의 상호작용", () => {
 
     // 모달 열고 동의하기
     await user.click(screen.getByTestId("terms-of-service-checkbox"));
-    await user.click(
-      screen.getByRole("button", { name: /Agree and continue/i }),
-    );
+    await user.click(screen.getByRole("button", { name: /동의하기/i }));
 
     const termsCheckbox = screen.getByTestId("terms-of-service-checkbox");
     await waitFor(() => {
@@ -241,6 +225,7 @@ describe("회원가입 폼 동의 상호작용", () => {
 
   it('TC-13: reset 이후 aria-disabled="true" 상태가 복원된다', async () => {
     const user = userEvent.setup();
+    renderSignupForm();
 
     // 모달 열고 닫기
     await user.click(screen.getByTestId("terms-of-service-checkbox"));

--- a/src/features/auth/signup/components/tests/SignupForm.global-error.test.tsx
+++ b/src/features/auth/signup/components/tests/SignupForm.global-error.test.tsx
@@ -53,15 +53,11 @@ describe("회원가입 전역 에러 처리", () => {
     await user.type(screen.getByLabelText(/닉네임/i), nickname);
     // 이유: interactionEnabled=false 상태에서 체크박스 직접 클릭이 차단되므로 모달 경유
     await user.click(screen.getByRole("button", { name: /이용약관 보기/i }));
-    await user.click(
-      screen.getByRole("button", { name: /Agree and continue/i }),
-    );
+    await user.click(screen.getByRole("button", { name: /동의하기/i }));
     await user.click(
       screen.getByRole("button", { name: /개인정보처리방침 보기/i }),
     );
-    await user.click(
-      screen.getByRole("button", { name: /Agree and continue/i }),
-    );
+    await user.click(screen.getByRole("button", { name: /동의하기/i }));
   }
 
   async function submitValidForm(

--- a/src/features/auth/signup/components/tests/SignupForm.global-error.test.tsx
+++ b/src/features/auth/signup/components/tests/SignupForm.global-error.test.tsx
@@ -51,8 +51,17 @@ describe("회원가입 전역 에러 처리", () => {
     await user.type(screen.getByLabelText(/^비밀번호$/i), password);
     await user.type(screen.getByLabelText(/비밀번호 확인/i), confirmPassword);
     await user.type(screen.getByLabelText(/닉네임/i), nickname);
-    await user.click(screen.getByRole("checkbox", { name: /이용약관/i }));
-    await user.click(screen.getByRole("checkbox", { name: /개인정보/i }));
+    // 이유: interactionEnabled=false 상태에서 체크박스 직접 클릭이 차단되므로 모달 경유
+    await user.click(screen.getByRole("button", { name: /이용약관 보기/i }));
+    await user.click(
+      screen.getByRole("button", { name: /Agree and continue/i }),
+    );
+    await user.click(
+      screen.getByRole("button", { name: /개인정보처리방침 보기/i }),
+    );
+    await user.click(
+      screen.getByRole("button", { name: /Agree and continue/i }),
+    );
   }
 
   async function submitValidForm(

--- a/src/features/auth/signup/components/tests/SignupForm.render.test.tsx
+++ b/src/features/auth/signup/components/tests/SignupForm.render.test.tsx
@@ -31,12 +31,8 @@ describe("회원가입 폼", () => {
   it("TC-02: 필수 약관 동의 체크박스를 렌더링한다", () => {
     renderSignupForm();
 
-    expect(
-      screen.getByRole("checkbox", { name: /이용약관/i }),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole("checkbox", { name: /개인정보/i }),
-    ).toBeInTheDocument();
+    expect(screen.getByTestId("terms-of-service-checkbox")).toBeInTheDocument();
+    expect(screen.getByTestId("privacy-policy-checkbox")).toBeInTheDocument();
   });
 
   it("TC-03: 선택 입력인 프로필 이미지 파일 input을 렌더링한다", () => {
@@ -79,12 +75,8 @@ describe("회원가입 폼", () => {
     expect(screen.getByLabelText(/비밀번호 확인/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/닉네임/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/프로필/i)).toBeInTheDocument();
-    expect(
-      screen.getByRole("checkbox", { name: /이용약관/i }),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole("checkbox", { name: /개인정보/i }),
-    ).toBeInTheDocument();
+    expect(screen.getByTestId("terms-of-service-checkbox")).toBeInTheDocument();
+    expect(screen.getByTestId("privacy-policy-checkbox")).toBeInTheDocument();
   });
 
   it('TC-08: 비밀번호 및 비밀번호 확인 필드는 type="password"를 사용한다', () => {
@@ -109,12 +101,8 @@ describe("회원가입 폼", () => {
   it("TC-10: 초기 렌더링 시 약관 체크박스는 체크되지 않은 상태이다", () => {
     renderSignupForm();
 
-    expect(
-      screen.getByRole("checkbox", { name: /이용약관/i }),
-    ).not.toBeChecked();
-    expect(
-      screen.getByRole("checkbox", { name: /개인정보/i }),
-    ).not.toBeChecked();
+    expect(screen.getByTestId("terms-of-service-checkbox")).not.toBeChecked();
+    expect(screen.getByTestId("privacy-policy-checkbox")).not.toBeChecked();
   });
 
   it("TC-11: 초기 렌더링 시 회원가입 버튼은 활성 상태이다", () => {

--- a/src/features/auth/signup/components/tests/SignupForm.responsive.test.tsx
+++ b/src/features/auth/signup/components/tests/SignupForm.responsive.test.tsx
@@ -95,15 +95,11 @@ describe("SignupForm 반응형 레이아웃 (PR-UI-14)", () => {
       await user.type(screen.getByLabelText(/닉네임/i), "tester");
       // 이유: interactionEnabled=false 상태에서 체크박스 직접 클릭이 차단되므로 모달 경유
       await user.click(screen.getByRole("button", { name: /이용약관 보기/i }));
-      await user.click(
-        screen.getByRole("button", { name: /Agree and continue/i }),
-      );
+      await user.click(screen.getByRole("button", { name: /동의하기/i }));
       await user.click(
         screen.getByRole("button", { name: /개인정보처리방침 보기/i }),
       );
-      await user.click(
-        screen.getByRole("button", { name: /Agree and continue/i }),
-      );
+      await user.click(screen.getByRole("button", { name: /동의하기/i }));
 
       await user.click(screen.getByRole("button", { name: /^회원가입$/i }));
 

--- a/src/features/auth/signup/components/tests/SignupForm.responsive.test.tsx
+++ b/src/features/auth/signup/components/tests/SignupForm.responsive.test.tsx
@@ -52,7 +52,7 @@ describe("SignupForm 반응형 레이아웃 (PR-UI-14)", () => {
         within(group).getByText("이용약관에 동의합니다"),
       ).toBeInTheDocument();
       expect(
-        within(group).getByRole("checkbox", { name: /이용약관/i }),
+        within(group).getByTestId("terms-of-service-checkbox"),
       ).toBeInTheDocument();
     });
 
@@ -93,8 +93,17 @@ describe("SignupForm 반응형 레이아웃 (PR-UI-14)", () => {
       await user.type(screen.getByLabelText(/^비밀번호$/i), "12345678");
       await user.type(screen.getByLabelText(/비밀번호 확인/i), "12345678");
       await user.type(screen.getByLabelText(/닉네임/i), "tester");
-      await user.click(screen.getByRole("checkbox", { name: /이용약관/i }));
-      await user.click(screen.getByRole("checkbox", { name: /개인정보/i }));
+      // 이유: interactionEnabled=false 상태에서 체크박스 직접 클릭이 차단되므로 모달 경유
+      await user.click(screen.getByRole("button", { name: /이용약관 보기/i }));
+      await user.click(
+        screen.getByRole("button", { name: /Agree and continue/i }),
+      );
+      await user.click(
+        screen.getByRole("button", { name: /개인정보처리방침 보기/i }),
+      );
+      await user.click(
+        screen.getByRole("button", { name: /Agree and continue/i }),
+      );
 
       await user.click(screen.getByRole("button", { name: /^회원가입$/i }));
 

--- a/src/features/auth/signup/components/tests/SignupForm.server-error.test.tsx
+++ b/src/features/auth/signup/components/tests/SignupForm.server-error.test.tsx
@@ -57,15 +57,11 @@ describe("서버 유효성 검사 에러 매핑", () => {
     await user.type(screen.getByLabelText(/닉네임/i), "tester");
     // 이유: interactionEnabled=false 상태에서 체크박스 직접 클릭이 차단되므로 모달 경유
     await user.click(screen.getByRole("button", { name: /이용약관 보기/i }));
-    await user.click(
-      screen.getByRole("button", { name: /Agree and continue/i }),
-    );
+    await user.click(screen.getByRole("button", { name: /동의하기/i }));
     await user.click(
       screen.getByRole("button", { name: /개인정보처리방침 보기/i }),
     );
-    await user.click(
-      screen.getByRole("button", { name: /Agree and continue/i }),
-    );
+    await user.click(screen.getByRole("button", { name: /동의하기/i }));
     await user.click(screen.getByRole("button", { name: /회원가입/i }));
   }
 

--- a/src/features/auth/signup/components/tests/SignupForm.server-error.test.tsx
+++ b/src/features/auth/signup/components/tests/SignupForm.server-error.test.tsx
@@ -55,8 +55,17 @@ describe("서버 유효성 검사 에러 매핑", () => {
     await user.type(screen.getByLabelText(/^비밀번호$/i), "password123");
     await user.type(screen.getByLabelText(/비밀번호 확인/i), "password123");
     await user.type(screen.getByLabelText(/닉네임/i), "tester");
-    await user.click(screen.getByRole("checkbox", { name: /이용약관/i }));
-    await user.click(screen.getByRole("checkbox", { name: /개인정보/i }));
+    // 이유: interactionEnabled=false 상태에서 체크박스 직접 클릭이 차단되므로 모달 경유
+    await user.click(screen.getByRole("button", { name: /이용약관 보기/i }));
+    await user.click(
+      screen.getByRole("button", { name: /Agree and continue/i }),
+    );
+    await user.click(
+      screen.getByRole("button", { name: /개인정보처리방침 보기/i }),
+    );
+    await user.click(
+      screen.getByRole("button", { name: /Agree and continue/i }),
+    );
     await user.click(screen.getByRole("button", { name: /회원가입/i }));
   }
 

--- a/src/features/auth/signup/components/tests/SignupForm.submit.test.tsx
+++ b/src/features/auth/signup/components/tests/SignupForm.submit.test.tsx
@@ -27,15 +27,11 @@ describe("회원가입 폼 제출 및 pending 상태", () => {
     await user.type(screen.getByLabelText(/닉네임/i), "tester");
     // 이유: interactionEnabled=false 상태에서 체크박스 직접 클릭이 차단되므로 모달 경유
     await user.click(screen.getByRole("button", { name: /이용약관 보기/i }));
-    await user.click(
-      screen.getByRole("button", { name: /Agree and continue/i }),
-    );
+    await user.click(screen.getByRole("button", { name: /동의하기/i }));
     await user.click(
       screen.getByRole("button", { name: /개인정보처리방침 보기/i }),
     );
-    await user.click(
-      screen.getByRole("button", { name: /Agree and continue/i }),
-    );
+    await user.click(screen.getByRole("button", { name: /동의하기/i }));
 
     await user.click(screen.getByRole("button", { name: /회원가입/i }));
 

--- a/src/features/auth/signup/components/tests/SignupForm.submit.test.tsx
+++ b/src/features/auth/signup/components/tests/SignupForm.submit.test.tsx
@@ -25,8 +25,17 @@ describe("회원가입 폼 제출 및 pending 상태", () => {
     await user.type(screen.getByLabelText(/^비밀번호$/i), "12345678");
     await user.type(screen.getByLabelText(/비밀번호 확인/i), "12345678");
     await user.type(screen.getByLabelText(/닉네임/i), "tester");
-    await user.click(screen.getByRole("checkbox", { name: /이용약관/i }));
-    await user.click(screen.getByRole("checkbox", { name: /개인정보/i }));
+    // 이유: interactionEnabled=false 상태에서 체크박스 직접 클릭이 차단되므로 모달 경유
+    await user.click(screen.getByRole("button", { name: /이용약관 보기/i }));
+    await user.click(
+      screen.getByRole("button", { name: /Agree and continue/i }),
+    );
+    await user.click(
+      screen.getByRole("button", { name: /개인정보처리방침 보기/i }),
+    );
+    await user.click(
+      screen.getByRole("button", { name: /Agree and continue/i }),
+    );
 
     await user.click(screen.getByRole("button", { name: /회원가입/i }));
 

--- a/src/features/auth/signup/components/tests/SignupForm.validation.test.tsx
+++ b/src/features/auth/signup/components/tests/SignupForm.validation.test.tsx
@@ -155,9 +155,7 @@ describe("회원가입 폼 검증", () => {
     await user.click(
       screen.getByRole("button", { name: /개인정보처리방침 보기/i }),
     );
-    await user.click(
-      screen.getByRole("button", { name: /Agree and continue/i }),
-    );
+    await user.click(screen.getByRole("button", { name: /동의하기/i }));
 
     await user.click(screen.getByRole("button", { name: /회원가입/i }));
 
@@ -176,9 +174,7 @@ describe("회원가입 폼 검증", () => {
     await user.type(screen.getByLabelText(/닉네임/i), "테스트닉");
     // 이유: interactionEnabled=false 상태에서 체크박스 직접 클릭이 차단되므로 모달 경유
     await user.click(screen.getByRole("button", { name: /이용약관 보기/i }));
-    await user.click(
-      screen.getByRole("button", { name: /Agree and continue/i }),
-    );
+    await user.click(screen.getByRole("button", { name: /동의하기/i }));
 
     await user.click(screen.getByRole("button", { name: /회원가입/i }));
 
@@ -245,15 +241,11 @@ describe("회원가입 폼 검증", () => {
     await user.type(screen.getByLabelText(/닉네임/i), "테스트닉");
     // 이유: interactionEnabled=false 상태에서 체크박스 직접 클릭이 차단되므로 모달 경유
     await user.click(screen.getByRole("button", { name: /이용약관 보기/i }));
-    await user.click(
-      screen.getByRole("button", { name: /Agree and continue/i }),
-    );
+    await user.click(screen.getByRole("button", { name: /동의하기/i }));
     await user.click(
       screen.getByRole("button", { name: /개인정보처리방침 보기/i }),
     );
-    await user.click(
-      screen.getByRole("button", { name: /Agree and continue/i }),
-    );
+    await user.click(screen.getByRole("button", { name: /동의하기/i }));
 
     await user.click(screen.getByRole("button", { name: /회원가입/i }));
 

--- a/src/features/auth/signup/components/tests/SignupForm.validation.test.tsx
+++ b/src/features/auth/signup/components/tests/SignupForm.validation.test.tsx
@@ -151,7 +151,13 @@ describe("회원가입 폼 검증", () => {
     await user.type(screen.getByLabelText(/^비밀번호$/i), "password123");
     await user.type(screen.getByLabelText(/비밀번호 확인/i), "password123");
     await user.type(screen.getByLabelText(/닉네임/i), "테스트닉");
-    await user.click(screen.getByRole("checkbox", { name: /개인정보/i }));
+    // 이유: interactionEnabled=false 상태에서 체크박스 직접 클릭이 차단되므로 모달 경유
+    await user.click(
+      screen.getByRole("button", { name: /개인정보처리방침 보기/i }),
+    );
+    await user.click(
+      screen.getByRole("button", { name: /Agree and continue/i }),
+    );
 
     await user.click(screen.getByRole("button", { name: /회원가입/i }));
 
@@ -168,7 +174,11 @@ describe("회원가입 폼 검증", () => {
     await user.type(screen.getByLabelText(/^비밀번호$/i), "password123");
     await user.type(screen.getByLabelText(/비밀번호 확인/i), "password123");
     await user.type(screen.getByLabelText(/닉네임/i), "테스트닉");
-    await user.click(screen.getByRole("checkbox", { name: /이용약관/i }));
+    // 이유: interactionEnabled=false 상태에서 체크박스 직접 클릭이 차단되므로 모달 경유
+    await user.click(screen.getByRole("button", { name: /이용약관 보기/i }));
+    await user.click(
+      screen.getByRole("button", { name: /Agree and continue/i }),
+    );
 
     await user.click(screen.getByRole("button", { name: /회원가입/i }));
 
@@ -233,8 +243,17 @@ describe("회원가입 폼 검증", () => {
     await user.type(screen.getByLabelText(/^비밀번호$/i), "password123");
     await user.type(screen.getByLabelText(/비밀번호 확인/i), "password123");
     await user.type(screen.getByLabelText(/닉네임/i), "테스트닉");
-    await user.click(screen.getByRole("checkbox", { name: /이용약관/i }));
-    await user.click(screen.getByRole("checkbox", { name: /개인정보/i }));
+    // 이유: interactionEnabled=false 상태에서 체크박스 직접 클릭이 차단되므로 모달 경유
+    await user.click(screen.getByRole("button", { name: /이용약관 보기/i }));
+    await user.click(
+      screen.getByRole("button", { name: /Agree and continue/i }),
+    );
+    await user.click(
+      screen.getByRole("button", { name: /개인정보처리방침 보기/i }),
+    );
+    await user.click(
+      screen.getByRole("button", { name: /Agree and continue/i }),
+    );
 
     await user.click(screen.getByRole("button", { name: /회원가입/i }));
 
@@ -270,8 +289,8 @@ describe("회원가입 폼 검증", () => {
     ).toBeInTheDocument();
 
     // 2️⃣ 접근성 연결 검증
-    const termsCheckbox = screen.getByRole("checkbox", { name: /이용약관/i });
-    const privacyCheckbox = screen.getByRole("checkbox", { name: /개인정보/i });
+    const termsCheckbox = screen.getByTestId("terms-of-service-checkbox");
+    const privacyCheckbox = screen.getByTestId("privacy-policy-checkbox");
 
     expect(termsCheckbox).toHaveAttribute(
       "aria-describedby",


### PR DESCRIPTION
## 개요

회원가입 약관 동의 과정에서  모달 열람 이후에만 체크가 가능하도록 인터랙션 제어 로직을 추가했다.

## PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] UI 디자인 변경
- [x] 코드 리팩토링
- [x] 테스트 추가/수정
- [ ] 문서 수정
- [ ] 빌드/패키지 설정 변경

## 관련 이슈

closes #121 

## 작업 내용

- radix-ui 기반 Dialog로 기존 dialog.tsx 교체
- LegalDialogWrapper 컴포넌트 구현
- SignupForm에 약관 인터랙션 제어 상태(interactionEnabled) 추가
- 체크박스 / 라벨 / 키보드 입력 인터셉트 로직 구현
- aria-disabled 기반 접근성 제어 적용
- 모달 동의 시 체크 반영 및 상태 전이 로직 구현
- reset 시 약관 상태 초기화 로직 추가
- 약관 인터랙션 관련 테스트 신규 작성
- 기존 체크박스 직접 클릭 기반 테스트를 모달 경유 방식으로 수정

## 테스트 방법

```
npx vitest run \
  src/features/auth/signup/components/SignupPageClient.test.tsx \
  src/features/auth/signup/components/tests/LegalDialogWrapper.test.tsx \
  src/features/auth/signup/components/tests/SignupForm.agreement-interaction-validation.test.tsx \
  src/features/auth/signup/components/tests/SignupForm.agreement-interaction.test.tsx \
  src/features/auth/signup/components/tests/SignupForm.global-error.test.tsx \
  src/features/auth/signup/components/tests/SignupForm.render.test.tsx \
  src/features/auth/signup/components/tests/SignupForm.responsive.test.tsx \
  src/features/auth/signup/components/tests/SignupForm.server-error.test.tsx \
  src/features/auth/signup/components/tests/SignupForm.submit.test.tsx \
  src/features/auth/signup/components/tests/SignupForm.validation.test.tsx

```

```
npx vitest run 'src/features/auth/signup/components/SignupPageClient.test.tsx' 'src/features/auth/signup/components/tests/LegalDialogWrapper.test.tsx' 'src/features/auth/signup/components/tests/SignupForm.agreement-interaction-validation.test.tsx' 'src/features/auth/signup/components/tests/SignupForm.agreement-interaction.test.tsx' 'src/features/auth/signup/components/tests/SignupForm.global-error.test.tsx' 'src/features/auth/signup/components/tests/SignupForm.render.test.tsx' 'src/features/auth/signup/components/tests/SignupForm.responsive.test.tsx' 'src/features/auth/signup/components/tests/SignupForm.server-error.test.tsx' 'src/features/auth/signup/components/tests/SignupForm.submit.test.tsx' 'src/features/auth/signup/components/tests/SignupForm.validation.test.tsx'

```

## 스크린샷 (FE 변경 시)

<img width="914" height="820" alt="image" src="https://github.com/user-attachments/assets/8db1b298-5369-41b8-a8ab-6941c4561d65" />

![modal](https://github.com/user-attachments/assets/ce044aed-74e6-4494-a577-4fe74418585b)


## 리뷰 요구사항 (선택)

- interactionEnabled 상태 전이 로직이 스펙 의도대로 동작하는지 확인 부탁드립니다.
- checkbox / label / keyboard 인터셉트가 누락된 케이스 없는지 확인 부탁드립니다.

## 체크리스트

- [x] 코드 컨벤션 준수
- [x] 커밋 메시지 컨벤션 준수
- [x] lint 통과
- [x] typecheck 통과
- [ ] (DB 변경 시) migration 포함 및 로컬 재현 확인
- [ ] (권한/RLS 영향 시) 정책 변경 요약 기재
- [ ] UI 변경 시 스크린샷/짧은 설명 첨부
- [x] 셀프 리뷰 완료