### PR TITLE
fix: #154 - RAF 기반 포커스 타이밍을 onCloseAutoFocus lifecycle로 전환

### DIFF
--- a/src/features/auth/signup/components/LegalDialogWrapper.tsx
+++ b/src/features/auth/signup/components/LegalDialogWrapper.tsx
@@ -17,6 +17,19 @@ import { cn } from "@/lib/utils/cn";
 
 type AgreementType = "termsOfService" | "privacyPolicy";
 
+/**
+ * onCloseComplete 동작 주의사항:
+ *
+ * - preventCloseAutoFocus=true:
+ *   Radix 기본 focus 복귀를 막고, onCloseComplete에서 포커스 이동을 직접 제어한다.
+ *
+ * - preventCloseAutoFocus=false:
+ *   Radix 기본 focus 복귀가 유지되므로,
+ *   onCloseComplete에서 포커스를 이동하더라도 최종 focus는 보장되지 않을 수 있다.
+ *
+ * 즉, onCloseComplete는 "닫힘 이후 후처리" 용도이며,
+ * 포커스 제어를 보장하려면 preventCloseAutoFocus=true와 함께 사용해야 한다.
+ */
 type LegalDialogWrapperProps = {
   agreementType: AgreementType;
   open: boolean;
@@ -27,6 +40,7 @@ type LegalDialogWrapperProps = {
   triggerButtonRef?: React.RefObject<HTMLButtonElement | null>;
   onTriggerClick?: () => void;
   preventCloseAutoFocus?: boolean;
+  onCloseComplete?: () => void;
 };
 
 /**
@@ -51,6 +65,7 @@ export function LegalDialogWrapper({
   triggerButtonRef,
   onTriggerClick,
   preventCloseAutoFocus = true,
+  onCloseComplete,
 }: LegalDialogWrapperProps) {
   // 콘텐츠 섹션 선택
   // 이유: agreementType에 따라 다른 법적 문서를 표시하기 위해 분기
@@ -82,12 +97,13 @@ export function LegalDialogWrapper({
         className="flex max-h-[85vh] flex-col overflow-hidden"
         aria-describedby={`${agreementType}-description`}
         onCloseAutoFocus={(event) => {
-          // 기본적으로 SignupForm에서 트리거/동의 경로별로 포커스를 명시적으로 제어하므로
-          // Radix 기본 복원(DialogTrigger 포커스)은 차단한다.
-          // 필요 시 preventCloseAutoFocus=false로 기본 동작을 허용할 수 있음
+          // preventCloseAutoFocus와 onCloseComplete는 독립적인 책임:
+          // 전자는 Radix 기본 복원(DialogTrigger 포커스) 억제,
+          // 후자는 닫힘 직후 커스텀 후처리 실행
           if (preventCloseAutoFocus) {
             event.preventDefault();
           }
+          onCloseComplete?.();
         }}
       >
         <DialogTitle className="mb-4">{dialogTitle}</DialogTitle>

--- a/src/features/auth/signup/components/SignupForm.tsx
+++ b/src/features/auth/signup/components/SignupForm.tsx
@@ -304,26 +304,29 @@ export function SignupForm({ onSubmit, isPending = false }: SignupFormProps) {
     [onConfirmChange, trigger],
   );
 
+  // onCloseAutoFocus 시점(Radix focus scope 해제 후)에 실행할 포커스 동작을 저장한다
+  // 이유: onOpenChange 시점에는 trigger/intent 상태가 유효하지만 focus scope가 아직 활성이므로,
+  //       실행 시점을 onCloseAutoFocus로 분리하기 위해 클로저를 ref에 캡처한다
+  const pendingTermsFocusRef = useRef<(() => void) | null>(null);
+  const pendingPrivacyFocusRef = useRef<(() => void) | null>(null);
+
+  // RAF 제거 — onCloseAutoFocus 콜백에서 동기 호출되므로 focus scope가 이미 해제됨
   const focusAgreementCheckbox = (
     checkboxRef: React.RefObject<HTMLButtonElement | null>,
   ) => {
-    requestAnimationFrame(() => {
-      checkboxRef.current?.scrollIntoView({
-        block: "center",
-        behavior: "smooth",
-      });
-      checkboxRef.current?.focus();
+    checkboxRef.current?.scrollIntoView({
+      block: "center",
+      behavior: "smooth",
     });
+    checkboxRef.current?.focus();
   };
 
   const focusNextAction = () => {
-    requestAnimationFrame(() => {
-      if (submitButtonRef.current && !submitButtonRef.current.disabled) {
-        submitButtonRef.current.focus();
-        return;
-      }
-      loginLinkRef.current?.focus();
-    });
+    if (submitButtonRef.current && !submitButtonRef.current.disabled) {
+      submitButtonRef.current.focus();
+      return;
+    }
+    loginLinkRef.current?.focus();
   };
 
   const restoreFocusByTrigger = (
@@ -334,15 +337,9 @@ export function SignupForm({ onSubmit, isPending = false }: SignupFormProps) {
       error: React.RefObject<HTMLButtonElement | null>;
     },
   ) => {
-    requestAnimationFrame(() => {
-      if (trigger === "checkbox") {
-        refs.checkbox.current?.focus();
-      } else if (trigger === "button") {
-        refs.button.current?.focus();
-      } else if (trigger === "error") {
-        refs.error.current?.focus();
-      }
-    });
+    if (trigger === "checkbox") refs.checkbox.current?.focus();
+    else if (trigger === "button") refs.button.current?.focus();
+    else if (trigger === "error") refs.error.current?.focus();
   };
 
   /**
@@ -370,16 +367,23 @@ export function SignupForm({ onSubmit, isPending = false }: SignupFormProps) {
     setTermsModalOpen(open);
     if (!open) {
       setTermsInteractionEnabled(true);
+
+      // onOpenChange 시점에 trigger/intent 상태를 클로저로 캡처한다
+      // 이유: onCloseAutoFocus가 실행되는 시점에는 setTermsModalTrigger(null)로 이미 초기화되므로
+      const trigger = termsModalTrigger;
       if (termsAgreeIntentRef.current) {
         termsAgreeIntentRef.current = false;
-        focusAgreementCheckbox(privacyCheckboxRef);
+        pendingTermsFocusRef.current = () =>
+          focusAgreementCheckbox(privacyCheckboxRef);
       } else {
-        restoreFocusByTrigger(termsModalTrigger, {
-          checkbox: termsCheckboxRef,
-          button: termsTriggerButtonRef,
-          error: termsErrorButtonRef,
-        });
+        pendingTermsFocusRef.current = () =>
+          restoreFocusByTrigger(trigger, {
+            checkbox: termsCheckboxRef,
+            button: termsTriggerButtonRef,
+            error: termsErrorButtonRef,
+          });
       }
+
       setTermsModalTrigger(null);
     }
   };
@@ -388,16 +392,20 @@ export function SignupForm({ onSubmit, isPending = false }: SignupFormProps) {
     setPrivacyModalOpen(open);
     if (!open) {
       setPrivacyInteractionEnabled(true);
+
+      const trigger = privacyModalTrigger;
       if (privacyAgreeIntentRef.current) {
         privacyAgreeIntentRef.current = false;
-        focusNextAction();
+        pendingPrivacyFocusRef.current = () => focusNextAction();
       } else {
-        restoreFocusByTrigger(privacyModalTrigger, {
-          checkbox: privacyCheckboxRef,
-          button: privacyTriggerButtonRef,
-          error: privacyErrorButtonRef,
-        });
+        pendingPrivacyFocusRef.current = () =>
+          restoreFocusByTrigger(trigger, {
+            checkbox: privacyCheckboxRef,
+            button: privacyTriggerButtonRef,
+            error: privacyErrorButtonRef,
+          });
       }
+
       setPrivacyModalTrigger(null);
     }
   };
@@ -430,14 +438,12 @@ export function SignupForm({ onSubmit, isPending = false }: SignupFormProps) {
     const privacyNewlyAppeared = hasPrivacyError && !hadPrivacyError;
 
     if (termsNewlyAppeared || privacyNewlyAppeared) {
-      requestAnimationFrame(() => {
-        if (termsNewlyAppeared) {
-          termsErrorButtonRef.current?.focus();
-          return;
-        }
-
-        privacyErrorButtonRef.current?.focus();
-      });
+      // useEffect는 React commit 이후 실행되므로 에러 DOM이 이미 존재함 — RAF 불필요
+      if (termsNewlyAppeared) {
+        termsErrorButtonRef.current?.focus();
+        return;
+      }
+      privacyErrorButtonRef.current?.focus();
     }
 
     prevAgreementErrorsRef.current = {
@@ -663,6 +669,11 @@ export function SignupForm({ onSubmit, isPending = false }: SignupFormProps) {
                 dialogTitle="이용약관"
                 triggerButtonRef={termsTriggerButtonRef}
                 onTriggerClick={() => setTermsModalTrigger("button")}
+                onCloseComplete={() => {
+                  const fn = pendingTermsFocusRef.current;
+                  pendingTermsFocusRef.current = null;
+                  fn?.();
+                }}
               />
             </div>
 
@@ -773,6 +784,11 @@ export function SignupForm({ onSubmit, isPending = false }: SignupFormProps) {
                 dialogTitle="개인정보처리방침"
                 triggerButtonRef={privacyTriggerButtonRef}
                 onTriggerClick={() => setPrivacyModalTrigger("button")}
+                onCloseComplete={() => {
+                  const fn = pendingPrivacyFocusRef.current;
+                  pendingPrivacyFocusRef.current = null;
+                  fn?.();
+                }}
               />
             </div>
 


### PR DESCRIPTION
## 개요

SignupForm agreement interaction 테스트(TC-19)에서 CI 환경에서 간헐적으로 실패하는 문제가 발생했다.

---

## PR 유형

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] UI 디자인 변경
- [x] 코드 리팩토링
- [ ] 테스트 추가/수정
- [ ] 문서 수정
- [ ] 빌드/패키지 설정 변경

---

## 관련 이슈

closes #154

---

## 작업 내용

### 1. 상황 분석

- SignupForm agreement interaction 테스트(TC-19)가 CI(jsdom 환경)에서 간헐적으로 실패
- 로컬에서는 정상 통과 → 환경 의존적인 문제로 판단
- 실패 시 `document.activeElement`가 기대 요소가 아니라 `<body>`로 남는 현상 발생

---

### 2. 문제 원인

- Dialog 닫힘 이후 포커스 이동이 `requestAnimationFrame`에 의존
- jsdom에서는 RAF가 실제 브라우저 렌더링 파이프라인을 따르지 않음
- React commit 및 Radix focus scope 해제 이전에 RAF가 실행될 수 있음
- 그 결과 focus scope에 의해 포커스가 가로채져 `<body>`에 남는 race condition 발생

→ 테스트 문제가 아니라 **포커스 타이밍 설계 문제** 

---

### 3. 해결 목표

- 환경(jsdom/CI)에 의존하지 않는 안정적인 포커스 처리
- Dialog 닫힘 이후 포커스 이동 타이밍을 명확하게 보장
- 테스트 코드 수정 없이 flaky 문제 제거

---

### 4. 해결 방안

#### A. RAF 유지 + 테스트에서 timer flush
- fake timer로 RAF 실행 제어
- 문제: 근본 해결이 아니라 테스트 보정

#### B. microtask 기반 처리 (Promise.resolve / queueMicrotask)
- RAF보다 빠르게 실행될 수 있음
- 문제: 오히려 더 불안정

#### C. Radix lifecycle(`onCloseAutoFocus`) 활용
- focus scope 해제 이후 실행이 보장됨
- 테스트 수정 없이 안정성 확보 가능

---

### 5. 선택 해결 방안

C안 선택 (Radix lifecycle 기반 처리)

#### (1) LegalDialogWrapper 수정

- `onCloseComplete` prop 추가
- `preventCloseAutoFocus`와 독립적으로 실행되도록 구조 변경

```tsx
onCloseAutoFocus={(event) => {
  if (preventCloseAutoFocus) {
    event.preventDefault();
  }
  onCloseComplete?.();
}}
```

→ 두 책임을 분리하여 hidden coupling 제거 

---

#### (2) SignupForm 구조 변경

- `pendingTermsFocusRef`, `pendingPrivacyFocusRef` 도입
- `onOpenChange(false)` 시점에는 포커스 대상만 캡처
- 실제 포커스 실행은 `onCloseComplete`에서 수행

---

#### (3) RAF 제거

- `focusNextAction`, `focusAgreementCheckbox`, `restoreFocusByTrigger`에서 RAF 제거
- 에러 포커스 `useEffect`에서도 RAF 제거

---

#### (4) 결과

- 포커스 타이밍을 “추측(RAF)”에서 “보장(lifecycle)”으로 전환
- ~~CI 환경에서도 안정적으로 테스트 통과~~
- 테스트 코드 수정 없이 flaky 문제 해결

---

## 테스트 방법

1. 테스트 실행

```bash
npx vitest run
```

2. 검증 대상

- SignupForm.agreement-interaction.test.tsx
  - TC-16
  - TC-17
  - TC-18
  - TC-19

3. 확인 포인트

- Dialog 닫힘 이후 포커스가 의도된 요소로 이동하는지
- CI 환경에서도 안정적으로 통과하는지

---

## 스크린샷 (FE 변경 시)

없음 (UI 변경 없음)

---

## 리뷰 요구사항 (선택)

- `onCloseAutoFocus` 기반 포커스 타이밍 구조가 적절한지
- `onCloseComplete`와 `preventCloseAutoFocus`의 책임 분리가 타당한지

---

## 체크리스트

- [x] 코드 컨벤션 준수
- [x] 커밋 메시지 컨벤션 준수
- [x] lint 통과
- [x] typecheck 통과
- [ ] (DB 변경 시) migration 포함 및 로컬 재현 확인
- [ ] (권한/RLS 영향 시) 정책 변경 요약 기재
- [ ] UI 변경 시 스크린샷/짧은 설명 첨부
- [x] 셀프 리뷰 완료