### PR TITLE
feat: #172 - 복습 알림 시간 설정 및 발송 추적 추가

### DIFF
--- a/src/features/mypage/components/ProfileSection.tsx
+++ b/src/features/mypage/components/ProfileSection.tsx
@@ -23,8 +23,13 @@ import {
   uploadAvatarAction,
 } from "../actions";
 
+type ProfileSectionProfile = Pick<
+  Profile,
+  "avatar_url" | "created_at" | "nickname" | "role"
+>;
+
 type ProfileSectionProps = {
-  profile: Profile;
+  profile: ProfileSectionProfile;
   email: string;
 };
 

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -40,6 +40,7 @@ export type Database = {
           created_at: string;
           id: string;
           next_review_at: string | null;
+          notification_time_of_day: string | null;
           review_round: number;
           title: string;
           updated_at: string;
@@ -50,6 +51,7 @@ export type Database = {
           created_at?: string;
           id?: string;
           next_review_at?: string | null;
+          notification_time_of_day?: string | null;
           review_round?: number;
           title: string;
           updated_at?: string;
@@ -60,6 +62,7 @@ export type Database = {
           created_at?: string;
           id?: string;
           next_review_at?: string | null;
+          notification_time_of_day?: string | null;
           review_round?: number;
           title?: string;
           updated_at?: string;
@@ -73,6 +76,7 @@ export type Database = {
           id: string;
           note_id: string | null;
           read_at: string | null;
+          review_log_id: string | null;
           sent_at: string;
           skipped_at: string | null;
           status: string;
@@ -85,6 +89,7 @@ export type Database = {
           id?: string;
           note_id?: string | null;
           read_at?: string | null;
+          review_log_id?: string | null;
           sent_at?: string;
           skipped_at?: string | null;
           status?: string;
@@ -97,6 +102,7 @@ export type Database = {
           id?: string;
           note_id?: string | null;
           read_at?: string | null;
+          review_log_id?: string | null;
           sent_at?: string;
           skipped_at?: string | null;
           status?: string;
@@ -112,11 +118,19 @@ export type Database = {
             referencedRelation: "notes";
             referencedColumns: ["id"];
           },
+          {
+            foreignKeyName: "notifications_review_log_id_fkey";
+            columns: ["review_log_id"];
+            isOneToOne: false;
+            referencedRelation: "review_logs";
+            referencedColumns: ["id"];
+          },
         ];
       };
       profiles: {
         Row: {
           avatar_url: string | null;
+          canonical_email: string | null;
           created_at: string;
           id: string;
           nickname: string;
@@ -125,6 +139,7 @@ export type Database = {
         };
         Insert: {
           avatar_url?: string | null;
+          canonical_email?: string | null;
           created_at?: string;
           id: string;
           nickname: string;
@@ -133,6 +148,7 @@ export type Database = {
         };
         Update: {
           avatar_url?: string | null;
+          canonical_email?: string | null;
           created_at?: string;
           id?: string;
           nickname?: string;
@@ -174,6 +190,11 @@ export type Database = {
           created_at: string;
           id: string;
           note_id: string;
+          notification_base_scheduled_at: string | null;
+          notification_claimed_at: string | null;
+          notification_dispatch_attempts: number;
+          notification_dispatch_failed_at: string | null;
+          notification_dispatched_at: string | null;
           round: number;
           scheduled_at: string;
           user_id: string;
@@ -183,6 +204,11 @@ export type Database = {
           created_at?: string;
           id?: string;
           note_id: string;
+          notification_base_scheduled_at?: string | null;
+          notification_claimed_at?: string | null;
+          notification_dispatch_attempts?: number;
+          notification_dispatch_failed_at?: string | null;
+          notification_dispatched_at?: string | null;
           round: number;
           scheduled_at: string;
           user_id: string;
@@ -192,6 +218,11 @@ export type Database = {
           created_at?: string;
           id?: string;
           note_id?: string;
+          notification_base_scheduled_at?: string | null;
+          notification_claimed_at?: string | null;
+          notification_dispatch_attempts?: number;
+          notification_dispatch_failed_at?: string | null;
+          notification_dispatched_at?: string | null;
           round?: number;
           scheduled_at?: string;
           user_id?: string;
@@ -211,26 +242,38 @@ export type Database = {
       [_ in never]: never;
     };
     Functions: {
+      apply_time_of_day: { Args: { t: string; ts: string }; Returns: string };
+      apply_time_of_day_not_before: {
+        Args: { t: string; ts: string };
+        Returns: string;
+      };
+      claim_due_review_logs: {
+        Args: { p_limit?: number };
+        Returns: {
+          id: string;
+          note_id: string;
+          round: number;
+          scheduled_at: string;
+          user_id: string;
+        }[];
+      };
       complete_review_and_schedule_next: {
-        Args: {
-          p_note_id: string;
-          p_review_log_id: string;
-        };
+        Args: { p_note_id: string; p_review_log_id: string };
         Returns: string;
       };
       create_note_with_initial_review_log: {
-        Args: {
-          p_content: string;
-          p_scheduled_at: string;
-          p_title: string;
-        };
+        Args: { p_content: string; p_scheduled_at: string; p_title: string };
         Returns: string;
       };
-      kst_date: {
-        Args: {
-          ts: string;
-        };
-        Returns: string;
+      is_current_user_email_confirmed: { Args: never; Returns: boolean };
+      kst_date: { Args: { ts: string }; Returns: string };
+      mark_notification_as_read: {
+        Args: { p_notification_id: string };
+        Returns: boolean;
+      };
+      update_notification_time_of_day: {
+        Args: { p_note_id: string; p_time?: string };
+        Returns: undefined;
       };
     };
     Enums: {

--- a/supabase/migrations/20260427000000_add_kst_apply_time_of_day_helper.sql
+++ b/supabase/migrations/20260427000000_add_kst_apply_time_of_day_helper.sql
@@ -1,0 +1,27 @@
+CREATE OR REPLACE FUNCTION public.apply_time_of_day(ts timestamptz, t time)
+RETURNS timestamptz
+LANGUAGE sql
+STABLE
+PARALLEL SAFE
+AS $$
+  SELECT (
+    (ts AT TIME ZONE 'Asia/Seoul')::date
+    + t
+  ) AT TIME ZONE 'Asia/Seoul';
+$$;
+
+CREATE OR REPLACE FUNCTION public.apply_time_of_day_not_before(ts timestamptz, t time)
+RETURNS timestamptz
+LANGUAGE sql
+STABLE
+PARALLEL SAFE
+AS $$
+  WITH shifted AS (
+    SELECT public.apply_time_of_day(ts, t) AS scheduled_at
+  )
+  SELECT CASE
+    WHEN shifted.scheduled_at >= ts THEN shifted.scheduled_at
+    ELSE public.apply_time_of_day(ts + interval '1 day', t)
+  END
+  FROM shifted;
+$$;

--- a/supabase/migrations/20260427000001_add_notification_time_of_day_to_notes.sql
+++ b/supabase/migrations/20260427000001_add_notification_time_of_day_to_notes.sql
@@ -1,0 +1,2 @@
+ALTER TABLE public.notes
+  ADD COLUMN notification_time_of_day time NULL;

--- a/supabase/migrations/20260427000002_add_review_log_notification_tracking.sql
+++ b/supabase/migrations/20260427000002_add_review_log_notification_tracking.sql
@@ -1,0 +1,23 @@
+ALTER TABLE public.review_logs
+  ADD COLUMN notification_claimed_at timestamptz NULL,
+  ADD COLUMN notification_dispatched_at timestamptz NULL,
+  ADD COLUMN notification_base_scheduled_at timestamptz NULL,
+  ADD COLUMN notification_dispatch_attempts integer DEFAULT 0 NOT NULL,
+  ADD COLUMN notification_dispatch_failed_at timestamptz NULL,
+  ADD CONSTRAINT review_logs_notification_dispatch_attempts_check
+    CHECK (notification_dispatch_attempts >= 0);
+
+COMMENT ON COLUMN public.review_logs.notification_base_scheduled_at IS
+  'Stores the unshifted cadence timestamp so clearing a custom notification time can restore the review schedule.';
+
+ALTER TABLE public.notifications
+  ADD COLUMN review_log_id uuid NULL REFERENCES public.review_logs(id) ON DELETE SET NULL;
+
+CREATE UNIQUE INDEX notifications_review_log_id_type_key
+  ON public.notifications (review_log_id, type);
+
+CREATE INDEX review_logs_pending_dispatch_idx
+  ON public.review_logs (scheduled_at, notification_claimed_at)
+  WHERE completed_at IS NULL
+    AND notification_dispatched_at IS NULL
+    AND notification_dispatch_failed_at IS NULL;

--- a/supabase/migrations/20260427000003_update_review_rpcs_for_notification_time.sql
+++ b/supabase/migrations/20260427000003_update_review_rpcs_for_notification_time.sql
@@ -1,0 +1,128 @@
+CREATE OR REPLACE FUNCTION public.complete_review_and_schedule_next(
+  p_note_id uuid,
+  p_review_log_id uuid
+)
+RETURNS uuid
+LANGUAGE plpgsql
+-- review_logs intentionally has no UPDATE policy, so this RPC performs the
+-- ownership check explicitly and updates the locked row within the same transaction.
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_user_id uuid := auth.uid();
+  v_email_confirmed_at timestamptz;
+  v_current_round integer;
+  v_note_review_round integer;
+  v_notification_time_of_day time;
+  v_base_next_review_at timestamptz;
+  v_next_review_at timestamptz;
+  -- Use wall-clock time so completion and the next schedule share the same actual timestamp.
+  v_now timestamptz := clock_timestamp();
+BEGIN
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'not authenticated';
+  END IF;
+
+  -- DB-level guard mirroring the app-level email verification redirects so that
+  -- direct RPC callers cannot bypass the "verified email required" policy.
+  SELECT email_confirmed_at
+    INTO v_email_confirmed_at
+  FROM auth.users
+  WHERE id = v_user_id;
+
+  IF v_email_confirmed_at IS NULL THEN
+    RAISE EXCEPTION 'email not confirmed';
+  END IF;
+
+  IF p_note_id IS NULL OR p_review_log_id IS NULL THEN
+    RAISE EXCEPTION 'note_id and review_log_id are required';
+  END IF;
+
+  SELECT rl.round, n.review_round, n.notification_time_of_day
+    INTO v_current_round, v_note_review_round, v_notification_time_of_day
+  FROM public.review_logs rl
+  JOIN public.notes n
+    ON n.id = rl.note_id
+  WHERE rl.id = p_review_log_id
+    AND rl.note_id = p_note_id
+    AND rl.user_id = v_user_id
+    AND rl.completed_at IS NULL
+    AND n.user_id = v_user_id
+  FOR UPDATE OF rl, n;
+
+  IF v_current_round IS NULL THEN
+    RAISE EXCEPTION 'pending review log not found';
+  END IF;
+
+  IF v_current_round <> v_note_review_round + 1 THEN
+    RAISE EXCEPTION 'review log round does not match current note state';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM public.review_logs
+    WHERE note_id = p_note_id
+      AND user_id = v_user_id
+      AND completed_at IS NOT NULL
+      AND public.kst_date(completed_at) = public.kst_date(v_now)
+  ) THEN
+    RAISE EXCEPTION 'daily review completion limit reached'
+      USING ERRCODE = 'WP001';
+  END IF;
+
+  -- Keep this in sync with REVIEW_INTERVALS_DAYS ([1, 3, 7]) so callers
+  -- cannot bypass the spaced-repetition cadence by supplying arbitrary dates.
+  v_base_next_review_at := CASE v_current_round
+    WHEN 1 THEN v_now + interval '3 days'
+    WHEN 2 THEN v_now + interval '7 days'
+    ELSE NULL
+  END;
+
+  v_next_review_at := v_base_next_review_at;
+
+  IF v_next_review_at IS NOT NULL AND v_notification_time_of_day IS NOT NULL THEN
+    v_next_review_at := public.apply_time_of_day_not_before(
+      v_base_next_review_at,
+      v_notification_time_of_day
+    );
+  END IF;
+
+  UPDATE public.review_logs
+  SET completed_at = v_now
+  WHERE id = p_review_log_id
+    AND note_id = p_note_id
+    AND user_id = v_user_id;
+
+  UPDATE public.notes
+  SET review_round = v_current_round,
+      next_review_at = v_next_review_at
+  WHERE id = p_note_id
+    AND user_id = v_user_id;
+
+  IF v_current_round < 3 THEN
+    INSERT INTO public.review_logs (
+      note_id,
+      user_id,
+      round,
+      scheduled_at,
+      notification_base_scheduled_at
+    )
+    VALUES (
+      p_note_id,
+      v_user_id,
+      v_current_round + 1,
+      v_next_review_at,
+      CASE
+        WHEN v_notification_time_of_day IS NULL THEN NULL
+        ELSE v_base_next_review_at
+      END
+    );
+  END IF;
+
+  RETURN p_note_id;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.complete_review_and_schedule_next(uuid, uuid) FROM PUBLIC, anon, authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.complete_review_and_schedule_next(uuid, uuid) TO authenticated;

--- a/supabase/migrations/20260427000004_add_update_notification_time_rpc.sql
+++ b/supabase/migrations/20260427000004_add_update_notification_time_rpc.sql
@@ -1,0 +1,76 @@
+CREATE OR REPLACE FUNCTION public.update_notification_time_of_day(
+  p_note_id uuid,
+  p_time time DEFAULT NULL
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_user_id uuid := auth.uid();
+  v_email_confirmed_at timestamptz;
+  v_pending_next_review_at timestamptz;
+BEGIN
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'not authenticated';
+  END IF;
+
+  SELECT email_confirmed_at
+    INTO v_email_confirmed_at
+  FROM auth.users
+  WHERE id = v_user_id;
+
+  IF v_email_confirmed_at IS NULL THEN
+    RAISE EXCEPTION 'email not confirmed';
+  END IF;
+
+  UPDATE public.notes
+  SET notification_time_of_day = p_time
+  WHERE id = p_note_id
+    AND user_id = v_user_id;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'note not found';
+  END IF;
+
+  WITH updated_pending AS (
+    UPDATE public.review_logs rl
+    SET scheduled_at = CASE
+          WHEN p_time IS NULL THEN
+            COALESCE(rl.notification_base_scheduled_at, rl.scheduled_at)
+          ELSE
+            public.apply_time_of_day_not_before(
+              COALESCE(rl.notification_base_scheduled_at, rl.scheduled_at),
+              p_time
+            )
+        END,
+        notification_base_scheduled_at = CASE
+          WHEN p_time IS NULL THEN NULL
+          ELSE COALESCE(rl.notification_base_scheduled_at, rl.scheduled_at)
+        END
+    WHERE rl.note_id = p_note_id
+      AND rl.user_id = v_user_id
+      AND rl.completed_at IS NULL
+      AND rl.notification_claimed_at IS NULL
+      AND rl.notification_dispatched_at IS NULL
+      AND rl.notification_dispatch_failed_at IS NULL
+    RETURNING rl.scheduled_at
+  )
+  SELECT min(scheduled_at)
+    INTO v_pending_next_review_at
+  FROM updated_pending;
+
+  IF v_pending_next_review_at IS NOT NULL THEN
+    UPDATE public.notes
+    SET next_review_at = v_pending_next_review_at
+    WHERE id = p_note_id
+      AND user_id = v_user_id;
+  END IF;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.update_notification_time_of_day(uuid, time)
+  FROM PUBLIC, anon, authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.update_notification_time_of_day(uuid, time)
+  TO authenticated;

--- a/supabase/migrations/20260427000005_add_mark_notification_as_read_rpc.sql
+++ b/supabase/migrations/20260427000005_add_mark_notification_as_read_rpc.sql
@@ -1,0 +1,38 @@
+CREATE OR REPLACE FUNCTION public.mark_notification_as_read(p_notification_id uuid)
+RETURNS boolean
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_user_id uuid := auth.uid();
+  v_email_confirmed_at timestamptz;
+BEGIN
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'not authenticated';
+  END IF;
+
+  SELECT email_confirmed_at
+    INTO v_email_confirmed_at
+  FROM auth.users
+  WHERE id = v_user_id;
+
+  IF v_email_confirmed_at IS NULL THEN
+    RAISE EXCEPTION 'email not confirmed';
+  END IF;
+
+  UPDATE public.notifications
+  SET status = 'READ',
+      read_at = COALESCE(read_at, clock_timestamp())
+  WHERE id = p_notification_id
+    AND user_id = v_user_id
+    AND status = 'SENT';
+
+  RETURN FOUND;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.mark_notification_as_read(uuid)
+  FROM PUBLIC, anon, authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.mark_notification_as_read(uuid)
+  TO authenticated;

--- a/supabase/migrations/20260427000006_add_claim_due_review_logs_rpc.sql
+++ b/supabase/migrations/20260427000006_add_claim_due_review_logs_rpc.sql
@@ -4,7 +4,10 @@ LANGUAGE sql
 SECURITY DEFINER
 SET search_path = public
 AS $$
-  WITH dead_lettered AS (
+  WITH safe_limit AS (
+    SELECT LEAST(GREATEST(COALESCE(p_limit, 200), 1), 200) AS value
+  ),
+  dead_lettered AS (
     UPDATE public.review_logs rl
     SET notification_dispatch_failed_at = clock_timestamp()
     WHERE rl.completed_at IS NULL
@@ -36,7 +39,7 @@ AS $$
         WHERE dl.id = rl.id
       )
     ORDER BY rl.scheduled_at
-    LIMIT p_limit
+    LIMIT (SELECT value FROM safe_limit)
     FOR UPDATE SKIP LOCKED
   )
   UPDATE public.review_logs rl

--- a/supabase/migrations/20260427000006_add_claim_due_review_logs_rpc.sql
+++ b/supabase/migrations/20260427000006_add_claim_due_review_logs_rpc.sql
@@ -1,0 +1,53 @@
+CREATE OR REPLACE FUNCTION public.claim_due_review_logs(p_limit int DEFAULT 200)
+RETURNS TABLE(id uuid, note_id uuid, user_id uuid, round int, scheduled_at timestamptz)
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  WITH dead_lettered AS (
+    UPDATE public.review_logs rl
+    SET notification_dispatch_failed_at = clock_timestamp()
+    WHERE rl.completed_at IS NULL
+      AND rl.notification_dispatched_at IS NULL
+      AND rl.notification_dispatch_failed_at IS NULL
+      AND rl.notification_dispatch_attempts >= 5
+      AND rl.scheduled_at <= clock_timestamp()
+      AND (
+        rl.notification_claimed_at IS NULL
+        OR rl.notification_claimed_at < clock_timestamp() - interval '15 minutes'
+      )
+    RETURNING rl.id
+  ),
+  due AS (
+    SELECT rl.id
+    FROM public.review_logs rl
+    WHERE rl.completed_at IS NULL
+      AND rl.notification_dispatched_at IS NULL
+      AND rl.notification_dispatch_failed_at IS NULL
+      AND rl.notification_dispatch_attempts < 5
+      AND (
+        rl.notification_claimed_at IS NULL
+        OR rl.notification_claimed_at < clock_timestamp() - interval '15 minutes'
+      )
+      AND rl.scheduled_at <= clock_timestamp()
+      AND NOT EXISTS (
+        SELECT 1
+        FROM dead_lettered dl
+        WHERE dl.id = rl.id
+      )
+    ORDER BY rl.scheduled_at
+    LIMIT p_limit
+    FOR UPDATE SKIP LOCKED
+  )
+  UPDATE public.review_logs rl
+  SET notification_claimed_at = clock_timestamp(),
+      notification_dispatch_attempts = rl.notification_dispatch_attempts + 1
+  FROM due
+  WHERE rl.id = due.id
+  RETURNING rl.id, rl.note_id, rl.user_id, rl.round, rl.scheduled_at;
+$$;
+
+REVOKE ALL ON FUNCTION public.claim_due_review_logs(int)
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.claim_due_review_logs(int)
+  TO service_role;

--- a/supabase/tests/notifications/mark_notification_as_read.sql
+++ b/supabase/tests/notifications/mark_notification_as_read.sql
@@ -1,0 +1,142 @@
+-- =========================================
+-- notifications / mark_notification_as_read
+-- =========================================
+
+BEGIN;
+
+SELECT plan(6);
+
+SELECT set_config('test.mark_read_user_a_id', gen_random_uuid()::text, true);
+SELECT set_config('test.mark_read_user_b_id', gen_random_uuid()::text, true);
+SELECT set_config('test.mark_read_unverified_user_id', gen_random_uuid()::text, true);
+SELECT set_config('test.mark_read_notification_a_id', gen_random_uuid()::text, true);
+SELECT set_config('test.mark_read_notification_b_id', gen_random_uuid()::text, true);
+SELECT set_config('test.mark_read_notification_unverified_id', gen_random_uuid()::text, true);
+
+INSERT INTO auth.users (id, email, email_confirmed_at, raw_user_meta_data)
+VALUES
+  (
+    current_setting('test.mark_read_user_a_id')::uuid,
+    'mark_read_a_' || current_setting('test.mark_read_user_a_id') || '@example.com',
+    now(),
+    '{}'::jsonb
+  ),
+  (
+    current_setting('test.mark_read_user_b_id')::uuid,
+    'mark_read_b_' || current_setting('test.mark_read_user_b_id') || '@example.com',
+    now(),
+    '{}'::jsonb
+  ),
+  (
+    current_setting('test.mark_read_unverified_user_id')::uuid,
+    'mark_read_unverified_' || current_setting('test.mark_read_unverified_user_id') || '@example.com',
+    NULL,
+    '{}'::jsonb
+  )
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO public.notifications (id, user_id, type, title, body, status)
+VALUES
+  (
+    current_setting('test.mark_read_notification_a_id')::uuid,
+    current_setting('test.mark_read_user_a_id')::uuid,
+    'REVIEW',
+    'a title',
+    'a body',
+    'SENT'
+  ),
+  (
+    current_setting('test.mark_read_notification_b_id')::uuid,
+    current_setting('test.mark_read_user_b_id')::uuid,
+    'REVIEW',
+    'b title',
+    'b body',
+    'SENT'
+  ),
+  (
+    current_setting('test.mark_read_notification_unverified_id')::uuid,
+    current_setting('test.mark_read_unverified_user_id')::uuid,
+    'REVIEW',
+    'unverified title',
+    'unverified body',
+    'SENT'
+  );
+
+SET LOCAL ROLE authenticated;
+SELECT set_config(
+  'request.jwt.claims',
+  json_build_object(
+    'sub', current_setting('test.mark_read_user_a_id'),
+    'role', 'authenticated'
+  )::text,
+  true
+);
+
+SELECT is(
+  public.mark_notification_as_read(
+    current_setting('test.mark_read_notification_a_id')::uuid
+  ),
+  true,
+  $$mark_notification_as_read should return true when it updates a SENT notification$$
+);
+
+SELECT ok(
+  (
+    SELECT status = 'READ' AND read_at IS NOT NULL
+    FROM public.notifications
+    WHERE id = current_setting('test.mark_read_notification_a_id')::uuid
+  ),
+  $$mark_notification_as_read should mark the notification as READ$$
+);
+
+SELECT is(
+  public.mark_notification_as_read(
+    current_setting('test.mark_read_notification_a_id')::uuid
+  ),
+  false,
+  $$mark_notification_as_read should return false when the notification is already READ$$
+);
+
+SELECT is(
+  public.mark_notification_as_read(
+    current_setting('test.mark_read_notification_b_id')::uuid
+  ),
+  false,
+  $$mark_notification_as_read should return false for another user's notification$$
+);
+
+RESET ROLE;
+
+SELECT ok(
+  (
+    SELECT status = 'SENT' AND read_at IS NULL
+    FROM public.notifications
+    WHERE id = current_setting('test.mark_read_notification_b_id')::uuid
+  ),
+  $$mark_notification_as_read should leave another user's notification unchanged$$
+);
+
+SET LOCAL ROLE authenticated;
+SELECT set_config(
+  'request.jwt.claims',
+  json_build_object(
+    'sub', current_setting('test.mark_read_unverified_user_id'),
+    'role', 'authenticated'
+  )::text,
+  true
+);
+
+SELECT throws_ok(
+  format(
+    $sql$
+      SELECT public.mark_notification_as_read('%s'::uuid);
+    $sql$,
+    current_setting('test.mark_read_notification_unverified_id')
+  ),
+  'P0001',
+  'email not confirmed',
+  $$unverified users should be blocked by the DB-level guard$$
+);
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/supabase/tests/review_logs/claim_due_review_logs.sql
+++ b/supabase/tests/review_logs/claim_due_review_logs.sql
@@ -1,0 +1,184 @@
+-- =========================================
+-- review_logs / claim_due_review_logs
+-- =========================================
+
+BEGIN;
+
+SELECT plan(10);
+
+SELECT set_config('test.claim_due_user_id', gen_random_uuid()::text, true);
+SELECT set_config('test.claim_due_note_id', gen_random_uuid()::text, true);
+SELECT set_config('test.claim_due_future_note_id', gen_random_uuid()::text, true);
+SELECT set_config('test.claim_due_exhausted_note_id', gen_random_uuid()::text, true);
+SELECT set_config('test.claim_due_log_id', gen_random_uuid()::text, true);
+SELECT set_config('test.claim_due_future_log_id', gen_random_uuid()::text, true);
+SELECT set_config('test.claim_due_exhausted_log_id', gen_random_uuid()::text, true);
+
+INSERT INTO auth.users (id, email, email_confirmed_at, raw_user_meta_data)
+VALUES (
+  current_setting('test.claim_due_user_id')::uuid,
+  'claim_due_' || current_setting('test.claim_due_user_id') || '@example.com',
+  now(),
+  '{}'::jsonb
+)
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO public.notes (id, user_id, title, content, review_round, next_review_at)
+VALUES
+  (
+    current_setting('test.claim_due_note_id')::uuid,
+    current_setting('test.claim_due_user_id')::uuid,
+    'claim due note',
+    'content',
+    0,
+    now() - interval '1 hour'
+  ),
+  (
+    current_setting('test.claim_due_future_note_id')::uuid,
+    current_setting('test.claim_due_user_id')::uuid,
+    'claim due future note',
+    'content',
+    0,
+    now() + interval '1 hour'
+  ),
+  (
+    current_setting('test.claim_due_exhausted_note_id')::uuid,
+    current_setting('test.claim_due_user_id')::uuid,
+    'claim due exhausted note',
+    'content',
+    0,
+    now() - interval '1 hour'
+  );
+
+INSERT INTO public.review_logs (
+  id,
+  note_id,
+  user_id,
+  round,
+  scheduled_at,
+  notification_claimed_at,
+  notification_dispatch_attempts
+)
+VALUES
+  (
+    current_setting('test.claim_due_log_id')::uuid,
+    current_setting('test.claim_due_note_id')::uuid,
+    current_setting('test.claim_due_user_id')::uuid,
+    1,
+    now() - interval '1 hour',
+    NULL,
+    0
+  ),
+  (
+    current_setting('test.claim_due_future_log_id')::uuid,
+    current_setting('test.claim_due_future_note_id')::uuid,
+    current_setting('test.claim_due_user_id')::uuid,
+    1,
+    now() + interval '1 hour',
+    NULL,
+    0
+  ),
+  (
+    current_setting('test.claim_due_exhausted_log_id')::uuid,
+    current_setting('test.claim_due_exhausted_note_id')::uuid,
+    current_setting('test.claim_due_user_id')::uuid,
+    1,
+    now() - interval '1 hour',
+    now() - interval '16 minutes',
+    5
+  );
+
+SET LOCAL ROLE service_role;
+
+SELECT is(
+  (SELECT count(*) FROM public.claim_due_review_logs(10)),
+  1::bigint,
+  $$claim_due_review_logs should claim one eligible due log$$
+);
+
+SELECT is(
+  (
+    SELECT notification_dispatch_attempts
+    FROM public.review_logs
+    WHERE id = current_setting('test.claim_due_log_id')::uuid
+  ),
+  1,
+  $$claiming a due log should increment dispatch attempts$$
+);
+
+SELECT ok(
+  (
+    SELECT notification_claimed_at IS NOT NULL
+    FROM public.review_logs
+    WHERE id = current_setting('test.claim_due_log_id')::uuid
+  ),
+  $$claiming a due log should stamp notification_claimed_at$$
+);
+
+SELECT ok(
+  (
+    SELECT notification_dispatch_failed_at IS NOT NULL
+    FROM public.review_logs
+    WHERE id = current_setting('test.claim_due_exhausted_log_id')::uuid
+  ),
+  $$stale rows at the retry limit should be dead-lettered$$
+);
+
+SELECT ok(
+  (
+    SELECT notification_claimed_at IS NULL
+    FROM public.review_logs
+    WHERE id = current_setting('test.claim_due_future_log_id')::uuid
+  ),
+  $$future review logs should not be claimed$$
+);
+
+SELECT is(
+  (SELECT count(*) FROM public.claim_due_review_logs(10)),
+  0::bigint,
+  $$recently claimed rows should not be reclaimed before the timeout$$
+);
+
+UPDATE public.review_logs
+SET notification_claimed_at = now() - interval '16 minutes'
+WHERE id = current_setting('test.claim_due_log_id')::uuid;
+
+SELECT is(
+  (SELECT count(*) FROM public.claim_due_review_logs(10)),
+  1::bigint,
+  $$stale claimed rows below the retry limit should be reclaimed$$
+);
+
+SELECT is(
+  (
+    SELECT notification_dispatch_attempts
+    FROM public.review_logs
+    WHERE id = current_setting('test.claim_due_log_id')::uuid
+  ),
+  2,
+  $$reclaiming should increment dispatch attempts again$$
+);
+
+UPDATE public.review_logs
+SET notification_claimed_at = now() - interval '16 minutes',
+    notification_dispatch_attempts = 5,
+    notification_dispatch_failed_at = NULL
+WHERE id = current_setting('test.claim_due_log_id')::uuid;
+
+SELECT is(
+  (SELECT count(*) FROM public.claim_due_review_logs(10)),
+  0::bigint,
+  $$rows at the retry limit should not be returned for another attempt$$
+);
+
+SELECT ok(
+  (
+    SELECT notification_dispatch_failed_at IS NOT NULL
+    FROM public.review_logs
+    WHERE id = current_setting('test.claim_due_log_id')::uuid
+  ),
+  $$rows at the retry limit should be marked failed when they become stale$$
+);
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/supabase/tests/review_logs/claim_due_review_logs.sql
+++ b/supabase/tests/review_logs/claim_due_review_logs.sql
@@ -4,7 +4,7 @@
 
 BEGIN;
 
-SELECT plan(10);
+SELECT plan(13);
 
 SELECT set_config('test.claim_due_user_id', gen_random_uuid()::text, true);
 SELECT set_config('test.claim_due_note_id', gen_random_uuid()::text, true);
@@ -178,6 +178,84 @@ SELECT ok(
     WHERE id = current_setting('test.claim_due_log_id')::uuid
   ),
   $$rows at the retry limit should be marked failed when they become stale$$
+);
+
+WITH inserted_notes AS (
+  INSERT INTO public.notes (id, user_id, title, content, review_round, next_review_at)
+  SELECT
+    gen_random_uuid(),
+    current_setting('test.claim_due_user_id')::uuid,
+    'claim due minimum clamp ' || n,
+    'content',
+    0,
+    now() - interval '1 hour'
+  FROM generate_series(1, 2) AS n
+  RETURNING id, user_id
+)
+INSERT INTO public.review_logs (note_id, user_id, round, scheduled_at)
+SELECT id, user_id, 1, now() - interval '1 hour'
+FROM inserted_notes;
+
+SELECT is(
+  (SELECT count(*) FROM public.claim_due_review_logs(0)),
+  1::bigint,
+  $$p_limit <= 0 should be clamped to the minimum batch size$$
+);
+
+UPDATE public.review_logs rl
+SET notification_dispatched_at = now()
+FROM public.notes n
+WHERE n.id = rl.note_id
+  AND n.title LIKE 'claim due minimum clamp %';
+
+WITH inserted_notes AS (
+  INSERT INTO public.notes (id, user_id, title, content, review_round, next_review_at)
+  SELECT
+    gen_random_uuid(),
+    current_setting('test.claim_due_user_id')::uuid,
+    'claim due null default ' || n,
+    'content',
+    0,
+    now() - interval '1 hour'
+  FROM generate_series(1, 201) AS n
+  RETURNING id, user_id
+)
+INSERT INTO public.review_logs (note_id, user_id, round, scheduled_at)
+SELECT id, user_id, 1, now() - interval '1 hour'
+FROM inserted_notes;
+
+SELECT is(
+  (SELECT count(*) FROM public.claim_due_review_logs(NULL)),
+  200::bigint,
+  $$NULL p_limit should use the default batch size$$
+);
+
+UPDATE public.review_logs rl
+SET notification_dispatched_at = now()
+FROM public.notes n
+WHERE n.id = rl.note_id
+  AND n.title LIKE 'claim due null default %';
+
+WITH inserted_notes AS (
+  INSERT INTO public.notes (id, user_id, title, content, review_round, next_review_at)
+  SELECT
+    gen_random_uuid(),
+    current_setting('test.claim_due_user_id')::uuid,
+    'claim due maximum clamp ' || n,
+    'content',
+    0,
+    now() - interval '1 hour'
+  FROM generate_series(1, 201) AS n
+  RETURNING id, user_id
+)
+INSERT INTO public.review_logs (note_id, user_id, round, scheduled_at)
+SELECT id, user_id, 1, now() - interval '1 hour'
+FROM inserted_notes;
+
+SELECT is(
+  (SELECT count(*) FROM public.claim_due_review_logs(201)),
+  200::bigint,
+  $$p_limit above the maximum batch size should be clamped$$
 );
 
 SELECT * FROM finish();

--- a/supabase/tests/review_logs/complete_review_and_schedule_next.sql
+++ b/supabase/tests/review_logs/complete_review_and_schedule_next.sql
@@ -4,7 +4,7 @@
 
 BEGIN;
 
-SELECT plan(20);
+SELECT plan(25);
 
 SELECT set_config('test.review_complete_user_a_id', gen_random_uuid()::text, true);
 SELECT set_config('test.review_complete_user_b_id', gen_random_uuid()::text, true);
@@ -15,12 +15,16 @@ SELECT set_config('test.review_complete_note_round3_id', gen_random_uuid()::text
 SELECT set_config('test.review_complete_note_other_id', gen_random_uuid()::text, true);
 SELECT set_config('test.review_complete_note_mismatch_id', gen_random_uuid()::text, true);
 SELECT set_config('test.review_complete_note_unverified_id', gen_random_uuid()::text, true);
+SELECT set_config('test.review_complete_note_notification_time_id', gen_random_uuid()::text, true);
+SELECT set_config('test.review_complete_note_cleared_notification_time_id', gen_random_uuid()::text, true);
 SELECT set_config('test.review_complete_log_round1_id', gen_random_uuid()::text, true);
 SELECT set_config('test.review_complete_log_round2_id', gen_random_uuid()::text, true);
 SELECT set_config('test.review_complete_log_round3_id', gen_random_uuid()::text, true);
 SELECT set_config('test.review_complete_log_other_id', gen_random_uuid()::text, true);
 SELECT set_config('test.review_complete_log_mismatch_id', gen_random_uuid()::text, true);
 SELECT set_config('test.review_complete_log_unverified_id', gen_random_uuid()::text, true);
+SELECT set_config('test.review_complete_log_notification_time_id', gen_random_uuid()::text, true);
+SELECT set_config('test.review_complete_log_cleared_notification_time_id', gen_random_uuid()::text, true);
 
 INSERT INTO auth.users (id, email, email_confirmed_at, raw_user_meta_data)
 VALUES
@@ -95,6 +99,35 @@ VALUES
     '2026-01-07T00:00:00Z'::timestamptz
   );
 
+INSERT INTO public.notes (
+  id,
+  user_id,
+  title,
+  content,
+  review_round,
+  next_review_at,
+  notification_time_of_day
+)
+VALUES
+  (
+    current_setting('test.review_complete_note_notification_time_id')::uuid,
+    current_setting('test.review_complete_user_a_id')::uuid,
+    'notification time note',
+    'notification time content',
+    0,
+    '2026-01-09T00:00:00Z'::timestamptz,
+    TIME '16:00'
+  ),
+  (
+    current_setting('test.review_complete_note_cleared_notification_time_id')::uuid,
+    current_setting('test.review_complete_user_a_id')::uuid,
+    'cleared notification time note',
+    'cleared notification time content',
+    0,
+    TIMESTAMPTZ '2026-05-01 14:30:00+09',
+    NULL
+  );
+
 INSERT INTO public.review_logs (id, note_id, user_id, round, scheduled_at)
 VALUES
   (
@@ -138,6 +171,20 @@ VALUES
     current_setting('test.review_complete_user_unverified_id')::uuid,
     1,
     '2026-01-07T00:00:00Z'::timestamptz
+  ),
+  (
+    current_setting('test.review_complete_log_notification_time_id')::uuid,
+    current_setting('test.review_complete_note_notification_time_id')::uuid,
+    current_setting('test.review_complete_user_a_id')::uuid,
+    1,
+    '2026-01-09T00:00:00Z'::timestamptz
+  ),
+  (
+    current_setting('test.review_complete_log_cleared_notification_time_id')::uuid,
+    current_setting('test.review_complete_note_cleared_notification_time_id')::uuid,
+    current_setting('test.review_complete_user_a_id')::uuid,
+    1,
+    TIMESTAMPTZ '2026-05-01 14:30:00+09'
   );
 
 SET LOCAL ROLE anon;
@@ -361,6 +408,88 @@ SELECT is(
   ),
   1::bigint,
   $$round 3 completion should not create an extra review log$$
+);
+
+SELECT is(
+  public.complete_review_and_schedule_next(
+    current_setting('test.review_complete_note_notification_time_id')::uuid,
+    current_setting('test.review_complete_log_notification_time_id')::uuid
+  )::text,
+  current_setting('test.review_complete_note_notification_time_id'),
+  $$round 1 completion with a notification time should return the note id$$
+);
+
+SELECT ok(
+  (
+    SELECT n.review_round = 1
+      AND n.next_review_at = public.apply_time_of_day_not_before(
+        completed.completed_at + interval '3 days',
+        TIME '16:00'
+      )
+      AND generated.scheduled_at = n.next_review_at
+      AND generated.notification_base_scheduled_at = completed.completed_at + interval '3 days'
+    FROM public.notes n
+    JOIN public.review_logs completed
+      ON completed.id = current_setting('test.review_complete_log_notification_time_id')::uuid
+    JOIN public.review_logs generated
+      ON generated.note_id = n.id
+     AND generated.round = 2
+     AND generated.completed_at IS NULL
+    WHERE n.id = current_setting('test.review_complete_note_notification_time_id')::uuid
+  ),
+  $$notification time should shift the generated next review and retain the base cadence timestamp$$
+);
+
+SELECT public.update_notification_time_of_day(
+  current_setting('test.review_complete_note_cleared_notification_time_id')::uuid,
+  TIME '16:00'
+);
+
+SELECT public.update_notification_time_of_day(
+  current_setting('test.review_complete_note_cleared_notification_time_id')::uuid,
+  NULL::time
+);
+
+SELECT ok(
+  (
+    SELECT n.notification_time_of_day IS NULL
+      AND n.next_review_at = TIMESTAMPTZ '2026-05-01 14:30:00+09'
+      AND rl.scheduled_at = TIMESTAMPTZ '2026-05-01 14:30:00+09'
+      AND rl.notification_base_scheduled_at IS NULL
+    FROM public.notes n
+    JOIN public.review_logs rl
+      ON rl.id = current_setting('test.review_complete_log_cleared_notification_time_id')::uuid
+    WHERE n.id = current_setting('test.review_complete_note_cleared_notification_time_id')::uuid
+  ),
+  $$clearing a notification time should restore the pending cadence timestamp before completion$$
+);
+
+SELECT is(
+  public.complete_review_and_schedule_next(
+    current_setting('test.review_complete_note_cleared_notification_time_id')::uuid,
+    current_setting('test.review_complete_log_cleared_notification_time_id')::uuid
+  )::text,
+  current_setting('test.review_complete_note_cleared_notification_time_id'),
+  $$round 1 completion after clearing a notification time should return the note id$$
+);
+
+SELECT ok(
+  (
+    SELECT n.review_round = 1
+      AND n.notification_time_of_day IS NULL
+      AND n.next_review_at = completed.completed_at + interval '3 days'
+      AND generated.scheduled_at = completed.completed_at + interval '3 days'
+      AND generated.notification_base_scheduled_at IS NULL
+    FROM public.notes n
+    JOIN public.review_logs completed
+      ON completed.id = current_setting('test.review_complete_log_cleared_notification_time_id')::uuid
+    JOIN public.review_logs generated
+      ON generated.note_id = n.id
+     AND generated.round = 2
+     AND generated.completed_at IS NULL
+    WHERE n.id = current_setting('test.review_complete_note_cleared_notification_time_id')::uuid
+  ),
+  $$cleared notification time should keep the next generated review on the default cadence$$
 );
 
 SELECT throws_ok(

--- a/supabase/tests/review_logs/notification_time_of_day.sql
+++ b/supabase/tests/review_logs/notification_time_of_day.sql
@@ -1,0 +1,175 @@
+-- =========================================
+-- review_logs / notification_time_of_day
+-- =========================================
+
+BEGIN;
+
+SELECT plan(11);
+
+SELECT set_config('test.notification_time_user_id', gen_random_uuid()::text, true);
+SELECT set_config('test.notification_time_note_id', gen_random_uuid()::text, true);
+SELECT set_config('test.notification_time_log_id', gen_random_uuid()::text, true);
+SELECT set_config('test.notification_time_duplicate_log_id', gen_random_uuid()::text, true);
+
+SELECT is(
+  public.apply_time_of_day(
+    TIMESTAMPTZ '2026-05-01 23:30:00+09',
+    TIME '01:00'
+  ),
+  TIMESTAMPTZ '2026-05-01 01:00:00+09',
+  $$apply_time_of_day should keep the same KST date$$
+);
+
+SELECT is(
+  public.apply_time_of_day_not_before(
+    TIMESTAMPTZ '2026-05-01 23:30:00+09',
+    TIME '01:00'
+  ),
+  TIMESTAMPTZ '2026-05-02 01:00:00+09',
+  $$apply_time_of_day_not_before should move earlier wall-clock times to the next KST date$$
+);
+
+SELECT is(
+  public.apply_time_of_day_not_before(
+    TIMESTAMPTZ '2026-05-01 13:00:00+09',
+    TIME '14:00'
+  ),
+  TIMESTAMPTZ '2026-05-01 14:00:00+09',
+  $$apply_time_of_day_not_before should keep later wall-clock times on the same KST date$$
+);
+
+INSERT INTO auth.users (id, email, email_confirmed_at, raw_user_meta_data)
+VALUES (
+  current_setting('test.notification_time_user_id')::uuid,
+  'notification_time_' || current_setting('test.notification_time_user_id') || '@example.com',
+  now(),
+  '{}'::jsonb
+)
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO public.notes (id, user_id, title, content, review_round, next_review_at)
+VALUES (
+  current_setting('test.notification_time_note_id')::uuid,
+  current_setting('test.notification_time_user_id')::uuid,
+  'notification time note',
+  'content',
+  0,
+  TIMESTAMPTZ '2026-05-01 14:30:00+09'
+);
+
+INSERT INTO public.review_logs (id, note_id, user_id, round, scheduled_at)
+VALUES (
+  current_setting('test.notification_time_log_id')::uuid,
+  current_setting('test.notification_time_note_id')::uuid,
+  current_setting('test.notification_time_user_id')::uuid,
+  1,
+  TIMESTAMPTZ '2026-05-01 14:30:00+09'
+);
+
+SELECT throws_ok(
+  format(
+    $sql$
+      INSERT INTO public.review_logs (id, note_id, user_id, round, scheduled_at)
+      VALUES (
+        '%s'::uuid,
+        '%s'::uuid,
+        '%s'::uuid,
+        2,
+        TIMESTAMPTZ '2026-05-02 14:30:00+09'
+      );
+    $sql$,
+    current_setting('test.notification_time_duplicate_log_id'),
+    current_setting('test.notification_time_note_id'),
+    current_setting('test.notification_time_user_id')
+  ),
+  '23505',
+  NULL,
+  $$review_logs should enforce at most one pending log per note$$
+);
+
+SET LOCAL ROLE authenticated;
+SELECT set_config(
+  'request.jwt.claims',
+  json_build_object(
+    'sub', current_setting('test.notification_time_user_id'),
+    'role', 'authenticated'
+  )::text,
+  true
+);
+
+SELECT lives_ok(
+  format(
+    $sql$
+      SELECT public.update_notification_time_of_day('%s'::uuid, TIME '16:00');
+    $sql$,
+    current_setting('test.notification_time_note_id')
+  ),
+  $$setting a custom notification time should succeed$$
+);
+
+SELECT is(
+  (
+    SELECT notification_time_of_day::text
+    FROM public.notes
+    WHERE id = current_setting('test.notification_time_note_id')::uuid
+  ),
+  '16:00:00',
+  $$notes.notification_time_of_day should store the custom time$$
+);
+
+SELECT is(
+  (
+    SELECT scheduled_at
+    FROM public.review_logs
+    WHERE id = current_setting('test.notification_time_log_id')::uuid
+  ),
+  TIMESTAMPTZ '2026-05-01 16:00:00+09',
+  $$pending review log should shift to the custom KST time$$
+);
+
+SELECT is(
+  (
+    SELECT notification_base_scheduled_at
+    FROM public.review_logs
+    WHERE id = current_setting('test.notification_time_log_id')::uuid
+  ),
+  TIMESTAMPTZ '2026-05-01 14:30:00+09',
+  $$pending review log should retain the original cadence timestamp$$
+);
+
+SELECT is(
+  (
+    SELECT next_review_at
+    FROM public.notes
+    WHERE id = current_setting('test.notification_time_note_id')::uuid
+  ),
+  TIMESTAMPTZ '2026-05-01 16:00:00+09',
+  $$notes.next_review_at should follow the shifted pending log$$
+);
+
+SELECT lives_ok(
+  format(
+    $sql$
+      SELECT public.update_notification_time_of_day('%s'::uuid, NULL::time);
+    $sql$,
+    current_setting('test.notification_time_note_id')
+  ),
+  $$clearing a custom notification time should succeed$$
+);
+
+SELECT ok(
+  (
+    SELECT n.notification_time_of_day IS NULL
+      AND n.next_review_at = TIMESTAMPTZ '2026-05-01 14:30:00+09'
+      AND rl.scheduled_at = TIMESTAMPTZ '2026-05-01 14:30:00+09'
+      AND rl.notification_base_scheduled_at IS NULL
+    FROM public.notes n
+    JOIN public.review_logs rl
+      ON rl.id = current_setting('test.notification_time_log_id')::uuid
+    WHERE n.id = current_setting('test.notification_time_note_id')::uuid
+  ),
+  $$clearing the custom time should restore the retained cadence timestamp$$
+);
+
+SELECT * FROM finish();
+ROLLBACK;


### PR DESCRIPTION
## 개요

복습 알림 발송을 위한 DB/RPC 기반을 추가했습니다. 노트별 알림 시각을 KST 기준으로 조정할 수 있게 하고, due review log를 안전하게 claim/dispatch 추적하도록 하며, 알림 읽음 처리는 직접 UPDATE 대신 소유자 검증 RPC로 처리합니다.

## PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] UI 디자인 변경
- [ ] 코드 리팩토링
- [x] 테스트 추가/수정
- [ ] 문서 수정
- [ ] 빌드/패키지 설정 변경

## 관련 이슈

closes #172

## 작업 내용

- `notes.notification_time_of_day` 컬럼과 KST 시간 보정 helper RPC를 추가했습니다.
- `complete_review_and_schedule_next`가 노트별 알림 시각 override를 반영해 다음 복습 일정을 생성하도록 갱신했습니다.
- `review_logs`에 알림 claim/dispatch 추적 컬럼을 추가하고, `notifications.review_log_id + type` 중복 방지 인덱스를 추가했습니다.
- dispatcher용 `claim_due_review_logs` RPC를 추가해 due review log를 idempotent하게 claim할 수 있게 했습니다.
- `update_notification_time_of_day`, `mark_notification_as_read` RPC를 추가해 인증 사용자/소유자 경계 안에서 알림 시간 설정과 읽음 처리를 수행합니다.
- Supabase 타입을 갱신하고, `ProfileSection` props 타입을 실제 사용 필드만 받도록 축소했습니다.
- 알림 읽음 처리, due review log claim, notification time override 동작을 검증하는 pgTAP 테스트를 추가했습니다.

## 테스트 방법

```bash
npm run lint
npm run type-check
supabase test db supabase/tests/notifications/mark_notification_as_read.sql supabase/tests/review_logs/claim_due_review_logs.sql supabase/tests/review_logs/notification_time_of_day.sql
```

- `npm run lint`: 통과
- `npm run type-check`: 통과
- `supabase test db ...`: 3개 파일, 27개 테스트 통과

## 스크린샷 (FE 변경 시)

FE 화면 변경 없음

## 리뷰 요구사항 (선택)

- `SECURITY DEFINER` RPC의 권한 범위가 의도대로 제한되어 있는지 확인 부탁드립니다.
- `claim_due_review_logs`의 stale claim 재처리 조건과 `notifications_review_log_id_type_key` 중복 방지 흐름을 중점적으로 봐주세요.
- `notification_time_of_day`를 `NULL`로 해제할 때 기존 pending schedule은 보존하는 정책이 요구사항과 맞는지 확인 부탁드립니다.

## 체크리스트

- [x] 코드 컨벤션 준수
- [x] 커밋 메시지 컨벤션 준수
- [x] lint 통과
- [x] typecheck 통과
- [x] (DB 변경 시) migration 포함 및 로컬 재현 확인
- [x] (권한/RLS 영향 시) 정책 변경 요약 기재
- [ ] UI 변경 시 스크린샷/짧은 설명 첨부 (해당 없음: FE 화면 변경 없음)
- [x] 셀프 리뷰 완료
