### PR TITLE
feat: #138 리뷰 rpc에 이메일 인증 가드 추가

### DIFF
--- a/src/features/review/README.md
+++ b/src/features/review/README.md
@@ -45,3 +45,10 @@
 ### 이메일 인증
 
 회원가입 플로우에서 magiclink 클릭 전까지 `email_confirmed_at`이 비어 있다. Supabase `User` shape에서는 이 값이 `null` 또는 `undefined`일 수 있으므로, 복습 관련 모든 엔트리포인트(페이지, `submitAnswerAction`, `completeReviewAction`)에서 `email_confirmed_at == null` 기준으로 `/verify-email`로 redirect한다.
+
+이메일 인증 가드는 두 층으로 구성된다:
+
+- **앱 레벨 (UX)**: 페이지/서버 액션에서 `email_confirmed_at == null` 시 `/verify-email` redirect. 사용자가 UI를 통해 복습 플로우에 진입하는 경우를 담당.
+- **DB 레벨 (쓰기 차단)**: `complete_review_and_schedule_next` RPC 본문에서 `auth.users.email_confirmed_at`이 `NULL`이면 `email not confirmed` 예외로 쓰기 자체를 차단. 서버 액션을 우회해 RPC/REST로 직접 호출하는 경로를 방어.
+
+RPC 에러는 `completeReviewAction`에서 기존 공통 실패 메시지로 변환되므로 사용자-facing 메시지 정책은 불변. 이슈 #138 참고.

--- a/supabase/migrations/20260420000000_enforce_email_confirmed_in_complete_review_rpc.sql
+++ b/supabase/migrations/20260420000000_enforce_email_confirmed_in_complete_review_rpc.sql
@@ -1,0 +1,87 @@
+CREATE OR REPLACE FUNCTION public.complete_review_and_schedule_next(
+  p_note_id uuid,
+  p_review_log_id uuid
+)
+RETURNS uuid
+LANGUAGE plpgsql
+-- review_logs intentionally has no UPDATE policy, so this RPC performs the
+-- ownership check explicitly and updates the locked row within the same transaction.
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_user_id uuid := auth.uid();
+  v_email_confirmed_at timestamptz;
+  v_current_round integer;
+  v_note_review_round integer;
+  v_next_review_at timestamptz;
+  -- Use wall-clock time so completion and the next schedule share the same actual timestamp.
+  v_now timestamptz := clock_timestamp();
+BEGIN
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'not authenticated';
+  END IF;
+
+  -- DB-level guard mirroring the app-level email verification redirects so that
+  -- direct RPC callers cannot bypass the "verified email required" policy.
+  SELECT email_confirmed_at
+    INTO v_email_confirmed_at
+  FROM auth.users
+  WHERE id = v_user_id;
+
+  IF v_email_confirmed_at IS NULL THEN
+    RAISE EXCEPTION 'email not confirmed';
+  END IF;
+
+  IF p_note_id IS NULL OR p_review_log_id IS NULL THEN
+    RAISE EXCEPTION 'note_id and review_log_id are required';
+  END IF;
+
+  SELECT rl.round, n.review_round
+    INTO v_current_round, v_note_review_round
+  FROM public.review_logs rl
+  JOIN public.notes n
+    ON n.id = rl.note_id
+  WHERE rl.id = p_review_log_id
+    AND rl.note_id = p_note_id
+    AND rl.user_id = v_user_id
+    AND rl.completed_at IS NULL
+    AND n.user_id = v_user_id
+  FOR UPDATE OF rl, n;
+
+  IF v_current_round IS NULL THEN
+    RAISE EXCEPTION 'pending review log not found';
+  END IF;
+
+  IF v_current_round <> v_note_review_round + 1 THEN
+    RAISE EXCEPTION 'review log round does not match current note state';
+  END IF;
+
+  -- Keep this in sync with REVIEW_INTERVALS_DAYS ([1, 3, 7]) so callers
+  -- cannot bypass the spaced-repetition cadence by supplying arbitrary dates.
+  v_next_review_at := CASE v_current_round
+    WHEN 1 THEN v_now + interval '3 days'
+    WHEN 2 THEN v_now + interval '7 days'
+    ELSE NULL
+  END;
+
+  UPDATE public.review_logs
+  SET completed_at = v_now
+  WHERE id = p_review_log_id
+    AND note_id = p_note_id
+    AND user_id = v_user_id;
+
+  UPDATE public.notes
+  SET review_round = v_current_round,
+      next_review_at = v_next_review_at
+  WHERE id = p_note_id
+    AND user_id = v_user_id;
+
+  IF v_current_round < 3 THEN
+    INSERT INTO public.review_logs (note_id, user_id, round, scheduled_at)
+    VALUES (p_note_id, v_user_id, v_current_round + 1, v_next_review_at);
+  END IF;
+
+  RETURN p_note_id;
+END;
+$$;

--- a/supabase/tests/review_logs/complete_review_and_schedule_next.sql
+++ b/supabase/tests/review_logs/complete_review_and_schedule_next.sql
@@ -4,31 +4,42 @@
 
 BEGIN;
 
-SELECT plan(17);
+SELECT plan(18);
 
 SELECT set_config('test.review_complete_user_a_id', gen_random_uuid()::text, true);
 SELECT set_config('test.review_complete_user_b_id', gen_random_uuid()::text, true);
+SELECT set_config('test.review_complete_user_unverified_id', gen_random_uuid()::text, true);
 SELECT set_config('test.review_complete_note_round1_id', gen_random_uuid()::text, true);
 SELECT set_config('test.review_complete_note_round2_id', gen_random_uuid()::text, true);
 SELECT set_config('test.review_complete_note_round3_id', gen_random_uuid()::text, true);
 SELECT set_config('test.review_complete_note_other_id', gen_random_uuid()::text, true);
 SELECT set_config('test.review_complete_note_mismatch_id', gen_random_uuid()::text, true);
+SELECT set_config('test.review_complete_note_unverified_id', gen_random_uuid()::text, true);
 SELECT set_config('test.review_complete_log_round1_id', gen_random_uuid()::text, true);
 SELECT set_config('test.review_complete_log_round2_id', gen_random_uuid()::text, true);
 SELECT set_config('test.review_complete_log_round3_id', gen_random_uuid()::text, true);
 SELECT set_config('test.review_complete_log_other_id', gen_random_uuid()::text, true);
 SELECT set_config('test.review_complete_log_mismatch_id', gen_random_uuid()::text, true);
+SELECT set_config('test.review_complete_log_unverified_id', gen_random_uuid()::text, true);
 
-INSERT INTO auth.users (id, email, raw_user_meta_data)
+INSERT INTO auth.users (id, email, email_confirmed_at, raw_user_meta_data)
 VALUES
   (
     current_setting('test.review_complete_user_a_id')::uuid,
     'review_complete_user_a_' || current_setting('test.review_complete_user_a_id') || '@example.com',
+    now(),
     '{}'::jsonb
   ),
   (
     current_setting('test.review_complete_user_b_id')::uuid,
     'review_complete_user_b_' || current_setting('test.review_complete_user_b_id') || '@example.com',
+    now(),
+    '{}'::jsonb
+  ),
+  (
+    current_setting('test.review_complete_user_unverified_id')::uuid,
+    'review_complete_user_unverified_' || current_setting('test.review_complete_user_unverified_id') || '@example.com',
+    NULL,
     '{}'::jsonb
   )
 ON CONFLICT (id) DO NOTHING;
@@ -74,6 +85,14 @@ VALUES
     'mismatch content',
     0,
     '2026-01-06T00:00:00Z'::timestamptz
+  ),
+  (
+    current_setting('test.review_complete_note_unverified_id')::uuid,
+    current_setting('test.review_complete_user_unverified_id')::uuid,
+    'unverified note',
+    'unverified content',
+    0,
+    '2026-01-07T00:00:00Z'::timestamptz
   );
 
 INSERT INTO public.review_logs (id, note_id, user_id, round, scheduled_at)
@@ -112,6 +131,13 @@ VALUES
     current_setting('test.review_complete_user_a_id')::uuid,
     2,
     '2026-01-06T00:00:00Z'::timestamptz
+  ),
+  (
+    current_setting('test.review_complete_log_unverified_id')::uuid,
+    current_setting('test.review_complete_note_unverified_id')::uuid,
+    current_setting('test.review_complete_user_unverified_id')::uuid,
+    1,
+    '2026-01-07T00:00:00Z'::timestamptz
   );
 
 SET LOCAL ROLE anon;
@@ -321,6 +347,27 @@ SELECT throws_ok(
   'P0001',
   'review log round does not match current note state',
   $$out-of-order review logs should be rejected$$
+);
+
+SELECT set_config(
+  'request.jwt.claims',
+  json_build_object(
+    'sub', current_setting('test.review_complete_user_unverified_id'),
+    'role', 'authenticated'
+  )::text,
+  true
+);
+
+SELECT throws_ok(
+  $sql$
+    SELECT public.complete_review_and_schedule_next(
+      current_setting('test.review_complete_note_unverified_id')::uuid,
+      current_setting('test.review_complete_log_unverified_id')::uuid
+    );
+  $sql$,
+  'P0001',
+  'email not confirmed',
+  $$unverified users should be blocked by the DB-level guard$$
 );
 
 SELECT * FROM finish();


### PR DESCRIPTION
## 개요

복습 완료 RPC(`complete_review_and_schedule_next`)에 DB 레벨 이메일 인증 가드를 추가했습니다.

기존에는 페이지/서버 액션에서만 `email_confirmed_at == null` 사용자를 `/verify-email`로 리다이렉트했기 때문에, 직접 RPC/REST를 호출하는 경로에서는 복습 완료 쓰기를 우회할 여지가 있었습니다. 이번 PR은 그 우회 경로를 DB 레벨에서 막아 "이메일 인증된 사용자만 복습 완료 가능" 정책을 일관되게 보장합니다.

## PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] UI 디자인 변경
- [ ] 코드 리팩토링
- [x] 테스트 추가/수정
- [x] 문서 수정
- [ ] 빌드/패키지 설정 변경

## 관련 이슈

closes #138

## 작업 내용

- `complete_review_and_schedule_next` RPC 본문에 `auth.users.email_confirmed_at` 확인 로직을 추가했습니다.
- 인증되지 않은 사용자가 RPC를 직접 호출하면 `email not confirmed` 예외로 쓰기를 차단하도록 했습니다.
- pgTAP 테스트에 미인증 사용자 fixture와 차단 시나리오를 추가했습니다.
- `src/features/review/README.md`에 이메일 인증 가드가 앱 레벨과 DB 레벨의 2중 방어로 동작한다는 점을 문서화했습니다.
- 권한/정책 영향 요약:
  - 앱 레벨: `/verify-email` 리다이렉트로 UX 가드 유지
  - DB 레벨: 직접 RPC/REST 호출 우회 차단 추가
  - RLS 정책 자체를 변경한 것은 아니고, `SECURITY DEFINER` RPC 내부 검증을 강화했습니다.

## 테스트 방법

1. `supabase test db supabase/tests/review_logs/complete_review_and_schedule_next.sql`
2. `npm run lint`
3. `npm run type-check`

확인 포인트:
- 미인증 사용자는 RPC 호출 시 `email not confirmed`로 차단되는지
- 기존 round 1/2/3 복습 완료 및 다음 회차 스케줄링 동작이 유지되는지
- 앱 레벨 문서 설명과 DB 동작이 일치하는지

참고:
- `npm run lint`는 통과했지만 변경 범위 밖 기존 warning 5건이 있습니다.

## 스크린샷 (FE 변경 시)

해당 없음

## 리뷰 요구사항 (선택)

앱 레벨 리다이렉트가 이미 있는데도 DB 레벨 가드를 추가한 이유가 적절한지 중점적으로 봐주시면 좋겠습니다. 의도는 UX 가드와 쓰기 차단을 분리해서, 직접 RPC 호출 우회 경로까지 막는 것입니다.

## 체크리스트

- [x] 코드 컨벤션 준수
- [x] 커밋 메시지 컨벤션 준수
- [x] lint 통과
- [x] typecheck 통과
- [x] (DB 변경 시) migration 포함 및 로컬 재현 확인
- [x] (권한/RLS 영향 시) 정책 변경 요약 기재
- [ ] UI 변경 시 스크린샷/짧은 설명 첨부
- [x] 셀프 리뷰 완료
