### PR TITLE
feat: #149 - 이메일 미인증 사용자의 노트 쓰기 차단 가드 추가

### DIFF
--- a/src/app/(main)/notes/[noteId]/page.test.tsx
+++ b/src/app/(main)/notes/[noteId]/page.test.tsx
@@ -39,12 +39,20 @@ vi.mock("next/navigation", () => ({
 
 import NoteDetailPage from "./page";
 
-function createSupabaseMock(userId: string | null) {
+function createSupabaseMock(
+  userId: string | null,
+  emailConfirmedAt?: string | null,
+) {
+  const resolvedEmailConfirmedAt =
+    arguments.length > 1 ? emailConfirmedAt : "2026-03-29T00:00:00.000Z";
+
   return {
     auth: {
       getUser: vi.fn().mockResolvedValue({
         data: {
-          user: userId ? { id: userId } : null,
+          user: userId
+            ? { id: userId, email_confirmed_at: resolvedEmailConfirmedAt }
+            : null,
         },
       }),
     },
@@ -83,6 +91,22 @@ describe("NoteDetailPage", () => {
     expect(redirectMock).toHaveBeenCalledWith(ROUTES.LOGIN);
     expect(getNoteByIdMock).not.toHaveBeenCalled();
   });
+
+  it.each([null, undefined])(
+    "redirects to verify email when email_confirmed_at is %s",
+    async (emailConfirmedAt) => {
+      createClientMock.mockResolvedValue(
+        createSupabaseMock("user-123", emailConfirmedAt),
+      );
+
+      await expect(
+        NoteDetailPage({ params: Promise.resolve({ noteId: "note-123" }) }),
+      ).rejects.toBe(REDIRECT_ERROR);
+
+      expect(redirectMock).toHaveBeenCalledWith(ROUTES.VERIFY_EMAIL);
+      expect(getNoteByIdMock).not.toHaveBeenCalled();
+    },
+  );
 
   it("renders a review entry point when the note is due for review", async () => {
     createClientMock.mockResolvedValue(createSupabaseMock("user-123"));

--- a/src/app/(main)/notes/[noteId]/page.tsx
+++ b/src/app/(main)/notes/[noteId]/page.tsx
@@ -31,6 +31,10 @@ export default async function NoteDetailPage({
     redirect(ROUTES.LOGIN);
   }
 
+  if (user.email_confirmed_at == null) {
+    redirect(ROUTES.VERIFY_EMAIL);
+  }
+
   const note = await getNoteById(noteId, user.id);
 
   if (!note) {

--- a/src/app/(main)/notes/new/page.test.tsx
+++ b/src/app/(main)/notes/new/page.test.tsx
@@ -24,12 +24,20 @@ vi.mock("@/features/notes/components/NoteForm", () => ({
 
 import NewNotePage from "./page";
 
-function createSupabaseMock(userId: string | null) {
+function createSupabaseMock(
+  userId: string | null,
+  emailConfirmedAt?: string | null,
+) {
+  const resolvedEmailConfirmedAt =
+    arguments.length > 1 ? emailConfirmedAt : "2026-03-29T00:00:00.000Z";
+
   return {
     auth: {
       getUser: vi.fn().mockResolvedValue({
         data: {
-          user: userId ? { id: userId } : null,
+          user: userId
+            ? { id: userId, email_confirmed_at: resolvedEmailConfirmedAt }
+            : null,
         },
       }),
     },
@@ -53,6 +61,19 @@ describe("NewNotePage", () => {
 
     expect(redirectMock).toHaveBeenCalledWith(ROUTES.LOGIN);
   });
+
+  it.each([null, undefined])(
+    "redirects to verify email when email_confirmed_at is %s",
+    async (emailConfirmedAt) => {
+      createClientMock.mockResolvedValue(
+        createSupabaseMock("user-123", emailConfirmedAt),
+      );
+
+      await expect(NewNotePage()).rejects.toBe(REDIRECT_ERROR);
+
+      expect(redirectMock).toHaveBeenCalledWith(ROUTES.VERIFY_EMAIL);
+    },
+  );
 
   it("renders the note form when the user is authenticated", async () => {
     createClientMock.mockResolvedValue(createSupabaseMock("user-123"));

--- a/src/app/(main)/notes/new/page.tsx
+++ b/src/app/(main)/notes/new/page.tsx
@@ -20,5 +20,9 @@ export default async function NewNotePage() {
     redirect(ROUTES.LOGIN);
   }
 
+  if (user.email_confirmed_at == null) {
+    redirect(ROUTES.VERIFY_EMAIL);
+  }
+
   return <NoteForm />;
 }

--- a/src/app/(main)/notes/page.test.tsx
+++ b/src/app/(main)/notes/page.test.tsx
@@ -25,12 +25,20 @@ vi.mock("next/navigation", () => ({
 
 import NotesPage from "./page";
 
-function createSupabaseMock(userId: string | null) {
+function createSupabaseMock(
+  userId: string | null,
+  emailConfirmedAt?: string | null,
+) {
+  const resolvedEmailConfirmedAt =
+    arguments.length > 1 ? emailConfirmedAt : "2026-03-29T00:00:00.000Z";
+
   return {
     auth: {
       getUser: vi.fn().mockResolvedValue({
         data: {
-          user: userId ? { id: userId } : null,
+          user: userId
+            ? { id: userId, email_confirmed_at: resolvedEmailConfirmedAt }
+            : null,
         },
       }),
     },
@@ -56,6 +64,20 @@ describe("NotesPage", () => {
     expect(redirectMock).toHaveBeenCalledWith(ROUTES.LOGIN);
     expect(getNotesMock).not.toHaveBeenCalled();
   });
+
+  it.each([null, undefined])(
+    "redirects to verify email when email_confirmed_at is %s",
+    async (emailConfirmedAt) => {
+      createClientMock.mockResolvedValue(
+        createSupabaseMock("user-123", emailConfirmedAt),
+      );
+
+      await expect(NotesPage()).rejects.toBe(REDIRECT_ERROR);
+
+      expect(redirectMock).toHaveBeenCalledWith(ROUTES.VERIFY_EMAIL);
+      expect(getNotesMock).not.toHaveBeenCalled();
+    },
+  );
 
   it("renders the note list for authenticated users", async () => {
     createClientMock.mockResolvedValue(createSupabaseMock("user-123"));

--- a/src/app/(main)/notes/page.tsx
+++ b/src/app/(main)/notes/page.tsx
@@ -23,6 +23,10 @@ export default async function NotesPage() {
     redirect(ROUTES.LOGIN);
   }
 
+  if (user.email_confirmed_at == null) {
+    redirect(ROUTES.VERIFY_EMAIL);
+  }
+
   const notes = await getNotes(user.id);
 
   return (

--- a/src/features/notes/actions.ts
+++ b/src/features/notes/actions.ts
@@ -48,6 +48,10 @@ export async function createNoteAction(
     return { error: "로그인이 필요합니다." };
   }
 
+  if (user.email_confirmed_at == null) {
+    redirect(ROUTES.VERIFY_EMAIL);
+  }
+
   const firstReviewDate = getNextReviewDate(0);
 
   if (!firstReviewDate) {
@@ -85,6 +89,10 @@ export async function deleteNoteAction(noteId: string) {
 
   if (!user) {
     return { error: "로그인이 필요합니다." };
+  }
+
+  if (user.email_confirmed_at == null) {
+    redirect(ROUTES.VERIFY_EMAIL);
   }
 
   const { data: deletedNote, error } = await supabase

--- a/src/features/notes/tests/actions.test.ts
+++ b/src/features/notes/tests/actions.test.ts
@@ -19,19 +19,31 @@ vi.mock("next/navigation", () => ({
 
 import { createNoteAction, deleteNoteAction } from "../actions";
 
-function createSupabaseMock({
-  userId = "user-123",
-  rpcError = null,
-  rpcResult = "note-123",
-  deleteError = null,
-  deletedNote = { id: "11111111-1111-4111-8111-111111111111" },
-}: {
-  userId?: string | null;
-  rpcError?: { message: string } | null;
-  rpcResult?: string | null;
-  deleteError?: { message: string } | null;
-  deletedNote?: { id: string } | null;
-} = {}) {
+function createSupabaseMock(
+  input: {
+    userId?: string | null;
+    emailConfirmedAt?: string | null | undefined;
+    rpcError?: { message: string } | null;
+    rpcResult?: string | null;
+    deleteError?: { message: string } | null;
+    deletedNote?: { id: string } | null;
+  } = {},
+) {
+  const {
+    userId = "user-123",
+    emailConfirmedAt,
+    rpcError = null,
+    rpcResult = "note-123",
+    deleteError = null,
+    deletedNote = { id: "11111111-1111-4111-8111-111111111111" },
+  } = input;
+  const resolvedEmailConfirmedAt = Object.prototype.hasOwnProperty.call(
+    input,
+    "emailConfirmedAt",
+  )
+    ? emailConfirmedAt
+    : "2026-03-29T00:00:00.000Z";
+
   const rpcMock = vi.fn().mockResolvedValue({
     data: rpcError ? null : rpcResult,
     error: rpcError,
@@ -68,7 +80,9 @@ function createSupabaseMock({
       auth: {
         getUser: vi.fn().mockResolvedValue({
           data: {
-            user: userId ? { id: userId } : null,
+            user: userId
+              ? { id: userId, email_confirmed_at: resolvedEmailConfirmedAt }
+              : null,
           },
         }),
       },
@@ -140,6 +154,27 @@ describe("createNoteAction", () => {
     expect(result).toEqual({ error: "로그인이 필요합니다." });
     expect(rpcMock).not.toHaveBeenCalled();
   });
+
+  it.each([null, undefined])(
+    "redirects unverified emails to the verify-email route when email_confirmed_at is %s",
+    async (emailConfirmedAt) => {
+      const { supabase, rpcMock } = createSupabaseMock({
+        emailConfirmedAt,
+      });
+      createClientMock.mockResolvedValue(supabase);
+
+      const formData = new FormData();
+      formData.set("title", "Valid title");
+      formData.set("content", "Valid content");
+
+      await expect(createNoteAction(null, formData)).rejects.toBe(
+        REDIRECT_ERROR,
+      );
+
+      expect(redirectMock).toHaveBeenCalledWith(ROUTES.VERIFY_EMAIL);
+      expect(rpcMock).not.toHaveBeenCalled();
+    },
+  );
 
   it("calls the note creation RPC and returns the new note id when the payload is valid", async () => {
     const { supabase, rpcMock } = createSupabaseMock();
@@ -254,6 +289,23 @@ describe("deleteNoteAction", () => {
     expect(result).toEqual({ error: "로그인이 필요합니다." });
     expect(fromMock).not.toHaveBeenCalled();
   });
+
+  it.each([null, undefined])(
+    "redirects unverified emails to the verify-email route when email_confirmed_at is %s",
+    async (emailConfirmedAt) => {
+      const { supabase, fromMock } = createSupabaseMock({
+        emailConfirmedAt,
+      });
+      createClientMock.mockResolvedValue(supabase);
+
+      await expect(
+        deleteNoteAction("11111111-1111-4111-8111-111111111111"),
+      ).rejects.toBe(REDIRECT_ERROR);
+
+      expect(redirectMock).toHaveBeenCalledWith(ROUTES.VERIFY_EMAIL);
+      expect(fromMock).not.toHaveBeenCalled();
+    },
+  );
 
   it("deletes the note and redirects to the notes page", async () => {
     const validNoteId = "11111111-1111-4111-8111-111111111111";

--- a/supabase/migrations/20260421000000_enforce_email_confirmed_in_notes_write_rls.sql
+++ b/supabase/migrations/20260421000000_enforce_email_confirmed_in_notes_write_rls.sql
@@ -1,0 +1,52 @@
+DROP POLICY IF EXISTS "notes_insert_own" ON "public"."notes";
+DROP POLICY IF EXISTS "notes_update_own" ON "public"."notes";
+DROP POLICY IF EXISTS "notes_delete_own" ON "public"."notes";
+
+CREATE OR REPLACE FUNCTION "public"."is_current_user_email_confirmed"()
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT EXISTS (
+    SELECT 1
+    FROM "auth"."users"
+    WHERE "id" = "auth"."uid"()
+      AND "email_confirmed_at" IS NOT NULL
+  );
+$$;
+
+REVOKE ALL ON FUNCTION "public"."is_current_user_email_confirmed"() FROM PUBLIC, anon, authenticated, service_role;
+GRANT EXECUTE ON FUNCTION "public"."is_current_user_email_confirmed"() TO authenticated;
+
+CREATE POLICY "notes_insert_own"
+ON "public"."notes"
+FOR INSERT
+TO "authenticated"
+WITH CHECK (
+  ("auth"."uid"() = "user_id")
+  AND "public"."is_current_user_email_confirmed"()
+);
+
+CREATE POLICY "notes_update_own"
+ON "public"."notes"
+FOR UPDATE
+TO "authenticated"
+USING (
+  ("auth"."uid"() = "user_id")
+  AND "public"."is_current_user_email_confirmed"()
+)
+WITH CHECK (
+  ("auth"."uid"() = "user_id")
+  AND "public"."is_current_user_email_confirmed"()
+);
+
+CREATE POLICY "notes_delete_own"
+ON "public"."notes"
+FOR DELETE
+TO "authenticated"
+USING (
+  ("auth"."uid"() = "user_id")
+  AND "public"."is_current_user_email_confirmed"()
+);

--- a/supabase/tests/notes/rls.sql
+++ b/supabase/tests/notes/rls.sql
@@ -4,17 +4,20 @@
 
 BEGIN;
 
-SELECT plan(32);
+SELECT plan(36);
 
 -- 테스트용 UUID 준비
 SELECT set_config('test.notes_rls_user_a_id', gen_random_uuid()::text, true);
 SELECT set_config('test.notes_rls_user_b_id', gen_random_uuid()::text, true);
+SELECT set_config('test.notes_rls_user_unverified_id', gen_random_uuid()::text, true);
 SELECT set_config('test.notes_rls_note_a_select_id', gen_random_uuid()::text, true);
 SELECT set_config('test.notes_rls_note_a_update_id', gen_random_uuid()::text, true);
 SELECT set_config('test.notes_rls_note_a_delete_id', gen_random_uuid()::text, true);
 SELECT set_config('test.notes_rls_note_b_select_id', gen_random_uuid()::text, true);
 SELECT set_config('test.notes_rls_note_b_update_id', gen_random_uuid()::text, true);
 SELECT set_config('test.notes_rls_note_b_delete_id', gen_random_uuid()::text, true);
+SELECT set_config('test.notes_rls_note_unverified_id', gen_random_uuid()::text, true);
+SELECT set_config('test.notes_rls_note_invalid_unverified_id', gen_random_uuid()::text, true);
 SELECT set_config('test.notes_rls_note_invalid_authenticated_id', gen_random_uuid()::text, true);
 SELECT set_config('test.notes_rls_note_invalid_zero_id', gen_random_uuid()::text, true);
 SELECT set_config('test.notes_rls_note_invalid_one_id', gen_random_uuid()::text, true);
@@ -61,6 +64,19 @@ VALUES
     'user_b_' || current_setting('test.notes_rls_user_b_id') || '@example.com',
     crypt('password123', gen_salt('bf')),
     now(),
+    '{"provider":"email","providers":["email"]}'::jsonb,
+    '{}'::jsonb,
+    now(),
+    now()
+  ),
+  (
+    current_setting('test.notes_rls_user_unverified_id')::uuid,
+    '00000000-0000-0000-0000-000000000000',
+    'authenticated',
+    'authenticated',
+    'user_unverified_' || current_setting('test.notes_rls_user_unverified_id') || '@example.com',
+    crypt('password123', gen_salt('bf')),
+    NULL,
     '{"provider":"email","providers":["email"]}'::jsonb,
     '{}'::jsonb,
     now(),
@@ -124,6 +140,14 @@ VALUES
     'content b delete',
     0,
     now() + interval '6 days'
+  ),
+  (
+    current_setting('test.notes_rls_note_unverified_id')::uuid,
+    current_setting('test.notes_rls_user_unverified_id')::uuid,
+    'note unverified',
+    'content unverified',
+    0,
+    now() + interval '7 days'
   )
 ON CONFLICT (id) DO NOTHING;
 
@@ -305,6 +329,59 @@ SELECT is(
 );
 
 -- [경계 조건]
+SET LOCAL ROLE authenticated;
+SELECT set_config(
+  'request.jwt.claims',
+  json_build_object(
+    'sub', current_setting('test.notes_rls_user_unverified_id'),
+    'role', 'authenticated'
+  )::text,
+  true
+);
+
+SELECT is(
+  (SELECT count(*) FROM public.notes),
+  1::bigint,
+  $$unverified users should still be able to select their own notes$$
+);
+
+SELECT throws_ok(
+  format(
+    $sql$
+      INSERT INTO public.notes (id, user_id, title, content, review_round)
+      VALUES ('%s'::uuid, '%s'::uuid, 'unverified blocked', 'content', 0);
+    $sql$,
+    current_setting('test.notes_rls_note_invalid_unverified_id'),
+    current_setting('test.notes_rls_user_unverified_id')
+  ),
+  '42501',
+  NULL,
+  $$unverified users should not be able to insert notes$$
+);
+
+WITH updated AS (
+  UPDATE public.notes
+  SET title = 'unverified blocked'
+  WHERE id = current_setting('test.notes_rls_note_unverified_id')::uuid
+  RETURNING 1
+)
+SELECT is(
+  (SELECT count(*) FROM updated),
+  0::bigint,
+  $$unverified users should not be able to update notes$$
+);
+
+WITH deleted AS (
+  DELETE FROM public.notes
+  WHERE id = current_setting('test.notes_rls_note_unverified_id')::uuid
+  RETURNING 1
+)
+SELECT is(
+  (SELECT count(*) FROM deleted),
+  0::bigint,
+  $$unverified users should not be able to delete notes$$
+);
+
 SET LOCAL ROLE authenticated;
 SELECT set_config(
   'request.jwt.claims',


### PR DESCRIPTION
## 개요

이메일 인증을 완료하지 않은 사용자가 노트를 생성·수정·삭제하지 못하도록
애플리케이션 레이어(서버 액션/RSC)와 DB 레이어(RLS) 양쪽에 가드를 추가했습니다.
조회(SELECT)는 기존처럼 허용하여 기존 노트는 계속 볼 수 있도록 유지했습니다.

## PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] UI 디자인 변경
- [ ] 코드 리팩토링
- [x] 테스트 추가/수정
- [ ] 문서 수정
- [ ] 빌드/패키지 설정 변경

## 관련 이슈

closes #149

## 작업 내용

- **DB / RLS (defense-in-depth)**
  - `supabase/migrations/20260421000000_enforce_email_confirmed_in_notes_write_rls.sql`
    신규 마이그레이션 추가
  - `public.is_current_user_email_confirmed()` SECURITY DEFINER 함수 추가
    (search_path 고정, PUBLIC/anon/service_role 권한 제거, authenticated 에만 EXECUTE 부여)
  - `notes_insert_own` / `notes_update_own` / `notes_delete_own` 정책을
    `auth.uid() = user_id AND is_current_user_email_confirmed()` 로 재정의
  - SELECT 정책은 의도적으로 변경하지 않음 → 미인증 사용자도 기존 노트 조회는 가능

- **Server Action 가드** ([src/features/notes/actions.ts](src/features/notes/actions.ts))
  - `createNoteAction` / `deleteNoteAction` 에 `email_confirmed_at == null` 시
    `ROUTES.VERIFY_EMAIL` 로 redirect 추가 (RPC / delete 쿼리 이전에 차단)

- **RSC 페이지 가드**
  - [src/app/(main)/notes/page.tsx](<src/app/(main)/notes/page.tsx>)
  - [src/app/(main)/notes/new/page.tsx](<src/app/(main)/notes/new/page.tsx>)
  - [src/app/(main)/notes/[noteId]/page.tsx](<src/app/(main)/notes/[noteId]/page.tsx>)
  - 각 페이지에서 로그인 체크 직후 이메일 인증 여부 확인 → 미인증 시 verify-email 로 redirect

- **테스트**
  - pgTAP RLS 테스트 ([supabase/tests/notes/rls.sql](supabase/tests/notes/rls.sql)):
    plan 32 → 36 으로 확장, 미인증 사용자 픽스처 추가 후 SELECT 허용 / INSERT(42501) / UPDATE 0행 / DELETE 0행 검증
  - 서버 액션 유닛 테스트 ([src/features/notes/tests/actions.test.ts](src/features/notes/tests/actions.test.ts)):
    `email_confirmed_at` 이 `null` / `undefined` 두 케이스 모두 verify-email 로 redirect 되는지 it.each 로 검증
  - 페이지 유닛 테스트 3종 동일 패턴으로 확장

## 테스트 방법

1. `supabase db reset` 로 로컬 DB 리셋 후 마이그레이션 적용
2. pgTAP: `supabase test db` — `supabase/tests/notes/rls.sql` 36개 플랜 모두 통과
3. Vitest: `npm test` — notes 페이지/액션 관련 테스트 전부 통과
4. (수동) 미인증 계정으로 로그인하여 `/notes`, `/notes/new`, `/notes/[id]` 진입 시 `verify-email` 로 리다이렉트되는지 확인

## 스크린샷 (FE 변경 시)

해당 없음 (UI 변경 없이 RSC redirect 만 추가).

## 리뷰 요구사항 (선택)

- `is_current_user_email_confirmed()` 를 `SECURITY DEFINER + STABLE + search_path=public` 조합으로 두고
  `auth.users` 조회를 감싼 설계가 적절한지 확인 부탁드립니다 (authenticated 에만 EXECUTE 허용).
- SELECT 정책을 변경하지 않은 이유는 "인증 전이라도 과거 노트는 열람 가능" 요구 때문인데, 이 정책 방향이 맞는지 확인 부탁드립니다.
 (애플리케이션은 UX redirect, RLS 는 최종 방어선).

## 체크리스트

- [x] 코드 컨벤션 준수
- [x] 커밋 메시지 컨벤션 준수
- [x] lint 통과
- [x] typecheck 통과
- [x] (DB 변경 시) migration 포함 및 로컬 재현 확인
- [x] (권한/RLS 영향 시) 정책 변경 요약 기재
- [ ] UI 변경 시 스크린샷/짧은 설명 첨부 (해당 없음)
- [x] 셀프 리뷰 완료
