### PR TITLE
feat: #145 - 헤더 네비게이션 UX 및 접근성 개선

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -32,7 +32,7 @@ export async function Header() {
 
   return (
     <header className="sticky top-0 z-50 border-b bg-background/80 backdrop-blur-sm">
-      <div className="grid grid-cols-3 items-center max-w-5xl mx-auto px-6 py-3.5">
+      <div className="flex justify-between md:grid md:grid-cols-3 items-center max-w-5xl mx-auto px-6 py-3.5">
         <Link href={ROUTES.HOME} className="flex items-center gap-2">
           <Image src="/favicon.svg" alt="딱다구리" width={28} height={28} />
           {/* font-jeju: 브랜드 폰트(JejuStoneWall), globals.css @font-face 참조 */}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -7,6 +7,7 @@ import { getUser } from "@/lib/supabase/getUser";
 import { createServerComponentClient } from "@/lib/supabase/server";
 import type { Profile } from "@/types/profiles.types";
 
+import { NotesNav } from "./NotesNav";
 import { UserMenu } from "./UserMenu";
 
 export async function Header() {
@@ -31,14 +32,18 @@ export async function Header() {
 
   return (
     <header className="sticky top-0 z-50 border-b bg-background/80 backdrop-blur-sm">
-      <div className="flex items-center justify-between max-w-5xl mx-auto px-6 py-3.5">
+      <div className="grid grid-cols-3 items-center max-w-5xl mx-auto px-6 py-3.5">
         <Link href={ROUTES.HOME} className="flex items-center gap-2">
           <Image src="/favicon.svg" alt="딱다구리" width={28} height={28} />
           {/* font-jeju: 브랜드 폰트(JejuStoneWall), globals.css @font-face 참조 */}
           <span className="font-jeju text-2xl">딱다구리</span>
         </Link>
 
-        <div className="flex gap-3">
+        <div className="flex justify-center">
+          {profile && user && <NotesNav />}
+        </div>
+
+        <div className="flex justify-end gap-3 items-center">
           {profile && user ? (
             <UserMenu
               nickname={profile.nickname}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -39,7 +39,7 @@ export async function Header() {
           <span className="font-jeju text-2xl">딱다구리</span>
         </Link>
 
-        <div className="flex justify-center">
+        <div className="hidden md:flex justify-center">
           {profile && user && <NotesNav />}
         </div>
 

--- a/src/components/layout/NotesNav.tsx
+++ b/src/components/layout/NotesNav.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Plus } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 
@@ -8,16 +9,17 @@ import { ROUTES } from "@/lib/constants/routes";
 export function NotesNav() {
   const pathname = usePathname();
   const isNotesList =
-    pathname === ROUTES.NOTES ||
-    (pathname.startsWith("/notes") && pathname !== ROUTES.NOTES_NEW);
+    pathname.startsWith(ROUTES.NOTES) && pathname !== ROUTES.NOTES_NEW;
+  const isNotesNew = pathname === ROUTES.NOTES_NEW;
 
   return (
     <nav className="flex items-center gap-6">
       <Link
         href={ROUTES.NOTES}
+        aria-current={isNotesList ? "page" : undefined}
         className={`text-base font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-sm ${
           isNotesList
-            ? "text-foreground"
+            ? "text-foreground font-semibold"
             : "text-muted-foreground hover:text-foreground"
         }`}
       >
@@ -25,9 +27,14 @@ export function NotesNav() {
       </Link>
       <Link
         href={ROUTES.NOTES_NEW}
-        className="text-base font-medium px-4 py-1.5 rounded-full cursor-pointer bg-[var(--color-orange-200)]/50 hover:bg-[var(--color-orange-200)] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        aria-current={isNotesNew ? "page" : undefined}
+        className={`text-base font-medium px-4 py-1.5 rounded-full transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring flex items-center gap-1 ${
+          isNotesNew
+            ? "bg-orange-200 text-foreground font-semibold"
+            : "bg-orange-200/50 hover:bg-orange-200"
+        }`}
       >
-        + 새 노트
+        <Plus size={16} />새 노트
       </Link>
     </nav>
   );

--- a/src/components/layout/NotesNav.tsx
+++ b/src/components/layout/NotesNav.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+import { ROUTES } from "@/lib/constants/routes";
+
+export function NotesNav() {
+  const pathname = usePathname();
+  const isNotesList =
+    pathname === ROUTES.NOTES ||
+    (pathname.startsWith("/notes") && pathname !== ROUTES.NOTES_NEW);
+
+  return (
+    <nav className="flex items-center gap-6">
+      <Link
+        href={ROUTES.NOTES}
+        className={`text-base font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-sm ${
+          isNotesList
+            ? "text-foreground"
+            : "text-muted-foreground hover:text-foreground"
+        }`}
+      >
+        노트 목록
+      </Link>
+      <Link
+        href={ROUTES.NOTES_NEW}
+        className="text-base font-medium px-4 py-1.5 rounded-full cursor-pointer bg-[var(--color-orange-200)]/50 hover:bg-[var(--color-orange-200)] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      >
+        + 새 노트
+      </Link>
+    </nav>
+  );
+}

--- a/src/components/layout/UserMenu.tsx
+++ b/src/components/layout/UserMenu.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { LogOut, Settings, User } from "lucide-react";
+import { LogOut, User } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
 import { useEffect, useRef, useState, useTransition } from "react";
@@ -20,13 +20,20 @@ export function UserMenu({ nickname, email, avatarUrl }: UserMenuProps) {
   const ref = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    const handler = (e: MouseEvent) => {
+    const handleMouseDown = (e: MouseEvent) => {
       if (ref.current && !ref.current.contains(e.target as Node)) {
         setOpen(false);
       }
     };
-    document.addEventListener("mousedown", handler);
-    return () => document.removeEventListener("mousedown", handler);
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("mousedown", handleMouseDown);
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("mousedown", handleMouseDown);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
   }, []);
 
   return (
@@ -72,14 +79,6 @@ export function UserMenu({ nickname, email, avatarUrl }: UserMenuProps) {
               <User className="size-4" />
               마이페이지
             </Link>
-            {/* <Link
-              href={`${ROUTES.MYPAGE}?section=account`}
-              onClick={() => setOpen(false)}
-              className="flex items-center gap-2 px-4 py-2 text-sm transition-colors hover:bg-accent"
-            >
-              <Settings className="size-4" />
-              계정 설정
-            </Link> */}
           </div>
 
           <div className="border-t" />

--- a/src/components/layout/UserMenu.tsx
+++ b/src/components/layout/UserMenu.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { LogOut, User } from "lucide-react";
+import { BookOpen, LogOut, Plus, User } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
 import { useEffect, useRef, useState, useTransition } from "react";
@@ -68,6 +68,27 @@ export function UserMenu({ nickname, email, avatarUrl }: UserMenuProps) {
           </div>
 
           <div className="border-t" />
+
+          {/* 노트 메뉴 — 모바일에서만 표시 */}
+          <div className="py-1 md:hidden">
+            <Link
+              href={ROUTES.NOTES}
+              onClick={() => setOpen(false)}
+              className="flex items-center gap-2 px-4 py-2 text-sm transition-colors hover:bg-accent"
+            >
+              <BookOpen className="size-4" />
+              노트 목록
+            </Link>
+            <Link
+              href={ROUTES.NOTES_NEW}
+              onClick={() => setOpen(false)}
+              className="flex items-center gap-2 px-4 py-2 text-sm transition-colors hover:bg-accent"
+            >
+              <Plus className="size-4" />새 노트
+            </Link>
+          </div>
+
+          <div className="border-t md:hidden" />
 
           {/* 메뉴 항목 */}
           <div className="py-1">


### PR DESCRIPTION
## 개요

로그인한 사용자에게 헤더 중앙에 노트 네비게이션을 제공하고, 드롭다운 메뉴의 키보드 접근성을 개선합니다.

## PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] UI 디자인 변경
- [x] 코드 리팩토링
- [ ] 테스트 추가/수정
- [ ] 문서 수정
- [ ] 빌드/패키지 설정 변경

## 관련 이슈

closes #145

## 작업 내용

- `NotesNav.tsx` 신규 생성 — 로그인 사용자 전용 헤더 중앙 네비게이션 (노트 목록 / + 새 노트), 현재 경로 기반 active 상태 표시
- `Header.tsx` — 레이아웃을 `flex justify-between` → `grid grid-cols-3`으로 변경, 로그인 시 `NotesNav` 렌더링
- `UserMenu.tsx` — Escape 키 닫기 지원, 미사용 `Settings` 아이콘 및 주석 코드 제거

## 테스트 방법

1. 로그인 → 헤더 중앙에 "노트 목록" / "+ 새 노트" 링크 확인
2. 각 링크 클릭 후 active 스타일 변경 확인
3. UserMenu 열기 → Escape 키로 닫히는지 확인
4. 비로그인 상태에서 NotesNav가 렌더링되지 않는지 확인

## 스크린샷 (FE 변경 시)

<img width="1263" height="89" alt="스크린샷 2026-04-21 111923" src="https://github.com/user-attachments/assets/4fe8886b-1e7c-4fd6-b859-2aac8d6b0372" />

## 리뷰 요구사항 (선택)

- `NotesNav`의 active 조건 (`pathname.startsWith("/notes") && pathname !== ROUTES.NOTES_NEW`) 로직이 의도에 맞는지 확인 부탁드립니다.

## 체크리스트

- [x] 코드 컨벤션 준수
- [x] 커밋 메시지 컨벤션 준수
- [x] lint 통과
- [x] typecheck 통과
- [ ] (DB 변경 시) migration 포함 및 로컬 재현 확인
- [ ] (권한/RLS 영향 시) 정책 변경 요약 기재
- [x] UI 변경 시 스크린샷/짧은 설명 첨부 <!-- TODO: 스크린샷 첨부 필요 -->
- [ ] 셀프 리뷰 완료