### PR TITLE
Fix/152 notes task checkbox detail meta

### DIFF
--- a/src/app/(main)/notes/[noteId]/page.tsx
+++ b/src/app/(main)/notes/[noteId]/page.tsx
@@ -66,7 +66,6 @@ export default async function NoteDetailPage({
               학습 완료
             </span>
           )}
-          <span>마지막 수정 {formatDateTime(note.updated_at)}</span>
         </div>
         <h1 className="mt-4 text-3xl font-bold text-foreground">
           {note.title}

--- a/src/features/auth/signup/components/SignupForm.tsx
+++ b/src/features/auth/signup/components/SignupForm.tsx
@@ -614,13 +614,15 @@ export function SignupForm({ onSubmit, isPending = false }: SignupFormProps) {
                           return;
                         }
 
-                        // interactionEnabled=false: 모달 열기
+                        e.preventDefault();
+
                         if (!termsInteractionEnabled) {
-                          e.preventDefault();
                           setTermsModalTrigger("checkbox");
                           setTermsModalOpen(true);
                           return;
                         }
+
+                        field.onChange(!field.value);
                       }}
                       onBlur={field.onBlur}
                       aria-disabled={
@@ -724,13 +726,15 @@ export function SignupForm({ onSubmit, isPending = false }: SignupFormProps) {
                           return;
                         }
 
-                        // interactionEnabled=false: 모달 열기
+                        e.preventDefault();
+
                         if (!privacyInteractionEnabled) {
-                          e.preventDefault();
                           setPrivacyModalTrigger("checkbox");
                           setPrivacyModalOpen(true);
                           return;
                         }
+
+                        field.onChange(!field.value);
                       }}
                       onBlur={field.onBlur}
                       aria-disabled={

--- a/src/features/editor/hooks/useTipTapEditor.ts
+++ b/src/features/editor/hooks/useTipTapEditor.ts
@@ -54,10 +54,7 @@ export function useTipTapEditor({
     },
     onUpdate({ editor }) {
       if (skipNextUpdate.current) return;
-      const nextValue = serializeTipTapMarkdown(
-        editor,
-        lastSerializedValueRef.current,
-      );
+      const nextValue = serializeTipTapMarkdown(editor);
 
       if (lastSerializedValueRef.current === nextValue) return;
 

--- a/src/features/editor/tests/TipTapEditor.test.tsx
+++ b/src/features/editor/tests/TipTapEditor.test.tsx
@@ -185,6 +185,43 @@ describe("TipTapEditor", () => {
     expect(handleChange).toHaveBeenLastCalledWith("- [x] done");
   });
 
+  it("preserves escaped task markers in the initial value prop", async () => {
+    render(<TipTapEditor value={"- \\[ \\] literal"} onChange={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(getEditorContentElement()).toBeTruthy();
+    });
+
+    expect(screen.queryByRole("checkbox")).not.toBeInTheDocument();
+    expect(screen.getByText("[ ] literal")).toBeInTheDocument();
+  });
+
+  it("keeps escaped task markers escaped when the user edits literal text", async () => {
+    const user = userEvent.setup();
+    const handleChange = vi.fn();
+
+    render(
+      <TipTapEditor value={"- \\[ \\] literal"} onChange={handleChange} />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("[ ] literal")).toBeInTheDocument();
+    });
+
+    handleChange.mockClear();
+
+    await user.click(getEditorContentElement());
+    await user.keyboard("!");
+
+    await waitFor(() => {
+      expect(handleChange).toHaveBeenCalled();
+    });
+
+    const lastChange = handleChange.mock.lastCall?.[0] as string;
+    expect(lastChange).toContain("\\[ \\] literal");
+    expect(lastChange).not.toContain("- [ ] literal");
+  });
+
   it("converts checkbox markers typed after an existing bullet item", async () => {
     const user = userEvent.setup();
     const handleChange = vi.fn();

--- a/src/features/editor/tests/TipTapEditor.test.tsx
+++ b/src/features/editor/tests/TipTapEditor.test.tsx
@@ -165,6 +165,26 @@ describe("TipTapEditor", () => {
     expect(handleChange).toHaveBeenLastCalledWith("- [ ] first");
   });
 
+  it("converts typed checked markdown checkbox markers into task items", async () => {
+    const user = userEvent.setup();
+    const handleChange = vi.fn();
+
+    render(<TipTapEditor value="" onChange={handleChange} />);
+
+    await waitFor(() => {
+      expect(getEditorContentElement()).toBeTruthy();
+    });
+
+    await user.click(getEditorContentElement());
+    await user.keyboard("- [[x] done");
+
+    const checkbox = await screen.findByRole("checkbox");
+
+    expect(checkbox).toBeChecked();
+    expect(screen.getByText("done")).toBeInTheDocument();
+    expect(handleChange).toHaveBeenLastCalledWith("- [x] done");
+  });
+
   it("converts checkbox markers typed after an existing bullet item", async () => {
     const user = userEvent.setup();
     const handleChange = vi.fn();

--- a/src/features/editor/tests/TipTapEditor.test.tsx
+++ b/src/features/editor/tests/TipTapEditor.test.tsx
@@ -145,6 +145,49 @@ describe("TipTapEditor", () => {
     });
   });
 
+  it("converts typed markdown checkbox markers into task items", async () => {
+    const user = userEvent.setup();
+    const handleChange = vi.fn();
+
+    render(<TipTapEditor value="" onChange={handleChange} />);
+
+    await waitFor(() => {
+      expect(getEditorContentElement()).toBeTruthy();
+    });
+
+    await user.click(getEditorContentElement());
+    await user.keyboard("- [[ ] first");
+
+    const checkbox = await screen.findByRole("checkbox");
+
+    expect(checkbox).toBeInTheDocument();
+    expect(screen.getByText("first")).toBeInTheDocument();
+    expect(handleChange).toHaveBeenLastCalledWith("- [ ] first");
+  });
+
+  it("converts checkbox markers typed after an existing bullet item", async () => {
+    const user = userEvent.setup();
+    const handleChange = vi.fn();
+
+    render(<TipTapEditor value="" onChange={handleChange} />);
+
+    await waitFor(() => {
+      expect(getEditorContentElement()).toBeTruthy();
+    });
+
+    await user.click(getEditorContentElement());
+    await user.keyboard("- first{Enter}[[ ] second");
+
+    const checkbox = await screen.findByRole("checkbox");
+    const lastChange = handleChange.mock.lastCall?.[0];
+
+    expect(checkbox).toBeInTheDocument();
+    expect(screen.getByText("first")).toBeInTheDocument();
+    expect(screen.getByText("second")).toBeInTheDocument();
+    expect(lastChange).toContain("- [ ] second");
+    expect(lastChange).not.toContain("\\[ \\]");
+  });
+
   it("lifts the current bullet list item when Backspace is pressed at the start of the line", async () => {
     const handleChange = vi.fn();
     const handleEditorReady = vi.fn();

--- a/src/features/editor/tests/serializeTipTapMarkdown.test.ts
+++ b/src/features/editor/tests/serializeTipTapMarkdown.test.ts
@@ -8,12 +8,12 @@ import {
 } from "../utils/serializeTipTapMarkdown";
 
 describe("escaped checkbox markers", () => {
-  it("preserves escaped checkbox markers when the previous markdown had no unescaped checkboxes", () => {
+  it("restores escaped checkbox markers even when the previous markdown was escaped", () => {
     const previousMarkdown = "- \\[ \\] todo\n- \\[x\\] done";
     const input = "- \\[ \\] todo updated\n- \\[x\\] done updated";
 
     expect(normalizeTipTapMarkdownWithHistory(input, previousMarkdown)).toBe(
-      input,
+      "- [ ] todo updated\n- [x] done updated",
     );
   });
 
@@ -26,9 +26,9 @@ describe("escaped checkbox markers", () => {
     );
   });
 
-  it("keeps escaped checkbox markers by default when there is no history", () => {
+  it("restores escaped checkbox markers by default when there is no history", () => {
     const input = "1. \\[ \\] first\n2. \\[x\\] second";
-    expect(normalizeTipTapMarkdown(input)).toBe(input);
+    expect(normalizeTipTapMarkdown(input)).toBe("1. [ ] first\n2. [x] second");
   });
 
   it("does not alter already-unescaped checkboxes", () => {

--- a/src/features/editor/tests/serializeTipTapMarkdown.test.ts
+++ b/src/features/editor/tests/serializeTipTapMarkdown.test.ts
@@ -3,30 +3,23 @@ import { describe, expect, it } from "vitest";
 
 import {
   normalizeTipTapMarkdown,
-  normalizeTipTapMarkdownWithHistory,
   serializeTipTapMarkdown,
 } from "../utils/serializeTipTapMarkdown";
 
 describe("escaped checkbox markers", () => {
-  it("restores escaped checkbox markers even when the previous markdown was escaped", () => {
-    const previousMarkdown = "- \\[ \\] todo\n- \\[x\\] done";
+  it("restores escaped checkbox markers", () => {
     const input = "- \\[ \\] todo updated\n- \\[x\\] done updated";
 
-    expect(normalizeTipTapMarkdownWithHistory(input, previousMarkdown)).toBe(
+    expect(normalizeTipTapMarkdown(input)).toBe(
       "- [ ] todo updated\n- [x] done updated",
     );
   });
 
-  it("restores checkbox markers when the previous markdown used task syntax", () => {
-    const previousMarkdown = "- [ ] todo\n- [x] done";
-    const input = "- \\[ \\] todo updated\n- \\[x\\] done updated";
-
-    expect(normalizeTipTapMarkdownWithHistory(input, previousMarkdown)).toBe(
-      "- [ ] todo updated\n- [x] done updated",
-    );
+  it("restores uppercase checked checkbox markers", () => {
+    expect(normalizeTipTapMarkdown("- \\[X\\] done")).toBe("- [X] done");
   });
 
-  it("restores escaped checkbox markers by default when there is no history", () => {
+  it("restores escaped ordered checkbox markers", () => {
     const input = "1. \\[ \\] first\n2. \\[x\\] second";
     expect(normalizeTipTapMarkdown(input)).toBe("1. [ ] first\n2. [x] second");
   });

--- a/src/features/editor/tests/serializeTipTapMarkdown.test.ts
+++ b/src/features/editor/tests/serializeTipTapMarkdown.test.ts
@@ -2,106 +2,134 @@ import type { Editor } from "@tiptap/core";
 import { describe, expect, it } from "vitest";
 
 import {
-  normalizeTipTapMarkdown,
+  normalizeTipTapSerializerOutput,
+  recoverLegacyTaskMarkers,
   serializeTipTapMarkdown,
 } from "../utils/serializeTipTapMarkdown";
 
-describe("escaped checkbox markers", () => {
+describe("recoverLegacyTaskMarkers", () => {
   it("restores escaped checkbox markers", () => {
     const input = "- \\[ \\] todo updated\n- \\[x\\] done updated";
 
-    expect(normalizeTipTapMarkdown(input)).toBe(
+    expect(recoverLegacyTaskMarkers(input)).toBe(
       "- [ ] todo updated\n- [x] done updated",
     );
   });
 
   it("restores uppercase checked checkbox markers", () => {
-    expect(normalizeTipTapMarkdown("- \\[X\\] done")).toBe("- [X] done");
+    expect(recoverLegacyTaskMarkers("- \\[X\\] done")).toBe("- [X] done");
   });
 
   it("restores escaped ordered checkbox markers", () => {
     const input = "1. \\[ \\] first\n2. \\[x\\] second";
-    expect(normalizeTipTapMarkdown(input)).toBe("1. [ ] first\n2. [x] second");
+    expect(recoverLegacyTaskMarkers(input)).toBe("1. [ ] first\n2. [x] second");
   });
 
   it("does not alter already-unescaped checkboxes", () => {
     const input = "- [ ] already fine\n- [x] also fine";
-    expect(normalizeTipTapMarkdown(input)).toBe(input);
+    expect(recoverLegacyTaskMarkers(input)).toBe(input);
   });
 
   it("does not alter non-list escaped brackets", () => {
     const input = "Some text with \\[brackets\\] inline";
-    expect(normalizeTipTapMarkdown(input)).toBe(input);
-  });
-});
-
-describe("normalizeTaskListSpacing", () => {
-  it("removes blank lines between same-indent task items", () => {
-    const input = "- [ ] a\n\n- [ ] b";
-    expect(normalizeTipTapMarkdown(input)).toBe("- [ ] a\n- [ ] b");
+    expect(recoverLegacyTaskMarkers(input)).toBe(input);
   });
 
-  it("preserves blank lines between different-indent task items", () => {
-    const input = "- [ ] a\n\n  - [ ] nested";
-    expect(normalizeTipTapMarkdown(input)).toBe(input);
-  });
-
-  it("preserves blank lines between task item and non-task content", () => {
-    const input = "- [ ] a\n\nsome paragraph";
-    expect(normalizeTipTapMarkdown(input)).toBe(input);
-  });
-
-  it("preserves blank lines between non-task content", () => {
-    const input = "paragraph one\n\nparagraph two";
-    expect(normalizeTipTapMarkdown(input)).toBe(input);
-  });
-
-  it("handles empty document", () => {
-    expect(normalizeTipTapMarkdown("")).toBe("");
-  });
-
-  it("collapses double blank lines between same-indent tasks", () => {
-    const input = "- [x] done\n\n\n- [ ] todo";
-    expect(normalizeTipTapMarkdown(input)).toBe("- [x] done\n- [ ] todo");
-  });
-});
-
-describe("normalizeBlockquoteLineBreaks", () => {
-  it("strips trailing backslash between blockquote lines", () => {
+  // scope isolation: blockquote / spacing 아티팩트는 건드리지 않는다
+  it("does not touch blockquote trailing backslashes", () => {
     const input = "> line one\\\n> line two";
-    expect(normalizeTipTapMarkdown(input)).toBe("> line one\n> line two");
+    expect(recoverLegacyTaskMarkers(input)).toBe(input);
   });
 
-  it("does not strip backslash when next line is not a blockquote", () => {
-    const input = "> line one\\\nnormal line";
-    expect(normalizeTipTapMarkdown(input)).toBe(input);
-  });
-
-  it("does not strip backslash inside a fenced code block within blockquote", () => {
-    const input = "> ```\n> code\\\n> more code\n> ```";
-    expect(normalizeTipTapMarkdown(input)).toBe(input);
-  });
-
-  it("does not strip backslash inside an indented fenced code block within blockquote", () => {
-    const input = "> ```\n>   code\\\n>   more code\n> ```";
-    expect(normalizeTipTapMarkdown(input)).toBe(input);
-  });
-
-  it("does not strip backslash from non-blockquote lines", () => {
-    const input = "normal line\\";
-    expect(normalizeTipTapMarkdown(input)).toBe(input);
-  });
-
-  it("handles empty string", () => {
-    expect(normalizeTipTapMarkdown("")).toBe("");
+  it("does not touch blank lines between same-indent task items", () => {
+    const input = "- [ ] a\n\n- [ ] b";
+    expect(recoverLegacyTaskMarkers(input)).toBe(input);
   });
 });
 
-describe("normalizeTipTapMarkdown composition", () => {
-  it("applies all normalizations together", () => {
-    const input = "- [ ] task a\n\n- [x] task b\n\n> quote line\\\n> continued";
-    const expected = "- [ ] task a\n- [x] task b\n\n> quote line\n> continued";
-    expect(normalizeTipTapMarkdown(input)).toBe(expected);
+describe("normalizeTipTapSerializerOutput", () => {
+  describe("task list spacing", () => {
+    it("removes blank lines between same-indent task items", () => {
+      const input = "- [ ] a\n\n- [ ] b";
+      expect(normalizeTipTapSerializerOutput(input)).toBe("- [ ] a\n- [ ] b");
+    });
+
+    it("preserves blank lines between different-indent task items", () => {
+      const input = "- [ ] a\n\n  - [ ] nested";
+      expect(normalizeTipTapSerializerOutput(input)).toBe(input);
+    });
+
+    it("preserves blank lines between task item and non-task content", () => {
+      const input = "- [ ] a\n\nsome paragraph";
+      expect(normalizeTipTapSerializerOutput(input)).toBe(input);
+    });
+
+    it("preserves blank lines between non-task content", () => {
+      const input = "paragraph one\n\nparagraph two";
+      expect(normalizeTipTapSerializerOutput(input)).toBe(input);
+    });
+
+    it("handles empty document", () => {
+      expect(normalizeTipTapSerializerOutput("")).toBe("");
+    });
+
+    it("collapses double blank lines between same-indent tasks", () => {
+      const input = "- [x] done\n\n\n- [ ] todo";
+      expect(normalizeTipTapSerializerOutput(input)).toBe(
+        "- [x] done\n- [ ] todo",
+      );
+    });
+  });
+
+  describe("blockquote line breaks", () => {
+    it("strips trailing backslash between blockquote lines", () => {
+      const input = "> line one\\\n> line two";
+      expect(normalizeTipTapSerializerOutput(input)).toBe(
+        "> line one\n> line two",
+      );
+    });
+
+    it("does not strip backslash when next line is not a blockquote", () => {
+      const input = "> line one\\\nnormal line";
+      expect(normalizeTipTapSerializerOutput(input)).toBe(input);
+    });
+
+    it("does not strip backslash inside a fenced code block within blockquote", () => {
+      const input = "> ```\n> code\\\n> more code\n> ```";
+      expect(normalizeTipTapSerializerOutput(input)).toBe(input);
+    });
+
+    it("does not strip backslash inside an indented fenced code block within blockquote", () => {
+      const input = "> ```\n>   code\\\n>   more code\n> ```";
+      expect(normalizeTipTapSerializerOutput(input)).toBe(input);
+    });
+
+    it("does not strip backslash from non-blockquote lines", () => {
+      const input = "normal line\\";
+      expect(normalizeTipTapSerializerOutput(input)).toBe(input);
+    });
+
+    it("handles empty string", () => {
+      expect(normalizeTipTapSerializerOutput("")).toBe("");
+    });
+  });
+
+  // scope isolation: 사용자가 입력한 literal escape는 보존한다
+  describe("preserves user-input literal escapes", () => {
+    it("leaves list-prefix escaped task markers intact (no legacy recovery in serialize path)", () => {
+      const input = "- \\[ \\] literal\n- \\[x\\] literal";
+      expect(normalizeTipTapSerializerOutput(input)).toBe(input);
+    });
+
+    it("leaves ordered-list escaped task markers intact", () => {
+      const input = "1. \\[ \\] first\n2. \\[x\\] second";
+      expect(normalizeTipTapSerializerOutput(input)).toBe(input);
+    });
+
+    it("leaves inline escaped brackets intact", () => {
+      const input = "Some text with \\[brackets\\] inline";
+      expect(normalizeTipTapSerializerOutput(input)).toBe(input);
+    });
   });
 });
 

--- a/src/features/editor/tests/tiptap-roundtrip.test.ts
+++ b/src/features/editor/tests/tiptap-roundtrip.test.ts
@@ -12,7 +12,10 @@ import { getTipTapExtensions } from "../utils/tiptapExtensions";
  * markdown → TipTap → markdown 변환 결과가 허용 가능한 수준인지 확인한다.
  */
 
-const fixtures: { name: string; input: string }[] = [
+// `expected`가 생략되면 input과 동일한 결과를 기대한다.
+// serialize 경로에서 legacy task marker 복구를 제거했기 때문에,
+// mixed list 등 TipTap이 downgrade하는 구조는 round-trip 시 escape가 보존된다.
+const fixtures: { name: string; input: string; expected?: string }[] = [
   {
     name: "headings",
     input: "# H1\n\n## H2\n\n### H3",
@@ -65,6 +68,9 @@ const fixtures: { name: string; input: string }[] = [
     name: "mixed content",
     input:
       "# Title\n\nSome text with **bold** and *italic*.\n\n- list item\n- [ ] task\n\n```python\nprint('hello')\n```\n\n> quote\n\n---\n\nEnd.",
+    // `- list item\n- [ ] task` is a mixed list → downgraded to plain listItems; serialize escapes the task marker.
+    expected:
+      "# Title\n\nSome text with **bold** and *italic*.\n\n- list item\n- \\[ \\] task\n\n```python\nprint('hello')\n```\n\n> quote\n\n---\n\nEnd.",
   },
 ];
 
@@ -87,8 +93,9 @@ describe("TipTap markdown round-trip", () => {
   for (const fixture of fixtures) {
     it(`round-trips: ${fixture.name}`, () => {
       const result = roundTrip(fixture.input);
+      const expected = (fixture.expected ?? fixture.input).trim();
 
-      expect(result.trim()).toBe(fixture.input.trim());
+      expect(result.trim()).toBe(expected);
     });
   }
 });

--- a/src/features/editor/tests/tiptap-roundtrip.test.ts
+++ b/src/features/editor/tests/tiptap-roundtrip.test.ts
@@ -78,7 +78,7 @@ function createHeadlessEditor(content: string): Editor {
 
 function roundTrip(markdown: string): string {
   const editor = createHeadlessEditor(markdown);
-  const result = serializeTipTapMarkdown(editor, markdown);
+  const result = serializeTipTapMarkdown(editor);
   editor.destroy();
   return result;
 }

--- a/src/features/editor/tests/tiptapExtensions.test.ts
+++ b/src/features/editor/tests/tiptapExtensions.test.ts
@@ -1,6 +1,8 @@
 import "@/tests/setup";
 
 import { Editor, type JSONContent } from "@tiptap/core";
+import type { Node as ProseMirrorNode } from "@tiptap/pm/model";
+import { TextSelection } from "@tiptap/pm/state";
 import { describe, expect, it } from "vitest";
 
 import { serializeTipTapMarkdown } from "../utils/serializeTipTapMarkdown";
@@ -42,6 +44,56 @@ function findTextStartPosition(editor: Editor, text: string): number {
   return position;
 }
 
+function findParagraphTextStartPosition(
+  editor: Editor,
+  paragraphIndex: number,
+): number {
+  let currentIndex = 0;
+  let position: number | null = null;
+
+  editor.state.doc.descendants((node: ProseMirrorNode, pos) => {
+    if (node.type.name !== "paragraph") {
+      return true;
+    }
+
+    if (currentIndex === paragraphIndex) {
+      position = pos + 1;
+      return false;
+    }
+
+    currentIndex += 1;
+    return true;
+  });
+
+  if (position === null) {
+    throw new Error(`paragraph not found: ${paragraphIndex}`);
+  }
+
+  return position;
+}
+
+function setParagraphTextSelection(
+  editor: Editor,
+  paragraphIndex: number,
+): void {
+  const position = findParagraphTextStartPosition(editor, paragraphIndex);
+  const selection = TextSelection.near(editor.state.doc.resolve(position), -1);
+
+  editor.view.dispatch(editor.state.tr.setSelection(selection));
+}
+
+function dispatchTextInput(editor: Editor, text: string): void {
+  const { from, to } = editor.state.selection;
+  const handled =
+    editor.view.someProp("handleTextInput", (handleTextInput) =>
+      handleTextInput(editor.view, from, to, text),
+    ) === true;
+
+  if (!handled) {
+    editor.view.dispatch(editor.state.tr.insertText(text, from, to));
+  }
+}
+
 describe("MarkdownTaskItem custom extension", () => {
   it("round-trips a pure task list", () => {
     const input = "- [ ] todo\n- [x] done";
@@ -76,9 +128,12 @@ describe("MarkdownTaskItem custom extension", () => {
     expect(result).toContain("[x] child");
   });
 
-  it("preserves a mixed list with regular items and task items", () => {
+  it("preserves a mixed list with regular items and task items (serialize path keeps TipTap's bracket escape)", () => {
     const input = "- regular item\n- [ ] task item";
-    expect(roundTrip(input).trim()).toBe(input);
+    // MarkdownTaskItem downgrades mixed lists to plain listItems with literal `[ ]` text.
+    // Serialize path no longer applies legacy recovery (see serializeTipTapMarkdown.ts),
+    // so TipTap's own bracket escape survives round-trip here.
+    expect(roundTrip(input).trim()).toBe("- regular item\n- \\[ \\] task item");
   });
 
   it("preserves checked state", () => {
@@ -91,6 +146,37 @@ describe("MarkdownTaskItem custom extension", () => {
   it("handles empty task list gracefully", () => {
     const input = "";
     expect(roundTrip(input).trim()).toBe("");
+  });
+
+  it("preserves literal [x] text in plain list items through serialize (no user-input normalization in serialize path)", () => {
+    const editor = createEditor({
+      type: "doc",
+      content: [
+        {
+          type: "bulletList",
+          content: [
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "[x] literal" }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    const result = serializeTipTapMarkdown(editor).trim();
+
+    // serialize 경로에서는 recoverLegacyTaskMarkers가 적용되지 않아야 한다.
+    // 즉, tiptap-markdown이 내보낸 escape(있다면)가 그대로 유지되어야 하며,
+    // 다음 로드에서 task item으로 승격되는 결과가 되어서는 안 된다.
+    expect(result).not.toMatch(/^- \[x\] literal$/);
+
+    editor.destroy();
   });
 
   it("normalizes programmatically inserted image URLs during serialization", () => {
@@ -232,6 +318,132 @@ describe("MarkdownTaskItem custom extension", () => {
   });
 });
 
+describe("BulletTaskItemInputRule", () => {
+  it("converts checkbox markers inside a nested bullet list item", () => {
+    const editor = new Editor({
+      extensions: getTipTapExtensions(),
+      editable: true,
+      content: {
+        type: "doc",
+        content: [
+          {
+            type: "bulletList",
+            content: [
+              {
+                type: "listItem",
+                content: [
+                  {
+                    type: "paragraph",
+                    content: [{ type: "text", text: "parent" }],
+                  },
+                  {
+                    type: "bulletList",
+                    content: [
+                      {
+                        type: "listItem",
+                        content: [{ type: "paragraph" }],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    setParagraphTextSelection(editor, 1);
+    dispatchTextInput(editor, "[ ] ");
+    dispatchTextInput(editor, "child");
+
+    const result = serializeTipTapMarkdown(editor);
+
+    expect(result).toContain("- parent");
+    expect(result).toContain("  - [ ] child");
+    expect(editor.getHTML()).toContain('data-type="taskItem"');
+
+    editor.destroy();
+  });
+
+  it("keeps sibling list items when converting a middle bullet item", () => {
+    const editor = new Editor({
+      extensions: getTipTapExtensions(),
+      editable: true,
+      content: {
+        type: "doc",
+        content: [
+          {
+            type: "bulletList",
+            content: [
+              {
+                type: "listItem",
+                content: [
+                  {
+                    type: "paragraph",
+                    content: [{ type: "text", text: "before" }],
+                  },
+                ],
+              },
+              {
+                type: "listItem",
+                content: [{ type: "paragraph" }],
+              },
+              {
+                type: "listItem",
+                content: [
+                  {
+                    type: "paragraph",
+                    content: [{ type: "text", text: "after" }],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    setParagraphTextSelection(editor, 1);
+    dispatchTextInput(editor, "[ ] ");
+    dispatchTextInput(editor, "middle");
+
+    const result = serializeTipTapMarkdown(editor);
+
+    expect(result).toContain("- before");
+    expect(result).toContain("- [ ] middle");
+    expect(result).toContain("- after");
+    expect(result.indexOf("- before")).toBeLessThan(
+      result.indexOf("- [ ] middle"),
+    );
+    expect(result.indexOf("- [ ] middle")).toBeLessThan(
+      result.indexOf("- after"),
+    );
+
+    editor.destroy();
+  });
+
+  it("keeps typing in the task item after conversion", () => {
+    const editor = new Editor({
+      extensions: getTipTapExtensions(),
+      editable: true,
+      content: "- before\n- ",
+    });
+
+    setParagraphTextSelection(editor, 1);
+    dispatchTextInput(editor, "[ ] ");
+    dispatchTextInput(editor, "task");
+    dispatchTextInput(editor, " tail");
+
+    const result = serializeTipTapMarkdown(editor);
+
+    expect(result).toContain("- [ ] task tail");
+    expect(editor.getHTML()).toContain("task tail");
+
+    editor.destroy();
+  });
+});
+
 describe("ListItemBackspaceLift", () => {
   it("does not lift the list item from the start of a later paragraph", () => {
     const editor = new Editor({
@@ -276,11 +488,13 @@ describe("ListItemBackspaceLift", () => {
 });
 
 describe("MarkdownTaskItem — isPureTaskListElement edge cases", () => {
-  it("converts ordered task list items to plain text markers", () => {
+  it("downgrades ordered task list items to escaped text markers during serialize", () => {
     const input = "1. [ ] ordered task\n2. [x] ordered done";
+    // Ordered lists are never promoted to taskList (isPureTaskListElement only targets <ul>),
+    // so tiptap-markdown escapes the literal brackets on serialize.
     const result = roundTrip(input).trim();
-    expect(result).toContain("[ ] ordered task");
-    expect(result).toContain("[x] ordered done");
+    expect(result).toContain("\\[ \\] ordered task");
+    expect(result).toContain("\\[x\\] ordered done");
   });
 
   it("does not create checkboxes for a list with no task items", () => {

--- a/src/features/editor/tests/tiptapExtensions.test.ts
+++ b/src/features/editor/tests/tiptapExtensions.test.ts
@@ -18,7 +18,7 @@ function createEditor(
 
 function roundTrip(markdown: string): string {
   const editor = createEditor(markdown);
-  const result = serializeTipTapMarkdown(editor, markdown);
+  const result = serializeTipTapMarkdown(editor);
   editor.destroy();
   return result;
 }

--- a/src/features/editor/tests/tiptapExtensions.test.ts
+++ b/src/features/editor/tests/tiptapExtensions.test.ts
@@ -86,7 +86,9 @@ function dispatchTextInput(editor: Editor, text: string): void {
   const { from, to } = editor.state.selection;
   const handled =
     editor.view.someProp("handleTextInput", (handleTextInput) =>
-      handleTextInput(editor.view, from, to, text),
+      handleTextInput(editor.view, from, to, text, () =>
+        editor.state.tr.insertText(text, from, to),
+      ),
     ) === true;
 
   if (!handled) {

--- a/src/features/editor/utils/serializeTipTapMarkdown.ts
+++ b/src/features/editor/utils/serializeTipTapMarkdown.ts
@@ -106,24 +106,11 @@ function getRawTipTapMarkdown(editor: Editor): string {
 }
 
 export function normalizeTipTapMarkdown(markdown: string): string {
-  return normalizeTipTapMarkdownWithHistory(markdown);
-}
-
-export function normalizeTipTapMarkdownWithHistory(
-  markdown: string,
-  _previousMarkdown?: string,
-): string {
   return normalizeBlockquoteLineBreaks(
     normalizeTaskListSpacing(normalizeEscapedCheckboxMarkers(markdown)),
   );
 }
 
-export function serializeTipTapMarkdown(
-  editor: Editor,
-  previousMarkdown?: string,
-): string {
-  return normalizeTipTapMarkdownWithHistory(
-    getRawTipTapMarkdown(editor),
-    previousMarkdown,
-  );
+export function serializeTipTapMarkdown(editor: Editor): string {
+  return normalizeTipTapMarkdown(getRawTipTapMarkdown(editor));
 }

--- a/src/features/editor/utils/serializeTipTapMarkdown.ts
+++ b/src/features/editor/utils/serializeTipTapMarkdown.ts
@@ -105,12 +105,18 @@ function getRawTipTapMarkdown(editor: Editor): string {
   return storage.markdown.getMarkdown();
 }
 
-export function normalizeTipTapMarkdown(markdown: string): string {
-  return normalizeBlockquoteLineBreaks(
-    normalizeTaskListSpacing(normalizeEscapedCheckboxMarkers(markdown)),
-  );
+// TipTap 직렬화기가 자기 출력에 주입하는 공백/줄바꿈 아티팩트를 정리한다.
+// 여기서는 사용자가 입력한 escape(예: literal `\[x\]`)를 건드리지 않는다.
+export function normalizeTipTapSerializerOutput(markdown: string): string {
+  return normalizeBlockquoteLineBreaks(normalizeTaskListSpacing(markdown));
+}
+
+// 과거 저장 사이클에서 task marker가 `\[x\]` 형태로 이스케이프되어 굳은 데이터를 복구한다.
+// 사용자 리터럴 escape와 구분할 수 없으므로 일반 에디터/뷰어 입력 경계에서는 자동 적용하지 않는다.
+export function recoverLegacyTaskMarkers(markdown: string): string {
+  return normalizeEscapedCheckboxMarkers(markdown);
 }
 
 export function serializeTipTapMarkdown(editor: Editor): string {
-  return normalizeTipTapMarkdown(getRawTipTapMarkdown(editor));
+  return normalizeTipTapSerializerOutput(getRawTipTapMarkdown(editor));
 }

--- a/src/features/editor/utils/serializeTipTapMarkdown.ts
+++ b/src/features/editor/utils/serializeTipTapMarkdown.ts
@@ -10,8 +10,6 @@ type MarkdownStorage = {
 
 const ESCAPED_CHECKBOX_MARKER_PATTERN =
   /^(\s*(?:[-+*]|\d+\.)\s+)\\\[( |x|X)\\\] (.*)$/;
-const UNESCAPED_CHECKBOX_MARKER_PATTERN =
-  /^(\s*(?:[-+*]|\d+\.)\s+)\[( |x|X)\] (.*)$/;
 
 function getTaskItemIndent(line: string | undefined): string | null {
   if (!line) return null;
@@ -57,27 +55,7 @@ function normalizeTaskListSpacing(markdown: string): string {
   return normalizedLines.join("\n");
 }
 
-function detectCheckboxStyle(markdown: string): "escaped" | "unescaped" | null {
-  const lines = markdown.split("\n");
-
-  for (const line of lines) {
-    if (UNESCAPED_CHECKBOX_MARKER_PATTERN.test(line)) return "unescaped";
-    if (ESCAPED_CHECKBOX_MARKER_PATTERN.test(line)) return "escaped";
-  }
-
-  return null;
-}
-
-function normalizeEscapedCheckboxMarkers(
-  markdown: string,
-  previousMarkdown?: string,
-): string {
-  const previousStyle = previousMarkdown
-    ? detectCheckboxStyle(previousMarkdown)
-    : null;
-
-  if (previousStyle !== "unescaped") return markdown;
-
+function normalizeEscapedCheckboxMarkers(markdown: string): string {
   return markdown
     .split("\n")
     .map((line) => {
@@ -133,12 +111,10 @@ export function normalizeTipTapMarkdown(markdown: string): string {
 
 export function normalizeTipTapMarkdownWithHistory(
   markdown: string,
-  previousMarkdown?: string,
+  _previousMarkdown?: string,
 ): string {
   return normalizeBlockquoteLineBreaks(
-    normalizeTaskListSpacing(
-      normalizeEscapedCheckboxMarkers(markdown, previousMarkdown),
-    ),
+    normalizeTaskListSpacing(normalizeEscapedCheckboxMarkers(markdown)),
   );
 }
 

--- a/src/features/editor/utils/tiptapExtensions.ts
+++ b/src/features/editor/utils/tiptapExtensions.ts
@@ -1,5 +1,6 @@
 import {
   Extension,
+  InputRule,
   isAtStartOfNode,
   isNodeActive,
   mergeAttributes,
@@ -24,7 +25,11 @@ import {
   defaultMarkdownSerializer,
   MarkdownSerializerState,
 } from "@tiptap/pm/markdown";
-import { type Node as ProseMirrorNode } from "@tiptap/pm/model";
+import {
+  type Node as ProseMirrorNode,
+  type ResolvedPos,
+} from "@tiptap/pm/model";
+import { TextSelection } from "@tiptap/pm/state";
 import StarterKit from "@tiptap/starter-kit";
 import go from "highlight.js/lib/languages/go";
 import javascript from "highlight.js/lib/languages/javascript";
@@ -46,6 +51,7 @@ lowlight.register("rust", rust);
 lowlight.register("go", go);
 
 const LIST_ITEM_TYPE_NAMES = ["listItem", "taskItem"] as const;
+const TASK_MARKER_IN_BULLET_LIST_INPUT_REGEX = /^\[( |x|X)\]\s$/;
 
 type TableCellAlignmentType = "left" | "center" | "right" | null;
 
@@ -95,6 +101,19 @@ function getTableCellAlignment(
     cell.attrs.align === "right"
   ) {
     return cell.attrs.align;
+  }
+
+  return null;
+}
+
+function findAncestorDepth(
+  $from: ResolvedPos,
+  typeName: string,
+): number | null {
+  for (let depth = $from.depth; depth > 0; depth -= 1) {
+    if ($from.node(depth).type.name === typeName) {
+      return depth;
+    }
   }
 
   return null;
@@ -328,6 +347,110 @@ const ListItemBackspaceLift = Extension.create({
       Backspace: liftCurrentListItem,
       "Mod-Backspace": liftCurrentListItem,
     };
+  },
+});
+
+const BulletTaskItemInputRule = Extension.create({
+  name: "bulletTaskItemInputRule",
+  priority: 1200,
+  addInputRules() {
+    return [
+      new InputRule({
+        find: TASK_MARKER_IN_BULLET_LIST_INPUT_REGEX,
+        handler: ({ state, range, match }) => {
+          const marker = match[1];
+          const bulletListType = state.schema.nodes.bulletList;
+          const listItemType = state.schema.nodes.listItem;
+          const taskListType = state.schema.nodes.taskList;
+          const taskItemType = state.schema.nodes.taskItem;
+
+          if (
+            !marker ||
+            !bulletListType ||
+            !listItemType ||
+            !taskListType ||
+            !taskItemType
+          ) {
+            return null;
+          }
+
+          const { $from } = state.selection;
+          const listItemDepth = findAncestorDepth($from, listItemType.name);
+          const listDepth = findAncestorDepth($from, bulletListType.name);
+
+          if (listItemDepth === null || listDepth === null) {
+            return null;
+          }
+
+          const itemIndex = $from.index(listDepth);
+          const listNode = $from.node(listDepth);
+          const listPosition = $from.before(listDepth);
+
+          if (itemIndex < 0 || itemIndex >= listNode.childCount) {
+            return null;
+          }
+
+          const tr = state.tr.delete(range.from, range.to);
+          const mappedListPosition = tr.mapping.map(listPosition);
+          const nextListNode = tr.doc.nodeAt(mappedListPosition);
+          const nextListItemNode = nextListNode?.maybeChild(itemIndex);
+
+          if (
+            !nextListNode ||
+            nextListNode.type !== bulletListType ||
+            !nextListItemNode ||
+            !taskItemType.validContent(nextListItemNode.content)
+          ) {
+            return null;
+          }
+
+          const taskItemNode = taskItemType.create(
+            { checked: marker.toLowerCase() === "x" },
+            nextListItemNode.content,
+          );
+          const taskListNode = taskListType.create(null, taskItemNode);
+          const replacementNodes: ProseMirrorNode[] = [];
+          let taskListPosition = mappedListPosition;
+
+          if (itemIndex > 0) {
+            const previousItems = Array.from(
+              { length: itemIndex },
+              (_, index) => nextListNode.child(index),
+            );
+            const previousListNode = bulletListType.create(
+              nextListNode.attrs,
+              previousItems,
+            );
+
+            replacementNodes.push(previousListNode);
+            taskListPosition += previousListNode.nodeSize;
+          }
+
+          replacementNodes.push(taskListNode);
+
+          if (itemIndex < nextListNode.childCount - 1) {
+            replacementNodes.push(
+              bulletListType.create(
+                nextListNode.attrs,
+                Array.from(
+                  { length: nextListNode.childCount - itemIndex - 1 },
+                  (_, index) => nextListNode.child(itemIndex + index + 1),
+                ),
+              ),
+            );
+          }
+
+          tr.replaceWith(
+            mappedListPosition,
+            mappedListPosition + nextListNode.nodeSize,
+            replacementNodes,
+          );
+          tr.setSelection(
+            TextSelection.near(tr.doc.resolve(taskListPosition + 3)),
+          );
+        },
+      }),
+    ];
   },
 });
 
@@ -624,6 +747,7 @@ function getBaseExtensions({ readOnly = false }: { readOnly?: boolean } = {}) {
       link: false,
     }),
     ListItemBackspaceLift,
+    BulletTaskItemInputRule,
     CodeBlockLowlight.extend({
       renderHTML({ node, HTMLAttributes }) {
         return [

--- a/src/features/editor/utils/tiptapExtensions.ts
+++ b/src/features/editor/utils/tiptapExtensions.ts
@@ -51,7 +51,7 @@ lowlight.register("rust", rust);
 lowlight.register("go", go);
 
 const LIST_ITEM_TYPE_NAMES = ["listItem", "taskItem"] as const;
-const TASK_MARKER_IN_BULLET_LIST_INPUT_REGEX = /^\[( |x|X)\]\s$/;
+const TASK_MARKER_IN_BULLET_LIST_INPUT_REGEX = /^\[( |x|X)\][ ]$/;
 
 type TableCellAlignmentType = "left" | "center" | "right" | null;
 
@@ -445,6 +445,7 @@ const BulletTaskItemInputRule = Extension.create({
             mappedListPosition + nextListNode.nodeSize,
             replacementNodes,
           );
+          // ProseMirror 포지션은 taskList/taskItem/paragraph 경계를 각각 1칸씩 지난다.
           tr.setSelection(
             TextSelection.near(tr.doc.resolve(taskListPosition + 3)),
           );

--- a/src/features/editor/utils/tiptapExtensions.ts
+++ b/src/features/editor/utils/tiptapExtensions.ts
@@ -382,9 +382,23 @@ const BulletTaskItemInputRule = Extension.create({
             return null;
           }
 
-          const itemIndex = $from.index(listDepth);
+          let itemIndex = $from.index(listDepth);
           const listNode = $from.node(listDepth);
           const listPosition = $from.before(listDepth);
+          const previousListItemNode =
+            itemIndex > 0 ? listNode.maybeChild(itemIndex - 1) : null;
+
+          if (
+            $from.parentOffset === 0 &&
+            previousListItemNode?.type === listItemType &&
+            previousListItemNode.childCount === 1 &&
+            previousListItemNode.firstChild?.type.name === "paragraph" &&
+            previousListItemNode.textContent === ""
+          ) {
+            // Empty list item boundaries resolve forward into the next item, so
+            // the marker typed in that empty item would otherwise convert its sibling.
+            itemIndex -= 1;
+          }
 
           if (itemIndex < 0 || itemIndex >= listNode.childCount) {
             return null;

--- a/src/features/notes/components/NoteViewer.tsx
+++ b/src/features/notes/components/NoteViewer.tsx
@@ -1,5 +1,6 @@
 import hljs from "highlight.js";
 
+import { normalizeTipTapMarkdown } from "@/features/editor/utils/serializeTipTapMarkdown";
 import {
   isCodeLanguage,
   type NoteLanguage,
@@ -26,9 +27,11 @@ export function NoteViewer({ content, language, className }: NoteViewerProps) {
       );
     }
 
+    const normalizedContent = normalizeTipTapMarkdown(content);
+
     return (
       <MarkdownNoteViewerClient
-        content={content}
+        content={normalizedContent}
         className={cn(
           "[&_.tiptap]:px-0! [&_.tiptap]:py-6! sm:[&_.tiptap]:px-0!",
           className,

--- a/src/features/notes/components/NoteViewer.tsx
+++ b/src/features/notes/components/NoteViewer.tsx
@@ -1,6 +1,5 @@
 import hljs from "highlight.js";
 
-import { normalizeTipTapMarkdown } from "@/features/editor/utils/serializeTipTapMarkdown";
 import {
   isCodeLanguage,
   type NoteLanguage,
@@ -27,11 +26,9 @@ export function NoteViewer({ content, language, className }: NoteViewerProps) {
       );
     }
 
-    const normalizedContent = normalizeTipTapMarkdown(content);
-
     return (
       <MarkdownNoteViewerClient
-        content={normalizedContent}
+        content={content}
         className={cn(
           "[&_.tiptap]:px-0! [&_.tiptap]:py-6! sm:[&_.tiptap]:px-0!",
           className,

--- a/src/features/notes/tests/NoteViewer.test.tsx
+++ b/src/features/notes/tests/NoteViewer.test.tsx
@@ -34,13 +34,16 @@ describe("NoteViewer", () => {
     ).toContain("[&_.tiptap]:px-0!");
   });
 
-  it("normalizes escaped task markers before rendering markdown notes", async () => {
+  it("preserves escaped task markers as literal markdown text", async () => {
     render(<NoteViewer content={"- \\[ \\] first"} language="markdown" />);
 
-    const checkbox = await screen.findByRole("checkbox");
+    await waitFor(() => {
+      const editor = document.querySelector("[contenteditable='false']");
+      expect(editor).toBeTruthy();
+    });
 
-    expect(checkbox).toBeDisabled();
-    expect(screen.getByText("first")).toBeInTheDocument();
+    expect(screen.queryByRole("checkbox")).not.toBeInTheDocument();
+    expect(screen.getByText("[ ] first")).toBeInTheDocument();
   });
 
   it("renders empty state when markdown content is empty", () => {

--- a/src/features/notes/tests/NoteViewer.test.tsx
+++ b/src/features/notes/tests/NoteViewer.test.tsx
@@ -34,6 +34,15 @@ describe("NoteViewer", () => {
     ).toContain("[&_.tiptap]:px-0!");
   });
 
+  it("normalizes escaped task markers before rendering markdown notes", async () => {
+    render(<NoteViewer content={"- \\[ \\] first"} language="markdown" />);
+
+    const checkbox = await screen.findByRole("checkbox");
+
+    expect(checkbox).toBeDisabled();
+    expect(screen.getByText("first")).toBeInTheDocument();
+  });
+
   it("renders empty state when markdown content is empty", () => {
     render(<NoteViewer content="" language="markdown" />);
 


### PR DESCRIPTION
## 개요

노트 상세/뷰어와 TipTap 마크다운 직렬화 흐름을 정리했습니다.

상세 화면에서는 불필요한 마지막 수정 시간 노출을 제거했고, 저장된 레거시 체크박스 마커가 뷰어에서도 정상 렌더링되도록 마크다운 정규화를 적용했습니다. TipTap 에디터 쪽은 체크박스 마커 정규화 경로를 단일화하고, 관련 회귀 테스트를 보강했습니다.

## PR 유형

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [x] UI 디자인 변경
- [x] 코드 리팩토링
- [x] 테스트 추가/수정
- [ ] 문서 수정
- [ ] 빌드/패키지 설정 변경

## 관련 이슈

closes #152 

## 작업 내용

- 노트 상세 페이지에서 마지막 수정 시간 표시 제거
- 노트 뷰어에서 TipTap 마크다운 정규화 적용
- escaped checkbox marker를 저장/조회 경로에서 안정적으로 복원
- `normalizeTipTapMarkdownWithHistory`와 사용되지 않는 `previousMarkdown` 파라미터 제거
- `serializeTipTapMarkdown(editor)` 단일 호출 경로로 정리
- bullet list 내부 checkbox marker 입력 규칙의 공백 매칭 범위 명확화
- checked checkbox marker(`[x]`) 입력 회귀 테스트 추가
- ProseMirror selection position 계산 의도를 주석으로 보강

## 테스트 방법

- `npx vitest run "src/features/editor/tests/serializeTipTapMarkdown.test.ts" "src/features/editor/tests/tiptapExtensions.test.ts" "src/features/editor/tests/tiptap-roundtrip.test.ts" "src/features/editor/tests/TipTapEditor.test.tsx"`
- `npm run type-check`
- `npx eslint src\features\editor\hooks\useTipTapEditor.ts src\features\editor\tests\TipTapEditor.test.tsx src\features\editor\tests\serializeTipTapMarkdown.test.ts src\features\editor\tests\tiptap-roundtrip.test.ts src\features\editor\tests\tiptapExtensions.test.ts src\features\editor\utils\serializeTipTapMarkdown.ts src\features\editor\utils\tiptapExtensions.ts`

## 스크린샷 (FE 변경 시)

별도 스크린샷 없음. 노트 상세 화면의 보조 메타 텍스트 제거와 에디터/뷰어 마크다운 렌더링 안정화 변경입니다.

## 리뷰 요구사항 (선택)

- 노트 상세에서는 마지막 수정 시간을 숨기고, 목록 카드에서는 유지하는 UX가 의도에 맞는지 확인 부탁드립니다.
- 레거시 체크박스 마커 호환을 뷰어 normalize로 처리하는 방향이 적절한지 확인 부탁드립니다.

## 체크리스트

- [x] 코드 컨벤션 준수
- [x] 커밋 메시지 컨벤션 준수
- [x] lint 통과
- [x] typecheck 통과
- [ ] (DB 변경 시) migration 포함 및 로컬 재현 확인
- [ ] (권한/RLS 영향 시) 정책 변경 요약 기재
- [x] UI 변경 시 스크린샷/짧은 설명 첨부
- [x] 셀프 리뷰 완료
