### PR TITLE
chore: #157 HSTS max-age 정책 조정

### DIFF
--- a/next.config.test.ts
+++ b/next.config.test.ts
@@ -105,7 +105,7 @@ describe("Security Headers — next.config.ts", () => {
         expect.arrayContaining([
           expect.objectContaining({
             key: "Strict-Transport-Security",
-            value: "max-age=63072000; includeSubDomains",
+            value: "max-age=300; includeSubDomains",
           }),
         ]),
       );

--- a/next.config.ts
+++ b/next.config.ts
@@ -173,12 +173,12 @@ const nextConfig: NextConfig = {
                   // - 평문 HTTP 접근 차단
                   //
                   // 현재 값 의미:
-                  // - max-age=63072000      : 2년 동안 HTTPS 강제 기억
+                  // - max-age=300      : 5분 동안 HTTPS 강제 기억
                   // - includeSubDomains    : 모든 서브도메인에도 동일 적용
                   //
                   // 주의:
                   // - 운영 환경 HTTPS 구성이 완전해야만 안전하게 적용 가능
-                  value: "max-age=63072000; includeSubDomains",
+                  value: "max-age=300; includeSubDomains",
                 },
               ]
             : []),

--- a/next.config.ts
+++ b/next.config.ts
@@ -157,10 +157,10 @@ const nextConfig: NextConfig = {
             value: cspReportOnly,
           },
           // ⚠️  HSTS(Strict-Transport-Security) 적용 전 반드시 확인사항:
-          // - HSTS는 브라우저에 max-age(63072000초 = 2년)동안 캐시된다
-          // - production에서 한 번 적용되면 해당 브라우저는 HTTP 접근을 장기간 차단한다
+          // - HSTS는 브라우저에 max-age(300초 = 5분)동안 캐시된다
+          // - production에서 한 번 적용되면 해당 브라우저는 HTTP 접근을 설정 기간 동안 차단한다
           // - 배포 전에 HTTPS가 정상 동작하는지 반드시 확인해야 한다
-          // - 잘못 적용 시 사용자 접근이 최대 2년간 차단될 수 있다
+          // - 잘못 적용 시 사용자 접근이 max-age 기간 동안 차단될 수 있다
           // - preload 옵션은 이번 단계에서 제외 (HSTS preload list 등록은 별도 절차 필요)
           ...(isProduction
             ? [


### PR DESCRIPTION
## 개요

production 환경의 HSTS max-age를 2년에서 5분으로 낮춰, HTTPS 구성 오류나 운영 도메인 변경 시 장기 캐시로 인한 복구 리스크를 줄였습니다.

## PR 유형

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] UI 디자인 변경
- [ ] 코드 리팩터링
- [ ] 테스트 추가/수정
- [ ] 문서 수정
- [x] 빌드/패키지 설정 변경

## 관련 이슈

closes #157

## 작업 내용

- Strict-Transport-Security의 max-age를 63072000초에서 300초로 변경
- HSTS max-age 설명 주석을 실제 값에 맞게 갱신

## 테스트 방법

- npm run build
  - 성공
  - 기존 unused-var ESLint warning 출력됨

## 스크린샷 (FE 변경)

N/A

## 리뷰 요구사항 (선택)

- HSTS max-age 300초가 현재 운영 정책에 맞는지 확인 부탁드립니다.
- includeSubDomains 유지 여부도 함께 확인 부탁드립니다.

## 체크리스트

- [x] 코드 컨벤션 준수
- [x] 커밋 메시지 컨벤션 준수
- [x] lint 통과
- [x] typecheck 통과
- [x] (DB 변경 시) migration 포함 및 로컬 실행 확인 - N/A
- [x] (권한/RLS 영향 시) 정책 변경 요약 기재 - N/A
- [x] UI 변경 시 스크린샷/지표 설명 첨부 - N/A
- [ ] 자체 리뷰 완료