### PR TITLE
feat: #127 - avatars 버킷 RLS 정책 추가 및 업로드 경로 변경

### DIFF
--- a/src/app/api/auth/signup/route.ts
+++ b/src/app/api/auth/signup/route.ts
@@ -147,7 +147,7 @@ async function uploadAvatar(
   }
 
   const ext = avatarFile.name.split(".").pop()?.toLowerCase() ?? "jpg";
-  const uploadPath = `${crypto.randomUUID()}.${ext}`;
+  const uploadPath = `${userId}/${crypto.randomUUID()}.${ext}`;
 
   /**
    * Storage 업로드

--- a/src/app/api/auth/signup/tests/route.avatar-upload.test.ts
+++ b/src/app/api/auth/signup/tests/route.avatar-upload.test.ts
@@ -118,9 +118,11 @@ describe("PR-API-07 프로필 이미지 업로드 성공 시 avatar_url 반영",
     expect(body.data.redirectTo).toBe(ROUTES.VERIFY_EMAIL);
   });
 
-  it("TC-02. avatarFile가 포함된 요청 시 storage.upload가 1회 호출된다", async () => {
+  it("TC-02. avatarFile가 포함된 요청 시 storage.upload가 1회 호출되며 userId/ 경로로 업로드된다", async () => {
     await POST(makeMultipartRequest());
     expect(mockStorageUpload).toHaveBeenCalledTimes(1);
+    const uploadPath = mockStorageUpload.mock.calls[0]?.[0] as string;
+    expect(uploadPath).toMatch(/^user-id\//);
   });
 
   it("TC-03. upload 경로로 getPublicUrl이 1회 호출된다", async () => {

--- a/supabase/migrations/20260416000000_add_avatars_storage_rls.sql
+++ b/supabase/migrations/20260416000000_add_avatars_storage_rls.sql
@@ -1,14 +1,9 @@
 -- avatars 버킷 RLS 정책
 --
 -- 설계 원칙:
--- - SELECT: 전체 공개 (public 버킷)
+-- - SELECT: 정책 없음 (public 버킷은 URL 서빙에 SELECT RLS 불필요, 열거 방지)
 -- - INSERT/UPDATE/DELETE: 인증 유저 본인 폴더({auth.uid()}/)만 허용
 -- - 회원가입 업로드는 service_role(adminClient)로 처리되어 RLS 우회
-
--- SELECT: 전체 공개
-CREATE POLICY "avatars_public_select"
-  ON storage.objects FOR SELECT
-  USING (bucket_id = 'avatars');
 
 -- INSERT: 인증 유저가 본인 폴더에만 업로드 가능
 CREATE POLICY "avatars_authenticated_insert"

--- a/supabase/migrations/20260416000000_add_avatars_storage_rls.sql
+++ b/supabase/migrations/20260416000000_add_avatars_storage_rls.sql
@@ -1,0 +1,38 @@
+-- avatars 버킷 RLS 정책
+--
+-- 설계 원칙:
+-- - SELECT: 전체 공개 (public 버킷)
+-- - INSERT/UPDATE/DELETE: 인증 유저 본인 폴더({auth.uid()}/)만 허용
+-- - 회원가입 업로드는 service_role(adminClient)로 처리되어 RLS 우회
+
+-- SELECT: 전체 공개
+CREATE POLICY "avatars_public_select"
+  ON storage.objects FOR SELECT
+  USING (bucket_id = 'avatars');
+
+-- INSERT: 인증 유저가 본인 폴더에만 업로드 가능
+CREATE POLICY "avatars_authenticated_insert"
+  ON storage.objects FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    bucket_id = 'avatars'
+    AND (storage.foldername(name))[1] = auth.uid()::text
+  );
+
+-- UPDATE: 인증 유저가 본인 폴더 파일만 수정 가능
+CREATE POLICY "avatars_authenticated_update"
+  ON storage.objects FOR UPDATE
+  TO authenticated
+  USING (
+    bucket_id = 'avatars'
+    AND (storage.foldername(name))[1] = auth.uid()::text
+  );
+
+-- DELETE: 인증 유저가 본인 폴더 파일만 삭제 가능
+CREATE POLICY "avatars_authenticated_delete"
+  ON storage.objects FOR DELETE
+  TO authenticated
+  USING (
+    bucket_id = 'avatars'
+    AND (storage.foldername(name))[1] = auth.uid()::text
+  );


### PR DESCRIPTION
## 개요
avatars Storage 버킷에 RLS 정책이 없어 접근 제어가 불가능한 상태.
인증 유저가 본인 폴더({user_id}/)에만 업로드/수정/삭제할 수 있도록
정책 4개를 추가하고, 회원가입 아바타 업로드 경로를 유저 폴더 구조로 변경.

## PR 유형
- [x] 새로운 기능 추가

## 관련 이슈
closes #127

## 작업 내용
- `supabase/migrations/20260416000000_add_avatars_storage_rls.sql`: avatars 버킷 RLS 정책 4개 추가
  - SELECT: 전체 공개
  - INSERT/UPDATE/DELETE: 인증 유저, 본인 폴더({auth.uid()}/) 한정
- `src/app/api/auth/signup/route.ts`: 아바타 업로드 경로 변경
  - `{uuid}.ext` → `{userId}/{uuid}.ext` (유저 폴더 기반 RLS 적용)

## 테스트 방법
1. Supabase 대시보드 Storage > Policies에서 4개 정책 확인
2. 회원가입 시 아바타 포함 가입 후 Storage > avatars 버킷에서 `{user_id}/` 폴더 구조로 파일 생성 확인

## 스크린샷 (FE 변경 시)
해당 없음

## 리뷰 요구사항 (선택)
- 회원가입은 adminClient(service_role) 사용으로 RLS 우회 — INSERT 정책은 향후 마이페이지 직접 업로드 시 적용됨

## 체크리스트
- [x] 코드 컨벤션 준수
- [x] 커밋 메시지 컨벤션 준수
- [x] lint 통과
- [x] typecheck 통과
- [x] (DB 변경 시) migration 포함 및 로컬 재현 확인
- [x] (권한/RLS 영향 시) 정책 변경 요약 기재
- [ ] UI 변경 시 스크린샷/짧은 설명 첨부
- [x] 셀프 리뷰 완료