### PR TITLE
feat: #174 알림 server layer (actions/queries/schema) 및 GET API 구현

### DIFF
--- a/src/app/api/notifications/route.test.ts
+++ b/src/app/api/notifications/route.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { createClientMock, getNotificationListMock, getUnreadCountMock } =
+  vi.hoisted(() => ({
+    createClientMock: vi.fn(),
+    getNotificationListMock: vi.fn(),
+    getUnreadCountMock: vi.fn(),
+  }));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: createClientMock,
+}));
+
+vi.mock("@/features/notifications/queries", () => ({
+  getNotificationList: getNotificationListMock,
+  getUnreadCount: getUnreadCountMock,
+}));
+
+import * as notificationsRoute from "./route";
+
+const USER_ID = "11111111-1111-4111-8111-111111111111";
+
+function createSupabaseMock(user: { id: string } | null = { id: USER_ID }) {
+  return {
+    auth: {
+      getUser: vi.fn().mockResolvedValue({
+        data: { user },
+        error: null,
+      }),
+    },
+  };
+}
+
+describe("/api/notifications", () => {
+  beforeEach(() => {
+    createClientMock.mockReset();
+    getNotificationListMock.mockReset();
+    getUnreadCountMock.mockReset();
+    createClientMock.mockResolvedValue(createSupabaseMock());
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns bell notification items and unread count", async () => {
+    const supabase = createSupabaseMock();
+    createClientMock.mockResolvedValue(supabase);
+    getNotificationListMock.mockResolvedValue([
+      {
+        id: "22222222-2222-4222-8222-222222222222",
+        title: "복습 시간이에요",
+      },
+    ]);
+    getUnreadCountMock.mockResolvedValue(1);
+
+    const response = await notificationsRoute.GET();
+
+    await expect(response.json()).resolves.toEqual({
+      items: [
+        {
+          id: "22222222-2222-4222-8222-222222222222",
+          title: "복습 시간이에요",
+        },
+      ],
+      unreadCount: 1,
+    });
+    expect(response.status).toBe(200);
+    expect(getNotificationListMock).toHaveBeenCalledWith({
+      supabase,
+      userId: USER_ID,
+    });
+    expect(getUnreadCountMock).toHaveBeenCalledWith({
+      supabase,
+      userId: USER_ID,
+    });
+  });
+
+  it("returns unauthorized when there is no logged-in user", async () => {
+    createClientMock.mockResolvedValue(createSupabaseMock(null));
+
+    const response = await notificationsRoute.GET();
+
+    await expect(response.json()).resolves.toEqual({
+      error: "unauthorized",
+    });
+    expect(response.status).toBe(401);
+    expect(getNotificationListMock).not.toHaveBeenCalled();
+    expect(getUnreadCountMock).not.toHaveBeenCalled();
+  });
+
+  it("logs and returns an error when notification lookup fails", async () => {
+    const error = new Error("query failed");
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    getNotificationListMock.mockRejectedValue(error);
+    getUnreadCountMock.mockResolvedValue(0);
+
+    const response = await notificationsRoute.GET();
+
+    await expect(response.json()).resolves.toEqual({
+      error: "notifications_lookup_failed",
+    });
+    expect(response.status).toBe(500);
+    expect(errorSpy).toHaveBeenCalledWith({
+      event: "notifications.get.failed",
+      error,
+    });
+  });
+});

--- a/src/app/api/notifications/route.ts
+++ b/src/app/api/notifications/route.ts
@@ -1,10 +1,36 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextResponse } from "next/server";
 
-export async function GET(_request: NextRequest) {
-  return NextResponse.json({ notifications: [] });
-}
+import {
+  getNotificationList,
+  getUnreadCount,
+} from "@/features/notifications/queries";
+import { logError } from "@/lib/logger";
+import { createClient } from "@/lib/supabase/server";
 
-export async function POST(request: NextRequest) {
-  const body = await request.json();
-  return NextResponse.json({ success: true, data: body });
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  try {
+    const supabase = await createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+    }
+
+    const [items, unreadCount] = await Promise.all([
+      getNotificationList({ supabase, userId: user.id }),
+      getUnreadCount({ supabase, userId: user.id }),
+    ]);
+
+    return NextResponse.json({ items, unreadCount });
+  } catch (error) {
+    logError({ event: "notifications.get.failed", error });
+    return NextResponse.json(
+      { error: "notifications_lookup_failed" },
+      { status: 500 },
+    );
+  }
 }

--- a/src/features/notifications/actions.ts
+++ b/src/features/notifications/actions.ts
@@ -1,0 +1,211 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
+
+import { getNoteDetailRoute, ROUTES } from "@/lib/constants/routes";
+import { createClient } from "@/lib/supabase/server";
+
+import {
+  notificationIdSchema,
+  pushSubscriptionEndpointSchema,
+  pushSubscriptionSchema,
+  setNotificationTimeSchema,
+} from "./schema";
+
+type NotificationActionResultType =
+  | {
+      success: true;
+      error?: never;
+    }
+  | {
+      success: false;
+      error: string;
+    };
+
+export type MarkNotificationAsReadActionResultType =
+  | {
+      success: true;
+      updated: boolean;
+      error?: never;
+    }
+  | {
+      success: false;
+      updated?: never;
+      error: string;
+    };
+
+async function getVerifiedNotificationContext() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return { error: "로그인이 필요합니다." } as const;
+  }
+
+  if (user.email_confirmed_at == null) {
+    redirect(ROUTES.VERIFY_EMAIL);
+  }
+
+  return { supabase, userId: user.id } as const;
+}
+
+export async function subscribeToPushAction(
+  subscription: unknown,
+): Promise<NotificationActionResultType> {
+  const parsed = pushSubscriptionSchema.safeParse(subscription);
+
+  if (!parsed.success) {
+    return {
+      success: false,
+      error: "브라우저 구독 정보가 올바르지 않습니다.",
+    };
+  }
+
+  const context = await getVerifiedNotificationContext();
+
+  if ("error" in context) {
+    return { success: false, error: context.error };
+  }
+
+  const { endpoint, keys } = parsed.data;
+  const { error } = await context.supabase.from("push_subscriptions").upsert(
+    {
+      user_id: context.userId,
+      endpoint,
+      p256dh: keys.p256dh,
+      auth: keys.auth,
+    },
+    { onConflict: "endpoint" },
+  );
+
+  if (error) {
+    return {
+      success: false,
+      error:
+        "푸시 알림 구독에 실패했습니다. 브라우저 알림 구독을 해제한 뒤 다시 시도해주세요.",
+    };
+  }
+
+  revalidatePath(ROUTES.MYPAGE);
+
+  return { success: true };
+}
+
+export async function unsubscribeFromPushAction(
+  endpoint: unknown,
+): Promise<NotificationActionResultType> {
+  const parsed = pushSubscriptionEndpointSchema.safeParse(endpoint);
+
+  if (!parsed.success) {
+    return {
+      success: false,
+      error: "브라우저 구독 정보가 올바르지 않습니다.",
+    };
+  }
+
+  const context = await getVerifiedNotificationContext();
+
+  if ("error" in context) {
+    return { success: false, error: context.error };
+  }
+
+  const { error } = await context.supabase
+    .from("push_subscriptions")
+    .delete()
+    .eq("endpoint", parsed.data)
+    .eq("user_id", context.userId);
+
+  if (error) {
+    return {
+      success: false,
+      error: "푸시 알림 구독 해제에 실패했습니다. 잠시 후 다시 시도해주세요.",
+    };
+  }
+
+  revalidatePath(ROUTES.MYPAGE);
+
+  return { success: true };
+}
+
+export async function markNotificationAsReadAction(
+  notificationId: unknown,
+): Promise<MarkNotificationAsReadActionResultType> {
+  const parsed = notificationIdSchema.safeParse(notificationId);
+
+  if (!parsed.success) {
+    return { success: false, error: "알림을 찾을 수 없습니다." };
+  }
+
+  const context = await getVerifiedNotificationContext();
+
+  if ("error" in context) {
+    return { success: false, error: context.error };
+  }
+
+  const { data, error } = await context.supabase.rpc(
+    "mark_notification_as_read",
+    {
+      p_notification_id: parsed.data,
+    },
+  );
+
+  if (error) {
+    return {
+      success: false,
+      error: "알림 읽음 처리에 실패했습니다. 잠시 후 다시 시도해주세요.",
+    };
+  }
+
+  // Bell state refresh is handled by the client React Query cache.
+  return { success: true, updated: data ?? false };
+}
+
+export async function setNotificationTimeAction(
+  noteId: unknown,
+  time: unknown,
+): Promise<NotificationActionResultType> {
+  const parsed = setNotificationTimeSchema.safeParse({
+    noteId,
+    time: time === "" ? null : time,
+  });
+
+  if (!parsed.success) {
+    const fieldErrors = parsed.error.flatten().fieldErrors;
+
+    if (fieldErrors.noteId) {
+      return { success: false, error: "알림 대상을 찾을 수 없습니다." };
+    }
+
+    return { success: false, error: "알림 시간이 올바르지 않습니다." };
+  }
+
+  const context = await getVerifiedNotificationContext();
+
+  if ("error" in context) {
+    return { success: false, error: context.error };
+  }
+
+  const { noteId: parsedNoteId, time: parsedTime } = parsed.data;
+  const rpcArgs =
+    parsedTime === null
+      ? { p_note_id: parsedNoteId }
+      : { p_note_id: parsedNoteId, p_time: parsedTime };
+  const { error } = await context.supabase.rpc(
+    "update_notification_time_of_day",
+    rpcArgs,
+  );
+
+  if (error) {
+    return {
+      success: false,
+      error: "알림 시간 저장에 실패했습니다. 잠시 후 다시 시도해주세요.",
+    };
+  }
+
+  revalidatePath(getNoteDetailRoute(parsedNoteId));
+
+  return { success: true };
+}

--- a/src/features/notifications/queries.ts
+++ b/src/features/notifications/queries.ts
@@ -1,9 +1,147 @@
-// TODO: Supabase query functions
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { z } from "zod";
 
-export async function getNotifications() {
-  return [];
+import {
+  NOTIFICATION_STATUS,
+  NOTIFICATION_TYPES,
+} from "@/lib/constants/notifications";
+import { createServerComponentClient } from "@/lib/supabase/server";
+import type { Database } from "@/types/database.types";
+
+const DEFAULT_NOTIFICATION_LIST_LIMIT = 20;
+const MAX_NOTIFICATION_LIST_LIMIT = 50;
+
+const notificationStatusSchema = z.enum([
+  NOTIFICATION_STATUS.SENT,
+  NOTIFICATION_STATUS.READ,
+  NOTIFICATION_STATUS.SKIPPED,
+]);
+
+const joinedNoteSchema = z.object({
+  title: z.string(),
+});
+
+const notificationListRowSchema = z.object({
+  id: z.string().uuid(),
+  title: z.string(),
+  body: z.string().nullable(),
+  type: z.enum([NOTIFICATION_TYPES.REVIEW_DUE]),
+  status: notificationStatusSchema,
+  sent_at: z.string(),
+  read_at: z.string().nullable(),
+  note_id: z.string().uuid().nullable(),
+  review_log_id: z.string().uuid().nullable(),
+  note: joinedNoteSchema.nullable().optional(),
+});
+
+const notificationListItemSchema = notificationListRowSchema.transform(
+  ({ note, ...item }) => ({
+    ...item,
+    noteTitle: note?.title ?? null,
+  }),
+);
+
+export type NotificationListItemType = z.infer<
+  typeof notificationListItemSchema
+>;
+
+type NotificationQueryClientType = {
+  auth: Pick<SupabaseClient<Database>["auth"], "getUser">;
+  from: SupabaseClient<Database>["from"];
+};
+
+type NotificationQueryOptionsType = {
+  supabase?: NotificationQueryClientType;
+  userId?: string;
+};
+
+type NotificationListOptionsType = NotificationQueryOptionsType & {
+  limit?: number;
+};
+
+function normalizeNotificationListLimit(limit: number | undefined) {
+  if (typeof limit !== "number" || !Number.isInteger(limit)) {
+    return DEFAULT_NOTIFICATION_LIST_LIMIT;
+  }
+
+  return Math.min(Math.max(limit, 1), MAX_NOTIFICATION_LIST_LIMIT);
 }
 
-export async function markAsRead(_id: string) {
-  return null;
+/**
+ * Defaults to the RSC client; route handlers and server actions should inject
+ * their strict client and userId after their own auth check.
+ */
+async function getNotificationQueryContext(
+  options: NotificationQueryOptionsType = {},
+) {
+  const supabase = options.supabase ?? (await createServerComponentClient());
+
+  if (options.userId) {
+    return {
+      supabase,
+      userId: options.userId,
+    };
+  }
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  return {
+    supabase,
+    userId: user?.id ?? null,
+  };
+}
+
+export async function getUnreadCount(
+  options: NotificationQueryOptionsType = {},
+): Promise<number> {
+  const { supabase, userId } = await getNotificationQueryContext(options);
+
+  if (!userId) return 0;
+
+  const { count, error } = await supabase
+    .from("notifications")
+    .select("id", { count: "exact", head: true })
+    .eq("user_id", userId)
+    .eq("type", NOTIFICATION_TYPES.REVIEW_DUE)
+    .eq("status", NOTIFICATION_STATUS.SENT);
+
+  if (error) throw error;
+
+  return count ?? 0;
+}
+
+export async function getNotificationList(
+  options: NotificationListOptionsType = {},
+): Promise<NotificationListItemType[]> {
+  const { supabase, userId } = await getNotificationQueryContext(options);
+
+  if (!userId) return [];
+
+  const limit = normalizeNotificationListLimit(options.limit);
+  const { data, error } = await supabase
+    .from("notifications")
+    .select(
+      "id, title, body, type, status, sent_at, read_at, note_id, review_log_id, note:notes(title)",
+    )
+    .eq("user_id", userId)
+    .eq("type", NOTIFICATION_TYPES.REVIEW_DUE)
+    .in("status", [
+      NOTIFICATION_STATUS.SENT,
+      NOTIFICATION_STATUS.READ,
+      NOTIFICATION_STATUS.SKIPPED,
+    ])
+    .order("sent_at", { ascending: false })
+    .limit(limit);
+
+  if (error) throw error;
+
+  const parsed = z.array(notificationListItemSchema).safeParse(data);
+
+  if (!parsed.success) {
+    throw parsed.error;
+  }
+
+  return parsed.data;
 }

--- a/src/features/notifications/queries.ts
+++ b/src/features/notifications/queries.ts
@@ -25,7 +25,7 @@ const notificationListRowSchema = z.object({
   id: z.string().uuid(),
   title: z.string(),
   body: z.string().nullable(),
-  type: z.enum([NOTIFICATION_TYPES.REVIEW_DUE]),
+  type: z.enum([NOTIFICATION_TYPES.REVIEW]),
   status: notificationStatusSchema,
   sent_at: z.string(),
   read_at: z.string().nullable(),
@@ -104,7 +104,7 @@ export async function getUnreadCount(
     .from("notifications")
     .select("id", { count: "exact", head: true })
     .eq("user_id", userId)
-    .eq("type", NOTIFICATION_TYPES.REVIEW_DUE)
+    .eq("type", NOTIFICATION_TYPES.REVIEW)
     .eq("status", NOTIFICATION_STATUS.SENT);
 
   if (error) throw error;
@@ -126,7 +126,7 @@ export async function getNotificationList(
       "id, title, body, type, status, sent_at, read_at, note_id, review_log_id, note:notes(title)",
     )
     .eq("user_id", userId)
-    .eq("type", NOTIFICATION_TYPES.REVIEW_DUE)
+    .eq("type", NOTIFICATION_TYPES.REVIEW)
     .in("status", [
       NOTIFICATION_STATUS.SENT,
       NOTIFICATION_STATUS.READ,

--- a/src/features/notifications/schema.ts
+++ b/src/features/notifications/schema.ts
@@ -1,0 +1,35 @@
+import { z } from "zod";
+
+const notificationUuidSchema = z.string().uuid();
+
+export const notificationIdSchema = notificationUuidSchema;
+export const notificationNoteIdSchema = notificationUuidSchema;
+
+export const pushSubscriptionEndpointSchema = z.string().trim().url();
+
+export const pushSubscriptionSchema = z
+  .object({
+    endpoint: pushSubscriptionEndpointSchema,
+    keys: z
+      .object({
+        p256dh: z.string().trim().min(1),
+        auth: z.string().trim().min(1),
+      })
+      .strict(),
+  })
+  .strip();
+
+export const notificationTimeSchema = z
+  .string()
+  .regex(/^([01]\d|2[0-3]):[0-5]\d$/);
+
+export const setNotificationTimeSchema = z.object({
+  noteId: notificationNoteIdSchema,
+  time: notificationTimeSchema.nullable(),
+});
+
+export type PushSubscriptionInputType = z.infer<typeof pushSubscriptionSchema>;
+export type NotificationTimeInputType = z.infer<typeof notificationTimeSchema>;
+export type SetNotificationTimeInputType = z.infer<
+  typeof setNotificationTimeSchema
+>;

--- a/src/features/notifications/tests/actions.test.ts
+++ b/src/features/notifications/tests/actions.test.ts
@@ -1,0 +1,223 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { getNoteDetailRoute, ROUTES } from "@/lib/constants/routes";
+
+const REDIRECT_ERROR = new Error("NEXT_REDIRECT");
+const USER_ID = "11111111-1111-4111-8111-111111111111";
+const NOTE_ID = "22222222-2222-4222-8222-222222222222";
+const NOTIFICATION_ID = "33333333-3333-4333-8333-333333333333";
+const ENDPOINT = "https://push.example.test/subscription-id";
+const CONFIRMED_AT = "2026-04-27T00:00:00.000Z";
+
+const { createClientMock, redirectMock, revalidatePathMock } = vi.hoisted(
+  () => ({
+    createClientMock: vi.fn(),
+    redirectMock: vi.fn(),
+    revalidatePathMock: vi.fn(),
+  }),
+);
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: createClientMock,
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: revalidatePathMock,
+}));
+
+vi.mock("next/navigation", () => ({
+  redirect: redirectMock,
+}));
+
+import {
+  markNotificationAsReadAction,
+  setNotificationTimeAction,
+  subscribeToPushAction,
+  unsubscribeFromPushAction,
+} from "../actions";
+
+function createSupabaseMock({
+  userId = USER_ID,
+  emailConfirmedAt = CONFIRMED_AT,
+  upsertError = null,
+  deleteError = null,
+  rpcData = true,
+  rpcError = null,
+}: {
+  userId?: string | null;
+  emailConfirmedAt?: string | null;
+  upsertError?: { message: string } | null;
+  deleteError?: { message: string } | null;
+  rpcData?: boolean | null;
+  rpcError?: { message: string } | null;
+} = {}) {
+  const upsertMock = vi.fn().mockResolvedValue({ error: upsertError });
+  const deleteUserEqMock = vi.fn().mockResolvedValue({ error: deleteError });
+  const deleteEndpointEqMock = vi.fn().mockReturnValue({
+    eq: deleteUserEqMock,
+  });
+  const deleteMock = vi.fn().mockReturnValue({
+    eq: deleteEndpointEqMock,
+  });
+  const fromMock = vi.fn().mockReturnValue({
+    upsert: upsertMock,
+    delete: deleteMock,
+  });
+  const rpcMock = vi.fn().mockResolvedValue({
+    data: rpcError ? null : rpcData,
+    error: rpcError,
+  });
+
+  return {
+    deleteEndpointEqMock,
+    deleteMock,
+    deleteUserEqMock,
+    fromMock,
+    rpcMock,
+    upsertMock,
+    supabase: {
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: {
+            user: userId
+              ? { id: userId, email_confirmed_at: emailConfirmedAt }
+              : null,
+          },
+        }),
+      },
+      from: fromMock,
+      rpc: rpcMock,
+    },
+  };
+}
+
+function createPushSubscriptionInput() {
+  return {
+    endpoint: ENDPOINT,
+    keys: {
+      p256dh: "p256dh-key",
+      auth: "auth-secret",
+    },
+  };
+}
+
+describe("notification server actions", () => {
+  beforeEach(() => {
+    createClientMock.mockReset();
+    redirectMock.mockReset();
+    revalidatePathMock.mockReset();
+    redirectMock.mockImplementation(() => {
+      throw REDIRECT_ERROR;
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns a validation error without opening a Supabase client for an invalid subscription", async () => {
+    const result = await subscribeToPushAction({ endpoint: "not-a-url" });
+
+    expect(result).toEqual({
+      success: false,
+      error: "브라우저 구독 정보가 올바르지 않습니다.",
+    });
+    expect(createClientMock).not.toHaveBeenCalled();
+  });
+
+  it("upserts a valid push subscription by endpoint", async () => {
+    const { supabase, upsertMock } = createSupabaseMock();
+    createClientMock.mockResolvedValue(supabase);
+
+    const result = await subscribeToPushAction(createPushSubscriptionInput());
+
+    expect(upsertMock).toHaveBeenCalledWith(
+      {
+        user_id: USER_ID,
+        endpoint: ENDPOINT,
+        p256dh: "p256dh-key",
+        auth: "auth-secret",
+      },
+      { onConflict: "endpoint" },
+    );
+    expect(revalidatePathMock).toHaveBeenCalledWith(ROUTES.MYPAGE);
+    expect(result).toEqual({ success: true });
+  });
+
+  it("deletes the current user's matching push subscription", async () => {
+    const { supabase, fromMock, deleteEndpointEqMock, deleteUserEqMock } =
+      createSupabaseMock();
+    createClientMock.mockResolvedValue(supabase);
+
+    const result = await unsubscribeFromPushAction(ENDPOINT);
+
+    expect(fromMock).toHaveBeenCalledWith("push_subscriptions");
+    expect(deleteEndpointEqMock).toHaveBeenCalledWith("endpoint", ENDPOINT);
+    expect(deleteUserEqMock).toHaveBeenCalledWith("user_id", USER_ID);
+    expect(result).toEqual({ success: true });
+  });
+
+  it("calls the read RPC instead of updating notifications directly", async () => {
+    const { supabase, fromMock, rpcMock } = createSupabaseMock({
+      rpcData: true,
+    });
+    createClientMock.mockResolvedValue(supabase);
+
+    const result = await markNotificationAsReadAction(NOTIFICATION_ID);
+
+    expect(rpcMock).toHaveBeenCalledWith("mark_notification_as_read", {
+      p_notification_id: NOTIFICATION_ID,
+    });
+    expect(fromMock).not.toHaveBeenCalled();
+    expect(result).toEqual({ success: true, updated: true });
+  });
+
+  it("uses the notification time RPC default when clearing the override", async () => {
+    const { supabase, rpcMock } = createSupabaseMock({ rpcData: null });
+    createClientMock.mockResolvedValue(supabase);
+
+    const result = await setNotificationTimeAction(NOTE_ID, null);
+
+    expect(rpcMock).toHaveBeenCalledWith("update_notification_time_of_day", {
+      p_note_id: NOTE_ID,
+    });
+    expect(revalidatePathMock).toHaveBeenCalledWith(
+      getNoteDetailRoute(NOTE_ID),
+    );
+    expect(result).toEqual({ success: true });
+  });
+
+  it("returns a note validation error before setting notification time", async () => {
+    const result = await setNotificationTimeAction("not-a-uuid", "09:30");
+
+    expect(result).toEqual({
+      success: false,
+      error: "알림 대상을 찾을 수 없습니다.",
+    });
+    expect(createClientMock).not.toHaveBeenCalled();
+  });
+
+  it("returns a time validation error before setting notification time", async () => {
+    const result = await setNotificationTimeAction(NOTE_ID, "24:00");
+
+    expect(result).toEqual({
+      success: false,
+      error: "알림 시간이 올바르지 않습니다.",
+    });
+    expect(createClientMock).not.toHaveBeenCalled();
+  });
+
+  it("redirects unverified users before mutating notification data", async () => {
+    const { supabase, upsertMock } = createSupabaseMock({
+      emailConfirmedAt: null,
+    });
+    createClientMock.mockResolvedValue(supabase);
+
+    await expect(
+      subscribeToPushAction(createPushSubscriptionInput()),
+    ).rejects.toBe(REDIRECT_ERROR);
+
+    expect(redirectMock).toHaveBeenCalledWith(ROUTES.VERIFY_EMAIL);
+    expect(upsertMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/notifications/tests/queries.test.ts
+++ b/src/features/notifications/tests/queries.test.ts
@@ -1,9 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import {
-  NOTIFICATION_STATUS,
-  NOTIFICATION_TYPES,
-} from "@/lib/constants/notifications";
+import { NOTIFICATION_STATUS } from "@/lib/constants/notifications";
 
 const USER_ID = "11111111-1111-4111-8111-111111111111";
 
@@ -115,10 +112,7 @@ describe("notification queries", () => {
       head: true,
     });
     expect(userEqMock).toHaveBeenCalledWith("user_id", USER_ID);
-    expect(typeEqMock).toHaveBeenCalledWith(
-      "type",
-      NOTIFICATION_TYPES.REVIEW_DUE,
-    );
+    expect(typeEqMock).toHaveBeenCalledWith("type", "REVIEW");
     expect(statusEqMock).toHaveBeenCalledWith(
       "status",
       NOTIFICATION_STATUS.SENT,
@@ -159,7 +153,7 @@ describe("notification queries", () => {
         id: "22222222-2222-4222-8222-222222222222",
         title: "복습 시간이에요",
         body: "Notification body",
-        type: NOTIFICATION_TYPES.REVIEW_DUE,
+        type: "REVIEW",
         status: NOTIFICATION_STATUS.SENT,
         sent_at: "2026-04-27T01:00:00.000Z",
         read_at: null,
@@ -176,10 +170,7 @@ describe("notification queries", () => {
       "id, title, body, type, status, sent_at, read_at, note_id, review_log_id, note:notes(title)",
     );
     expect(userEqMock).toHaveBeenCalledWith("user_id", USER_ID);
-    expect(typeEqMock).toHaveBeenCalledWith(
-      "type",
-      NOTIFICATION_TYPES.REVIEW_DUE,
-    );
+    expect(typeEqMock).toHaveBeenCalledWith("type", "REVIEW");
     expect(inMock).toHaveBeenCalledWith("status", [
       NOTIFICATION_STATUS.SENT,
       NOTIFICATION_STATUS.READ,
@@ -192,7 +183,7 @@ describe("notification queries", () => {
         id: "22222222-2222-4222-8222-222222222222",
         title: "복습 시간이에요",
         body: "Notification body",
-        type: NOTIFICATION_TYPES.REVIEW_DUE,
+        type: "REVIEW",
         status: NOTIFICATION_STATUS.SENT,
         sent_at: "2026-04-27T01:00:00.000Z",
         read_at: null,

--- a/src/features/notifications/tests/queries.test.ts
+++ b/src/features/notifications/tests/queries.test.ts
@@ -1,0 +1,225 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  NOTIFICATION_STATUS,
+  NOTIFICATION_TYPES,
+} from "@/lib/constants/notifications";
+
+const USER_ID = "11111111-1111-4111-8111-111111111111";
+
+const { createServerComponentClientMock } = vi.hoisted(() => ({
+  createServerComponentClientMock: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createServerComponentClient: createServerComponentClientMock,
+}));
+
+import { getNotificationList, getUnreadCount } from "../queries";
+
+function withAuth<T extends Record<string, unknown>>(
+  supabase: T,
+  userId: string | null,
+) {
+  return {
+    ...supabase,
+    auth: {
+      getUser: vi.fn().mockResolvedValue({
+        data: {
+          user: userId ? { id: userId } : null,
+        },
+      }),
+    },
+  };
+}
+
+function createUnreadCountMock(count: number | null) {
+  const statusEqMock = vi.fn().mockResolvedValue({ count, error: null });
+  const typeEqMock = vi.fn().mockReturnValue({
+    eq: statusEqMock,
+  });
+  const userEqMock = vi.fn().mockReturnValue({
+    eq: typeEqMock,
+  });
+  const selectMock = vi.fn().mockReturnValue({
+    eq: userEqMock,
+  });
+
+  return {
+    selectMock,
+    statusEqMock,
+    typeEqMock,
+    userEqMock,
+    supabase: withAuth(
+      {
+        from: vi.fn().mockReturnValue({
+          select: selectMock,
+        }),
+      },
+      USER_ID,
+    ),
+  };
+}
+
+function createNotificationListMock(data: unknown) {
+  const limitMock = vi.fn().mockResolvedValue({ data, error: null });
+  const orderMock = vi.fn().mockReturnValue({
+    limit: limitMock,
+  });
+  const inMock = vi.fn().mockReturnValue({
+    order: orderMock,
+  });
+  const typeEqMock = vi.fn().mockReturnValue({
+    in: inMock,
+  });
+  const userEqMock = vi.fn().mockReturnValue({
+    eq: typeEqMock,
+  });
+  const selectMock = vi.fn().mockReturnValue({
+    eq: userEqMock,
+  });
+
+  return {
+    inMock,
+    limitMock,
+    orderMock,
+    selectMock,
+    typeEqMock,
+    userEqMock,
+    supabase: withAuth(
+      {
+        from: vi.fn().mockReturnValue({
+          select: selectMock,
+        }),
+      },
+      USER_ID,
+    ),
+  };
+}
+
+describe("notification queries", () => {
+  beforeEach(() => {
+    createServerComponentClientMock.mockReset();
+  });
+
+  it("counts SENT notifications for the current user", async () => {
+    const { supabase, selectMock, userEqMock, typeEqMock, statusEqMock } =
+      createUnreadCountMock(3);
+    createServerComponentClientMock.mockResolvedValue(supabase);
+
+    const result = await getUnreadCount();
+
+    expect(supabase.from).toHaveBeenCalledWith("notifications");
+    expect(selectMock).toHaveBeenCalledWith("id", {
+      count: "exact",
+      head: true,
+    });
+    expect(userEqMock).toHaveBeenCalledWith("user_id", USER_ID);
+    expect(typeEqMock).toHaveBeenCalledWith(
+      "type",
+      NOTIFICATION_TYPES.REVIEW_DUE,
+    );
+    expect(statusEqMock).toHaveBeenCalledWith(
+      "status",
+      NOTIFICATION_STATUS.SENT,
+    );
+    expect(result).toBe(3);
+  });
+
+  it("uses an injected user id without opening the RSC client", async () => {
+    const { supabase } = createUnreadCountMock(1);
+
+    await expect(getUnreadCount({ supabase, userId: USER_ID })).resolves.toBe(
+      1,
+    );
+
+    expect(supabase.auth.getUser).not.toHaveBeenCalled();
+    expect(createServerComponentClientMock).not.toHaveBeenCalled();
+  });
+
+  it("returns an empty unread count when there is no logged-in user", async () => {
+    createServerComponentClientMock.mockResolvedValue(
+      withAuth({ from: vi.fn() }, null),
+    );
+
+    await expect(getUnreadCount()).resolves.toBe(0);
+  });
+
+  it("returns notification list items with joined note titles", async () => {
+    const {
+      supabase,
+      selectMock,
+      userEqMock,
+      typeEqMock,
+      inMock,
+      orderMock,
+      limitMock,
+    } = createNotificationListMock([
+      {
+        id: "22222222-2222-4222-8222-222222222222",
+        title: "복습 시간이에요",
+        body: "Notification body",
+        type: NOTIFICATION_TYPES.REVIEW_DUE,
+        status: NOTIFICATION_STATUS.SENT,
+        sent_at: "2026-04-27T01:00:00.000Z",
+        read_at: null,
+        note_id: "33333333-3333-4333-8333-333333333333",
+        review_log_id: "44444444-4444-4444-8444-444444444444",
+        note: { title: "Joined note title" },
+      },
+    ]);
+    createServerComponentClientMock.mockResolvedValue(supabase);
+
+    const result = await getNotificationList({ limit: 100 });
+
+    expect(selectMock).toHaveBeenCalledWith(
+      "id, title, body, type, status, sent_at, read_at, note_id, review_log_id, note:notes(title)",
+    );
+    expect(userEqMock).toHaveBeenCalledWith("user_id", USER_ID);
+    expect(typeEqMock).toHaveBeenCalledWith(
+      "type",
+      NOTIFICATION_TYPES.REVIEW_DUE,
+    );
+    expect(inMock).toHaveBeenCalledWith("status", [
+      NOTIFICATION_STATUS.SENT,
+      NOTIFICATION_STATUS.READ,
+      NOTIFICATION_STATUS.SKIPPED,
+    ]);
+    expect(orderMock).toHaveBeenCalledWith("sent_at", { ascending: false });
+    expect(limitMock).toHaveBeenCalledWith(50);
+    expect(result).toEqual([
+      {
+        id: "22222222-2222-4222-8222-222222222222",
+        title: "복습 시간이에요",
+        body: "Notification body",
+        type: NOTIFICATION_TYPES.REVIEW_DUE,
+        status: NOTIFICATION_STATUS.SENT,
+        sent_at: "2026-04-27T01:00:00.000Z",
+        read_at: null,
+        note_id: "33333333-3333-4333-8333-333333333333",
+        review_log_id: "44444444-4444-4444-8444-444444444444",
+        noteTitle: "Joined note title",
+      },
+    ]);
+  });
+
+  it("throws when notification list rows do not match the expected schema", async () => {
+    const { supabase } = createNotificationListMock([
+      {
+        id: "22222222-2222-4222-8222-222222222222",
+        title: "Review due",
+        body: null,
+        type: "UNKNOWN",
+        status: "SENT",
+        sent_at: "2026-04-27T01:00:00.000Z",
+        read_at: null,
+        note_id: null,
+        review_log_id: null,
+        note: null,
+      },
+    ]);
+    createServerComponentClientMock.mockResolvedValue(supabase);
+
+    await expect(getNotificationList()).rejects.toThrow();
+  });
+});

--- a/src/features/notifications/tests/schema.test.ts
+++ b/src/features/notifications/tests/schema.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+
+import { notificationTimeSchema, pushSubscriptionSchema } from "../schema";
+
+describe("pushSubscriptionSchema", () => {
+  it("accepts the browser push subscription JSON shape", () => {
+    const result = pushSubscriptionSchema.safeParse({
+      endpoint: "https://push.example.test/subscription-id",
+      expirationTime: null,
+      keys: {
+        p256dh: "p256dh-key",
+        auth: "auth-secret",
+      },
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects a subscription without required keys", () => {
+    const result = pushSubscriptionSchema.safeParse({
+      endpoint: "https://push.example.test/subscription-id",
+      keys: {
+        p256dh: "p256dh-key",
+      },
+    });
+
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("notificationTimeSchema", () => {
+  it.each(["00:00", "09:30", "23:59"])("accepts %s", (time) => {
+    expect(notificationTimeSchema.safeParse(time).success).toBe(true);
+  });
+
+  it.each(["9:30", "24:00", "12:60", "12:30:00"])("rejects %s", (time) => {
+    expect(notificationTimeSchema.safeParse(time).success).toBe(false);
+  });
+});

--- a/src/lib/constants/notifications.ts
+++ b/src/lib/constants/notifications.ts
@@ -1,0 +1,15 @@
+export const NOTIFICATION_TYPES = {
+  REVIEW_DUE: "REVIEW_DUE",
+} as const;
+
+export const NOTIFICATION_STATUS = {
+  SENT: "SENT",
+  READ: "READ",
+  SKIPPED: "SKIPPED",
+} as const;
+
+export type NotificationKindType =
+  (typeof NOTIFICATION_TYPES)[keyof typeof NOTIFICATION_TYPES];
+
+export type NotificationStatusType =
+  (typeof NOTIFICATION_STATUS)[keyof typeof NOTIFICATION_STATUS];

--- a/src/lib/constants/notifications.ts
+++ b/src/lib/constants/notifications.ts
@@ -1,5 +1,6 @@
 export const NOTIFICATION_TYPES = {
-  REVIEW_DUE: "REVIEW_DUE",
+  REVIEW: "REVIEW",
+  SYSTEM: "SYSTEM",
 } as const;
 
 export const NOTIFICATION_STATUS = {

--- a/src/types/notifications.types.ts
+++ b/src/types/notifications.types.ts
@@ -1,12 +1,11 @@
+import type {
+  NotificationKindType,
+  NotificationStatusType,
+} from "@/lib/constants/notifications";
 import type { InsertDto, Row, UpdateDto } from "@/types/db.helpers";
 
-export type NotificationStatus =
-  | "PENDING"
-  | "SENT"
-  | "READ"
-  | "SKIPPED"
-  | "FAILED";
-export type NotificationType = "REVIEW" | "SYSTEM";
+export type NotificationStatus = NotificationStatusType;
+export type NotificationType = NotificationKindType;
 
 // DB Row를 베이스로 status/type을 리터럴 유니온으로 override
 type NotificationRow = Omit<Row<"notifications">, "status" | "type"> & {
@@ -21,11 +20,6 @@ export type NotificationUpdate = UpdateDto<"notifications">;
 export type NotificationId = Notification["id"];
 export type NotificationUserId = Notification["user_id"];
 export type NotificationNoteId = Notification["note_id"];
-
-export type NotificationListItem = Pick<
-  Notification,
-  "id" | "title" | "body" | "type" | "status" | "sent_at" | "read_at"
->;
 
 export type NotificationCreateInput = Omit<
   NotificationInsert,


### PR DESCRIPTION
## 개요

알림 기능의 서버 레이어(actions/queries/schema)와 알림 목록 조회 GET API를 구현합니다. 기존 stub이던 `/api/notifications`를 실제 인증/조회 흐름으로 대체했습니다.

## PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] UI 디자인 변경
- [ ] 코드 리팩토링
- [x] 테스트 추가/수정
- [ ] 문서 수정
- [ ] 빌드/패키지 설정 변경

## 관련 이슈

closes #174

## 작업 내용

- `src/features/notifications/`
  - `actions.ts`: 알림 관련 Server Actions 추가
  - `queries.ts`: `getNotificationList`, `getUnreadCount` 등 조회 로직 구현
  - `schema.ts`: Zod 스키마(`pushSubscriptionSchema`, `notificationTimeSchema`, `setNotificationTimeSchema`) 정의
  - `tests/`: actions/queries/schema 단위 테스트 추가
- `src/app/api/notifications/route.ts`: stub 제거, 인증된 사용자의 알림 목록과 미읽음 카운트를 함께 반환하도록 변경 (`force-dynamic`)
- `src/lib/constants/notifications.ts`: `NOTIFICATION_TYPES`, `NOTIFICATION_STATUS` 상수 및 파생 타입 정의
- `src/types/notifications.types.ts`: 상수 기반 리터럴 타입으로 정리, 미사용 `NotificationListItem` 제거

## 테스트 방법

1. `pnpm test src/features/notifications` — actions/queries/schema 테스트 통과 확인
2. `pnpm test src/app/api/notifications/route.test.ts` — 인증/비인증/에러 케이스 응답 확인
3. 로그인 상태로 `GET /api/notifications` 호출 시 `{ items, unreadCount }` 반환, 비로그인 시 401 확인

## 리뷰 요구사항 (선택)

- `schema.ts`의 `pushSubscriptionSchema`가 `.strict()` + `.strip()` 조합인 부분 의도 확인 부탁드립니다 (keys는 strict, 최상위는 추가 필드 무시).
- `NotificationStatus`에서 기존 `PENDING`/`FAILED` 리터럴이 제거되었습니다 — DB 컬럼 값과 정합한지 확인 필요.

## 체크리스트

- [x] 코드 컨벤션 준수
- [x] 커밋 메시지 컨벤션 준수
- [x] lint 통과
- [x] typecheck 통과
- [ ] (DB 변경 시) migration 포함 및 로컬 재현 확인 — 해당 없음
- [ ] (권한/RLS 영향 시) 정책 변경 요약 기재 — 해당 없음
- [ ] UI 변경 시 스크린샷/짧은 설명 첨부 — 해당 없음
- [x] 셀프 리뷰 완료