### PR TITLE
feat: #175 Vercel Cron 디스패처 라우트 및 Web Push 래퍼 구현

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,9 @@ APP_URL=http://localhost:3000
 NEXT_PUBLIC_VAPID_PUBLIC_KEY=your-vapid-public-key
 VAPID_PRIVATE_KEY=your-vapid-private-key
 
+# Vercel Cron
+CRON_SECRET=your-cron-secret
+
 # AEAD 기반 이메일 인증 ticket 암호화/복호화에 사용하는 서버 전용 비밀 키
 EMAIL_TICKET_SECRET=email-ticket-secret
 SUPABASE_HOOK_SECRET=supabase-hook-secret

--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ cp .env.example .env.local
 
 팀 공유 채널에서 환경 변수 값을 받아 `.env.local`에 입력하세요.
 
+### Vercel Cron
+
+`vercel.json`의 `/api/cron/dispatch-notifications`는 복습 알림 지연을 줄이기 위해 5분 간격(`*/5 * * * *`)으로 실행합니다. 이 주기는 Vercel Pro/Team 이상 플랜을 전제로 하며, Hobby 플랜 배포 시에는 플랜 또는 스케줄 조정이 필요합니다.
+
 ---
 
 ## 4. 개발 서버 실행

--- a/src/app/api/cron/dispatch-notifications/route.test.ts
+++ b/src/app/api/cron/dispatch-notifications/route.test.ts
@@ -1,0 +1,330 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { createAdminClientMock, sendPushMock, setVapidDetailsMock } = vi.hoisted(
+  () => ({
+    createAdminClientMock: vi.fn(),
+    sendPushMock: vi.fn(),
+    setVapidDetailsMock: vi.fn(),
+  }),
+);
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: createAdminClientMock,
+}));
+
+vi.mock("@/lib/webPush", () => ({
+  sendPush: sendPushMock,
+  setVapidDetails: setVapidDetailsMock,
+}));
+
+import * as dispatchRoute from "./route";
+
+const USER_ID = "11111111-1111-4111-8111-111111111111";
+const NOTE_ID = "22222222-2222-4222-8222-222222222222";
+const REVIEW_LOG_ID = "33333333-3333-4333-8333-333333333333";
+const NOTIFICATION_ID = "44444444-4444-4444-8444-444444444444";
+const SUBSCRIPTION_ID = "55555555-5555-4555-8555-555555555555";
+const ENDPOINT = "https://push.example.test/subscription-id";
+const CRON_URL = "http://localhost/api/cron/dispatch-notifications";
+
+const CLAIMED_LOG = {
+  id: REVIEW_LOG_ID,
+  note_id: NOTE_ID,
+  round: 1,
+  scheduled_at: "2026-04-27T00:00:00.000Z",
+  user_id: USER_ID,
+};
+
+function createAuthorizedRequest() {
+  return new Request(CRON_URL, {
+    headers: {
+      authorization: "Bearer cron-secret",
+    },
+  });
+}
+
+function createSupabaseMock({
+  claimedLogs = [CLAIMED_LOG],
+  insertedNotification = { id: NOTIFICATION_ID },
+  note = { title: "알림 노트" },
+  subscriptions = [
+    {
+      auth: "auth-secret",
+      endpoint: ENDPOINT,
+      id: SUBSCRIPTION_ID,
+      p256dh: "p256dh-key",
+    },
+  ],
+}: {
+  claimedLogs?: (typeof CLAIMED_LOG)[];
+  insertedNotification?: { id: string } | null;
+  note?: { title: string } | null;
+  subscriptions?: {
+    auth: string;
+    endpoint: string;
+    id: string;
+    p256dh: string;
+  }[];
+} = {}) {
+  const rpcMock = vi.fn().mockResolvedValue({
+    data: claimedLogs,
+    error: null,
+  });
+
+  const notesMaybeSingleMock = vi.fn().mockResolvedValue({
+    data: note,
+    error: null,
+  });
+  const notesUserEqMock = vi.fn().mockReturnValue({
+    maybeSingle: notesMaybeSingleMock,
+  });
+  const notesIdEqMock = vi.fn().mockReturnValue({
+    eq: notesUserEqMock,
+  });
+  const notesSelectMock = vi.fn().mockReturnValue({
+    eq: notesIdEqMock,
+  });
+
+  const subscriptionsEqMock = vi.fn().mockResolvedValue({
+    data: subscriptions,
+    error: null,
+  });
+  const subscriptionsSelectMock = vi.fn().mockReturnValue({
+    eq: subscriptionsEqMock,
+  });
+  const deleteSubscriptionEqMock = vi.fn().mockResolvedValue({ error: null });
+  const deleteSubscriptionMock = vi.fn().mockReturnValue({
+    eq: deleteSubscriptionEqMock,
+  });
+
+  const notificationUpsertMaybeSingleMock = vi.fn().mockResolvedValue({
+    data: insertedNotification,
+    error: null,
+  });
+  const notificationUpsertSelectMock = vi.fn().mockReturnValue({
+    maybeSingle: notificationUpsertMaybeSingleMock,
+  });
+  const notificationUpsertMock = vi.fn().mockReturnValue({
+    select: notificationUpsertSelectMock,
+  });
+
+  const reviewLogUpdateEqMock = vi.fn().mockResolvedValue({ error: null });
+  const reviewLogUpdateMock = vi.fn().mockReturnValue({
+    eq: reviewLogUpdateEqMock,
+  });
+
+  const fromMock = vi.fn((table: string) => {
+    if (table === "notes") {
+      return {
+        select: notesSelectMock,
+      };
+    }
+
+    if (table === "push_subscriptions") {
+      return {
+        delete: deleteSubscriptionMock,
+        select: subscriptionsSelectMock,
+      };
+    }
+
+    if (table === "notifications") {
+      return {
+        upsert: notificationUpsertMock,
+      };
+    }
+
+    if (table === "review_logs") {
+      return {
+        update: reviewLogUpdateMock,
+      };
+    }
+
+    throw new Error(`Unexpected table: ${table}`);
+  });
+
+  return {
+    deleteSubscriptionEqMock,
+    fromMock,
+    notificationUpsertMock,
+    reviewLogUpdateMock,
+    rpcMock,
+    supabase: {
+      from: fromMock,
+      rpc: rpcMock,
+    },
+  };
+}
+
+describe("/api/cron/dispatch-notifications", () => {
+  beforeEach(() => {
+    createAdminClientMock.mockReset();
+    sendPushMock.mockReset();
+    setVapidDetailsMock.mockReset();
+    vi.stubEnv("CRON_SECRET", "cron-secret");
+    sendPushMock.mockResolvedValue({ ok: true });
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it("rejects requests without the cron bearer token", async () => {
+    const response = await dispatchRoute.GET(new Request(CRON_URL));
+
+    await expect(response.json()).resolves.toEqual({ error: "unauthorized" });
+    expect(response.status).toBe(401);
+    expect(createAdminClientMock).not.toHaveBeenCalled();
+  });
+
+  it("returns a server error when the cron secret is missing", async () => {
+    vi.stubEnv("CRON_SECRET", "");
+
+    const response = await dispatchRoute.GET(createAuthorizedRequest());
+
+    await expect(response.json()).resolves.toEqual({
+      error: "cron_secret_missing",
+    });
+    expect(response.status).toBe(500);
+    expect(createAdminClientMock).not.toHaveBeenCalled();
+  });
+
+  it("claims due review logs, creates an in-app notification, and sends push", async () => {
+    const { notificationUpsertMock, reviewLogUpdateMock, rpcMock, supabase } =
+      createSupabaseMock();
+    createAdminClientMock.mockReturnValue(supabase);
+
+    const response = await dispatchRoute.GET(createAuthorizedRequest());
+
+    await expect(response.json()).resolves.toEqual({
+      claimed: 1,
+      dispatched: 1,
+      expiredSubscriptions: 0,
+      itemFailed: 0,
+      pushFailed: 0,
+      pushed: 1,
+    });
+    expect(response.status).toBe(200);
+    expect(setVapidDetailsMock).toHaveBeenCalledTimes(1);
+    expect(rpcMock).toHaveBeenCalledWith("claim_due_review_logs", {
+      p_limit: 200,
+    });
+    expect(notificationUpsertMock).toHaveBeenCalledWith(
+      {
+        body: "알림 노트",
+        note_id: NOTE_ID,
+        review_log_id: REVIEW_LOG_ID,
+        status: "SENT",
+        title: "복습 시간이에요",
+        type: "REVIEW",
+        user_id: USER_ID,
+      },
+      { ignoreDuplicates: true, onConflict: "review_log_id,type" },
+    );
+    expect(reviewLogUpdateMock).toHaveBeenCalledWith({
+      notification_dispatched_at: expect.any(String),
+    });
+    expect(sendPushMock).toHaveBeenCalledWith(
+      {
+        endpoint: ENDPOINT,
+        keys: {
+          auth: "auth-secret",
+          p256dh: "p256dh-key",
+        },
+      },
+      {
+        body: "알림 노트",
+        data: {
+          noteId: NOTE_ID,
+          notificationId: NOTIFICATION_ID,
+          reviewLogId: REVIEW_LOG_ID,
+          url: `/notes/${NOTE_ID}/review`,
+        },
+        title: "복습 시간이에요",
+      },
+    );
+  });
+
+  it("deletes expired push subscriptions", async () => {
+    const { deleteSubscriptionEqMock, supabase } = createSupabaseMock();
+    createAdminClientMock.mockReturnValue(supabase);
+    sendPushMock.mockResolvedValue({ gone: true, ok: false });
+
+    const response = await dispatchRoute.GET(createAuthorizedRequest());
+
+    await expect(response.json()).resolves.toMatchObject({
+      expiredSubscriptions: 1,
+      pushFailed: 0,
+      pushed: 0,
+    });
+    expect(deleteSubscriptionEqMock).toHaveBeenCalledWith(
+      "id",
+      SUBSCRIPTION_ID,
+    );
+  });
+
+  it("does not send duplicate push when the notification already exists", async () => {
+    const { supabase } = createSupabaseMock({
+      insertedNotification: null,
+    });
+    createAdminClientMock.mockReturnValue(supabase);
+
+    const response = await dispatchRoute.GET(createAuthorizedRequest());
+
+    await expect(response.json()).resolves.toMatchObject({
+      dispatched: 1,
+      pushed: 0,
+    });
+    expect(sendPushMock).not.toHaveBeenCalled();
+  });
+
+  it("does not create a notification when the note is missing", async () => {
+    const { notificationUpsertMock, reviewLogUpdateMock, supabase } =
+      createSupabaseMock({
+        note: null,
+      });
+    createAdminClientMock.mockReturnValue(supabase);
+
+    const response = await dispatchRoute.GET(createAuthorizedRequest());
+
+    await expect(response.json()).resolves.toMatchObject({
+      dispatched: 0,
+      itemFailed: 1,
+      pushed: 0,
+    });
+    expect(notificationUpsertMock).not.toHaveBeenCalled();
+    expect(reviewLogUpdateMock).not.toHaveBeenCalled();
+    expect(sendPushMock).not.toHaveBeenCalled();
+  });
+
+  it("counts non-expired push failures separately", async () => {
+    const { supabase } = createSupabaseMock({
+      subscriptions: [
+        {
+          auth: "auth-secret",
+          endpoint: ENDPOINT,
+          id: SUBSCRIPTION_ID,
+          p256dh: "p256dh-key",
+        },
+        {
+          auth: "second-auth-secret",
+          endpoint: "https://push.example.test/second-subscription-id",
+          id: "66666666-6666-4666-8666-666666666666",
+          p256dh: "second-p256dh-key",
+        },
+      ],
+    });
+    createAdminClientMock.mockReturnValue(supabase);
+    sendPushMock
+      .mockResolvedValueOnce({ ok: true })
+      .mockResolvedValueOnce({ ok: false });
+
+    const response = await dispatchRoute.GET(createAuthorizedRequest());
+
+    await expect(response.json()).resolves.toMatchObject({
+      itemFailed: 0,
+      pushFailed: 1,
+      pushed: 1,
+    });
+  });
+});

--- a/src/app/api/cron/dispatch-notifications/route.test.ts
+++ b/src/app/api/cron/dispatch-notifications/route.test.ts
@@ -45,6 +45,7 @@ function createAuthorizedRequest() {
 
 function createSupabaseMock({
   claimedLogs = [CLAIMED_LOG],
+  existingNotification = { id: NOTIFICATION_ID },
   insertedNotification = { id: NOTIFICATION_ID },
   note = { title: "알림 노트" },
   subscriptions = [
@@ -56,7 +57,8 @@ function createSupabaseMock({
     },
   ],
 }: {
-  claimedLogs?: (typeof CLAIMED_LOG)[];
+  claimedLogs?: (typeof CLAIMED_LOG)[] | null;
+  existingNotification?: { id: string } | null;
   insertedNotification?: { id: string } | null;
   note?: { title: string } | null;
   subscriptions?: {
@@ -107,6 +109,22 @@ function createSupabaseMock({
   const notificationUpsertMock = vi.fn().mockReturnValue({
     select: notificationUpsertSelectMock,
   });
+  const notificationSelectMaybeSingleMock = vi.fn().mockResolvedValue({
+    data: existingNotification,
+    error: null,
+  });
+  const notificationSelectUserEqMock = vi.fn().mockReturnValue({
+    maybeSingle: notificationSelectMaybeSingleMock,
+  });
+  const notificationSelectTypeEqMock = vi.fn().mockReturnValue({
+    eq: notificationSelectUserEqMock,
+  });
+  const notificationSelectReviewLogEqMock = vi.fn().mockReturnValue({
+    eq: notificationSelectTypeEqMock,
+  });
+  const notificationSelectMock = vi.fn().mockReturnValue({
+    eq: notificationSelectReviewLogEqMock,
+  });
 
   const reviewLogUpdateEqMock = vi.fn().mockResolvedValue({ error: null });
   const reviewLogUpdateMock = vi.fn().mockReturnValue({
@@ -129,6 +147,7 @@ function createSupabaseMock({
 
     if (table === "notifications") {
       return {
+        select: notificationSelectMock,
         upsert: notificationUpsertMock,
       };
     }
@@ -145,6 +164,7 @@ function createSupabaseMock({
   return {
     deleteSubscriptionEqMock,
     fromMock,
+    notificationSelectMock,
     notificationUpsertMock,
     reviewLogUpdateMock,
     rpcMock,
@@ -233,7 +253,7 @@ describe("/api/cron/dispatch-notifications", () => {
         },
       },
       {
-        body: "알림 노트",
+        body: "복습할 노트가 있어요.",
         data: {
           noteId: NOTE_ID,
           notificationId: NOTIFICATION_ID,
@@ -243,6 +263,26 @@ describe("/api/cron/dispatch-notifications", () => {
         title: "복습 시간이에요",
       },
     );
+  });
+
+  it("treats null claim data as an empty batch", async () => {
+    const { fromMock, supabase } = createSupabaseMock({
+      claimedLogs: null,
+    });
+    createAdminClientMock.mockReturnValue(supabase);
+
+    const response = await dispatchRoute.GET(createAuthorizedRequest());
+
+    await expect(response.json()).resolves.toEqual({
+      claimed: 0,
+      dispatched: 0,
+      expiredSubscriptions: 0,
+      itemFailed: 0,
+      pushFailed: 0,
+      pushed: 0,
+    });
+    expect(response.status).toBe(200);
+    expect(fromMock).not.toHaveBeenCalled();
   });
 
   it("deletes expired push subscriptions", async () => {
@@ -263,19 +303,32 @@ describe("/api/cron/dispatch-notifications", () => {
     );
   });
 
-  it("does not send duplicate push when the notification already exists", async () => {
-    const { supabase } = createSupabaseMock({
-      insertedNotification: null,
-    });
+  it("retries push when the notification already exists but the review log is still due", async () => {
+    const { notificationSelectMock, reviewLogUpdateMock, supabase } =
+      createSupabaseMock({
+        insertedNotification: null,
+      });
     createAdminClientMock.mockReturnValue(supabase);
 
     const response = await dispatchRoute.GET(createAuthorizedRequest());
 
     await expect(response.json()).resolves.toMatchObject({
       dispatched: 1,
-      pushed: 0,
+      pushed: 1,
     });
-    expect(sendPushMock).not.toHaveBeenCalled();
+    expect(notificationSelectMock).toHaveBeenCalledWith("id");
+    expect(sendPushMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        data: expect.objectContaining({
+          notificationId: NOTIFICATION_ID,
+          reviewLogId: REVIEW_LOG_ID,
+        }),
+      }),
+    );
+    expect(reviewLogUpdateMock).toHaveBeenCalledWith({
+      notification_dispatched_at: expect.any(String),
+    });
   });
 
   it("does not create a notification when the note is missing", async () => {
@@ -297,8 +350,11 @@ describe("/api/cron/dispatch-notifications", () => {
     expect(sendPushMock).not.toHaveBeenCalled();
   });
 
-  it("counts non-expired push failures separately", async () => {
-    const { supabase } = createSupabaseMock({
+  it("leaves review logs retryable when a non-expired push fails", async () => {
+    const consoleWarnSpy = vi
+      .spyOn(console, "warn")
+      .mockImplementation(() => undefined);
+    const { reviewLogUpdateMock, supabase } = createSupabaseMock({
       subscriptions: [
         {
           auth: "auth-secret",
@@ -315,16 +371,27 @@ describe("/api/cron/dispatch-notifications", () => {
       ],
     });
     createAdminClientMock.mockReturnValue(supabase);
-    sendPushMock
-      .mockResolvedValueOnce({ ok: true })
-      .mockResolvedValueOnce({ ok: false });
+    sendPushMock.mockResolvedValueOnce({ ok: true }).mockResolvedValueOnce({
+      ok: false,
+      reason: "temporary provider failure",
+      statusCode: 503,
+    });
 
     const response = await dispatchRoute.GET(createAuthorizedRequest());
 
     await expect(response.json()).resolves.toMatchObject({
+      dispatched: 0,
       itemFailed: 0,
       pushFailed: 1,
       pushed: 1,
     });
+    expect(reviewLogUpdateMock).not.toHaveBeenCalled();
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: "cron.dispatchNotifications.pushFailed",
+        reason: "temporary provider failure",
+        statusCode: 503,
+      }),
+    );
   });
 });

--- a/src/app/api/cron/dispatch-notifications/route.ts
+++ b/src/app/api/cron/dispatch-notifications/route.ts
@@ -1,0 +1,439 @@
+import { createHash, timingSafeEqual } from "node:crypto";
+
+import { NextResponse } from "next/server";
+
+import {
+  NOTIFICATION_STATUS,
+  NOTIFICATION_TYPES,
+} from "@/lib/constants/notifications";
+import { logError, logWarn } from "@/lib/logger";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { sendPush, setVapidDetails } from "@/lib/webPush";
+
+export const runtime = "nodejs";
+export const maxDuration = 60;
+export const dynamic = "force-dynamic";
+
+const CLAIM_LIMIT = 200;
+const CLAIM_CONCURRENCY = 8;
+const REVIEW_NOTIFICATION_TITLE = "복습 시간이에요";
+const REVIEW_ROUTE_SEGMENT = "review";
+
+type ClaimedReviewLogType = {
+  id: string;
+  note_id: string;
+  round: number;
+  scheduled_at: string;
+  user_id: string;
+};
+
+type PushSubscriptionRowType = {
+  auth: string;
+  endpoint: string;
+  id: string;
+  p256dh: string;
+};
+
+type DispatchStatsType = {
+  claimed: number;
+  dispatched: number;
+  expiredSubscriptions: number;
+  itemFailed: number;
+  pushFailed: number;
+  pushed: number;
+};
+
+type DispatchItemStatsType = Omit<DispatchStatsType, "claimed">;
+
+type PushDispatchStatsType = Pick<
+  DispatchItemStatsType,
+  "expiredSubscriptions" | "pushFailed" | "pushed"
+>;
+
+type EnsureNotificationResultType =
+  | {
+      id: string;
+      isNew: true;
+    }
+  | {
+      isNew: false;
+    };
+
+function hashSecretValue(value: string): Buffer {
+  return createHash("sha256").update(value).digest();
+}
+
+function timingSafeStringEqual(left: string, right: string): boolean {
+  return timingSafeEqual(hashSecretValue(left), hashSecretValue(right));
+}
+
+function getSecretErrorResponse(): NextResponse | null {
+  const cronSecret = process.env.CRON_SECRET;
+
+  if (!cronSecret) {
+    logError({ event: "cron.dispatchNotifications.secretMissing" });
+    return NextResponse.json({ error: "cron_secret_missing" }, { status: 500 });
+  }
+
+  return null;
+}
+
+function authorizeCronRequest(request: Request): NextResponse | null {
+  const secretError = getSecretErrorResponse();
+
+  if (secretError) {
+    return secretError;
+  }
+
+  const expectedAuthorization = `Bearer ${process.env.CRON_SECRET}`;
+  const authorization = request.headers.get("authorization") ?? "";
+
+  if (!timingSafeStringEqual(authorization, expectedAuthorization)) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  return null;
+}
+
+function buildReviewUrl(noteId: string): string {
+  return `/notes/${noteId}/${REVIEW_ROUTE_SEGMENT}`;
+}
+
+function buildPushPayload({
+  noteId,
+  notificationId,
+  noteTitle,
+  reviewLogId,
+}: {
+  noteId: string;
+  notificationId: string;
+  noteTitle: string;
+  reviewLogId: string;
+}) {
+  const url = buildReviewUrl(noteId);
+
+  return {
+    title: REVIEW_NOTIFICATION_TITLE,
+    body: noteTitle,
+    data: {
+      noteId,
+      notificationId,
+      reviewLogId,
+      url,
+    },
+  };
+}
+
+async function deleteExpiredSubscription(
+  supabase: ReturnType<typeof createAdminClient>,
+  subscription: PushSubscriptionRowType,
+): Promise<boolean> {
+  const { error } = await supabase
+    .from("push_subscriptions")
+    .delete()
+    .eq("id", subscription.id);
+
+  if (error) {
+    logWarn({
+      event: "cron.dispatchNotifications.subscriptionDeleteFailed",
+      error,
+      subscriptionId: subscription.id,
+    });
+    return false;
+  }
+
+  return true;
+}
+
+async function ensureNotification(
+  supabase: ReturnType<typeof createAdminClient>,
+  claimedLog: ClaimedReviewLogType,
+  noteTitle: string,
+): Promise<EnsureNotificationResultType> {
+  const { data, error } = await supabase
+    .from("notifications")
+    .upsert(
+      {
+        body: noteTitle,
+        note_id: claimedLog.note_id,
+        review_log_id: claimedLog.id,
+        status: NOTIFICATION_STATUS.SENT,
+        title: REVIEW_NOTIFICATION_TITLE,
+        type: NOTIFICATION_TYPES.REVIEW,
+        user_id: claimedLog.user_id,
+      },
+      { ignoreDuplicates: true, onConflict: "review_log_id,type" },
+    )
+    .select("id")
+    .maybeSingle();
+
+  if (error) {
+    throw error;
+  }
+
+  if (data?.id) {
+    return { id: data.id, isNew: true };
+  }
+
+  return { isNew: false };
+}
+
+async function markReviewLogDispatched(
+  supabase: ReturnType<typeof createAdminClient>,
+  reviewLogId: string,
+): Promise<void> {
+  const { error } = await supabase
+    .from("review_logs")
+    .update({ notification_dispatched_at: new Date().toISOString() })
+    .eq("id", reviewLogId);
+
+  if (error) {
+    throw error;
+  }
+}
+
+async function dispatchPushSubscription(
+  supabase: ReturnType<typeof createAdminClient>,
+  subscription: PushSubscriptionRowType,
+  payload: ReturnType<typeof buildPushPayload>,
+): Promise<PushDispatchStatsType> {
+  const stats = {
+    expiredSubscriptions: 0,
+    pushFailed: 0,
+    pushed: 0,
+  };
+
+  const result = await sendPush(
+    {
+      endpoint: subscription.endpoint,
+      keys: {
+        auth: subscription.auth,
+        p256dh: subscription.p256dh,
+      },
+    },
+    payload,
+  );
+
+  if (result.ok) {
+    stats.pushed += 1;
+    return stats;
+  }
+
+  if (result.gone) {
+    const deleted = await deleteExpiredSubscription(supabase, subscription);
+
+    if (deleted) {
+      stats.expiredSubscriptions += 1;
+    } else {
+      stats.pushFailed += 1;
+    }
+
+    return stats;
+  }
+
+  stats.pushFailed += 1;
+  logWarn({
+    event: "cron.dispatchNotifications.pushFailed",
+    reviewLogId: payload.data.reviewLogId,
+    subscriptionId: subscription.id,
+  });
+
+  return stats;
+}
+
+function addPushDispatchStats(
+  current: DispatchItemStatsType,
+  next: PushDispatchStatsType,
+): void {
+  current.expiredSubscriptions += next.expiredSubscriptions;
+  current.pushFailed += next.pushFailed;
+  current.pushed += next.pushed;
+}
+
+async function dispatchClaimedReviewLog(
+  supabase: ReturnType<typeof createAdminClient>,
+  claimedLog: ClaimedReviewLogType,
+): Promise<DispatchItemStatsType> {
+  const stats = {
+    dispatched: 0,
+    expiredSubscriptions: 0,
+    itemFailed: 0,
+    pushFailed: 0,
+    pushed: 0,
+  };
+
+  try {
+    const [noteResult, subscriptionsResult] = await Promise.all([
+      supabase
+        .from("notes")
+        .select("title")
+        .eq("id", claimedLog.note_id)
+        .eq("user_id", claimedLog.user_id)
+        .maybeSingle(),
+      supabase
+        .from("push_subscriptions")
+        .select("id, endpoint, p256dh, auth")
+        .eq("user_id", claimedLog.user_id),
+    ]);
+
+    if (noteResult.error) {
+      throw noteResult.error;
+    }
+
+    if (subscriptionsResult.error) {
+      throw subscriptionsResult.error;
+    }
+
+    if (!noteResult.data) {
+      stats.itemFailed += 1;
+      logWarn({
+        event: "cron.dispatchNotifications.noteMissing",
+        noteId: claimedLog.note_id,
+        reviewLogId: claimedLog.id,
+        userId: claimedLog.user_id,
+      });
+      return stats;
+    }
+
+    const noteTitle = noteResult.data.title;
+    const notification = await ensureNotification(
+      supabase,
+      claimedLog,
+      noteTitle,
+    );
+
+    await markReviewLogDispatched(supabase, claimedLog.id);
+    stats.dispatched += 1;
+
+    if (!notification.isNew) {
+      return stats;
+    }
+
+    const payload = buildPushPayload({
+      noteId: claimedLog.note_id,
+      notificationId: notification.id,
+      noteTitle,
+      reviewLogId: claimedLog.id,
+    });
+
+    const subscriptions = subscriptionsResult.data ?? [];
+    const pushResults = await Promise.allSettled(
+      subscriptions.map((subscription) =>
+        dispatchPushSubscription(supabase, subscription, payload),
+      ),
+    );
+
+    for (const [index, pushResult] of pushResults.entries()) {
+      if (pushResult.status === "fulfilled") {
+        addPushDispatchStats(stats, pushResult.value);
+        continue;
+      }
+
+      stats.pushFailed += 1;
+      logWarn({
+        event: "cron.dispatchNotifications.pushFailed",
+        error: pushResult.reason,
+        reviewLogId: claimedLog.id,
+        subscriptionId: subscriptions[index]?.id,
+      });
+    }
+  } catch (error) {
+    stats.itemFailed += 1;
+    logError({
+      event: "cron.dispatchNotifications.itemFailed",
+      error,
+      reviewLogId: claimedLog.id,
+    });
+  }
+
+  return stats;
+}
+
+function addDispatchStats(
+  current: DispatchStatsType,
+  next: DispatchItemStatsType,
+): DispatchStatsType {
+  return {
+    claimed: current.claimed,
+    dispatched: current.dispatched + next.dispatched,
+    expiredSubscriptions:
+      current.expiredSubscriptions + next.expiredSubscriptions,
+    itemFailed: current.itemFailed + next.itemFailed,
+    pushFailed: current.pushFailed + next.pushFailed,
+    pushed: current.pushed + next.pushed,
+  };
+}
+
+async function runWithConcurrencyLimit<ItemType, ResultType>(
+  items: readonly ItemType[],
+  concurrency: number,
+  task: (item: ItemType) => Promise<ResultType>,
+): Promise<ResultType[]> {
+  const results = new Array<ResultType>(items.length);
+  const iterator = items.entries();
+  const workerCount = Math.min(Math.max(concurrency, 1), items.length);
+
+  await Promise.all(
+    Array.from({ length: workerCount }, async () => {
+      for (let next = iterator.next(); !next.done; next = iterator.next()) {
+        const [index, item] = next.value;
+        results[index] = await task(item);
+      }
+    }),
+  );
+
+  return results;
+}
+
+export async function GET(request: Request) {
+  const unauthorizedResponse = authorizeCronRequest(request);
+
+  if (unauthorizedResponse) {
+    return unauthorizedResponse;
+  }
+
+  try {
+    setVapidDetails();
+
+    const supabase = createAdminClient();
+    const { data: claimedLogs, error } = await supabase.rpc(
+      "claim_due_review_logs",
+      { p_limit: CLAIM_LIMIT },
+    );
+
+    if (error) {
+      logError({ event: "cron.dispatchNotifications.claimFailed", error });
+      return NextResponse.json(
+        { error: "notification_claim_failed" },
+        { status: 500 },
+      );
+    }
+
+    let stats: DispatchStatsType = {
+      claimed: claimedLogs.length,
+      dispatched: 0,
+      expiredSubscriptions: 0,
+      itemFailed: 0,
+      pushFailed: 0,
+      pushed: 0,
+    };
+
+    const claimedLogResults = await runWithConcurrencyLimit(
+      claimedLogs,
+      CLAIM_CONCURRENCY,
+      (claimedLog) => dispatchClaimedReviewLog(supabase, claimedLog),
+    );
+
+    for (const nextStats of claimedLogResults) {
+      stats = addDispatchStats(stats, nextStats);
+    }
+
+    return NextResponse.json(stats);
+  } catch (error) {
+    logError({ event: "cron.dispatchNotifications.failed", error });
+    return NextResponse.json(
+      { error: "notification_dispatch_failed" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/cron/dispatch-notifications/route.ts
+++ b/src/app/api/cron/dispatch-notifications/route.ts
@@ -16,6 +16,7 @@ export const dynamic = "force-dynamic";
 
 const CLAIM_LIMIT = 200;
 const CLAIM_CONCURRENCY = 8;
+const REVIEW_NOTIFICATION_PUSH_BODY = "복습할 노트가 있어요.";
 const REVIEW_NOTIFICATION_TITLE = "복습 시간이에요";
 const REVIEW_ROUTE_SEGMENT = "review";
 
@@ -50,14 +51,9 @@ type PushDispatchStatsType = Pick<
   "expiredSubscriptions" | "pushFailed" | "pushed"
 >;
 
-type EnsureNotificationResultType =
-  | {
-      id: string;
-      isNew: true;
-    }
-  | {
-      isNew: false;
-    };
+type EnsureNotificationResultType = {
+  id: string;
+};
 
 function hashSecretValue(value: string): Buffer {
   return createHash("sha256").update(value).digest();
@@ -102,19 +98,17 @@ function buildReviewUrl(noteId: string): string {
 function buildPushPayload({
   noteId,
   notificationId,
-  noteTitle,
   reviewLogId,
 }: {
   noteId: string;
   notificationId: string;
-  noteTitle: string;
   reviewLogId: string;
 }) {
   const url = buildReviewUrl(noteId);
 
   return {
     title: REVIEW_NOTIFICATION_TITLE,
-    body: noteTitle,
+    body: REVIEW_NOTIFICATION_PUSH_BODY,
     data: {
       noteId,
       notificationId,
@@ -172,10 +166,29 @@ async function ensureNotification(
   }
 
   if (data?.id) {
-    return { id: data.id, isNew: true };
+    return { id: data.id };
   }
 
-  return { isNew: false };
+  const { data: existingNotification, error: existingNotificationError } =
+    await supabase
+      .from("notifications")
+      .select("id")
+      .eq("review_log_id", claimedLog.id)
+      .eq("type", NOTIFICATION_TYPES.REVIEW)
+      .eq("user_id", claimedLog.user_id)
+      .maybeSingle();
+
+  if (existingNotificationError) {
+    throw existingNotificationError;
+  }
+
+  if (!existingNotification?.id) {
+    throw new Error(
+      "Existing notification was not found after upsert conflict.",
+    );
+  }
+
+  return { id: existingNotification.id };
 }
 
 async function markReviewLogDispatched(
@@ -234,7 +247,11 @@ async function dispatchPushSubscription(
   stats.pushFailed += 1;
   logWarn({
     event: "cron.dispatchNotifications.pushFailed",
+    ...(result.reason !== undefined ? { reason: result.reason } : {}),
     reviewLogId: payload.data.reviewLogId,
+    ...(result.statusCode !== undefined
+      ? { statusCode: result.statusCode }
+      : {}),
     subscriptionId: subscription.id,
   });
 
@@ -242,7 +259,7 @@ async function dispatchPushSubscription(
 }
 
 function addPushDispatchStats(
-  current: DispatchItemStatsType,
+  current: PushDispatchStatsType,
   next: PushDispatchStatsType,
 ): void {
   current.expiredSubscriptions += next.expiredSubscriptions;
@@ -302,21 +319,18 @@ async function dispatchClaimedReviewLog(
       noteTitle,
     );
 
-    await markReviewLogDispatched(supabase, claimedLog.id);
-    stats.dispatched += 1;
-
-    if (!notification.isNew) {
-      return stats;
-    }
-
     const payload = buildPushPayload({
       noteId: claimedLog.note_id,
       notificationId: notification.id,
-      noteTitle,
       reviewLogId: claimedLog.id,
     });
 
     const subscriptions = subscriptionsResult.data ?? [];
+    const pushStats = {
+      expiredSubscriptions: 0,
+      pushFailed: 0,
+      pushed: 0,
+    };
     const pushResults = await Promise.allSettled(
       subscriptions.map((subscription) =>
         dispatchPushSubscription(supabase, subscription, payload),
@@ -325,11 +339,11 @@ async function dispatchClaimedReviewLog(
 
     for (const [index, pushResult] of pushResults.entries()) {
       if (pushResult.status === "fulfilled") {
-        addPushDispatchStats(stats, pushResult.value);
+        addPushDispatchStats(pushStats, pushResult.value);
         continue;
       }
 
-      stats.pushFailed += 1;
+      pushStats.pushFailed += 1;
       logWarn({
         event: "cron.dispatchNotifications.pushFailed",
         error: pushResult.reason,
@@ -337,6 +351,16 @@ async function dispatchClaimedReviewLog(
         subscriptionId: subscriptions[index]?.id,
       });
     }
+
+    addPushDispatchStats(stats, pushStats);
+
+    if (pushStats.pushFailed > 0) {
+      // Keep the review log retryable because web push has no per-subscription delivery state.
+      return stats;
+    }
+
+    await markReviewLogDispatched(supabase, claimedLog.id);
+    stats.dispatched += 1;
   } catch (error) {
     stats.itemFailed += 1;
     logError({
@@ -352,16 +376,12 @@ async function dispatchClaimedReviewLog(
 function addDispatchStats(
   current: DispatchStatsType,
   next: DispatchItemStatsType,
-): DispatchStatsType {
-  return {
-    claimed: current.claimed,
-    dispatched: current.dispatched + next.dispatched,
-    expiredSubscriptions:
-      current.expiredSubscriptions + next.expiredSubscriptions,
-    itemFailed: current.itemFailed + next.itemFailed,
-    pushFailed: current.pushFailed + next.pushFailed,
-    pushed: current.pushed + next.pushed,
-  };
+): void {
+  current.dispatched += next.dispatched;
+  current.expiredSubscriptions += next.expiredSubscriptions;
+  current.itemFailed += next.itemFailed;
+  current.pushFailed += next.pushFailed;
+  current.pushed += next.pushed;
 }
 
 async function runWithConcurrencyLimit<ItemType, ResultType>(
@@ -396,7 +416,7 @@ export async function GET(request: Request) {
     setVapidDetails();
 
     const supabase = createAdminClient();
-    const { data: claimedLogs, error } = await supabase.rpc(
+    const { data: claimedLogRows, error } = await supabase.rpc(
       "claim_due_review_logs",
       { p_limit: CLAIM_LIMIT },
     );
@@ -409,7 +429,9 @@ export async function GET(request: Request) {
       );
     }
 
-    let stats: DispatchStatsType = {
+    const claimedLogs = claimedLogRows ?? [];
+
+    const stats: DispatchStatsType = {
       claimed: claimedLogs.length,
       dispatched: 0,
       expiredSubscriptions: 0,
@@ -425,7 +447,7 @@ export async function GET(request: Request) {
     );
 
     for (const nextStats of claimedLogResults) {
-      stats = addDispatchStats(stats, nextStats);
+      addDispatchStats(stats, nextStats);
     }
 
     return NextResponse.json(stats);

--- a/src/lib/webPush/index.test.ts
+++ b/src/lib/webPush/index.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { sendNotificationMock, setVapidDetailsMock } = vi.hoisted(() => ({
+  sendNotificationMock: vi.fn(),
+  setVapidDetailsMock: vi.fn(),
+}));
+
+vi.mock("web-push", () => ({
+  sendNotification: sendNotificationMock,
+  setVapidDetails: setVapidDetailsMock,
+}));
+
+import { sendPush, setVapidDetails } from ".";
+
+const SUBSCRIPTION = {
+  endpoint: "https://push.example.test/subscription-id",
+  keys: {
+    auth: "auth-secret",
+    p256dh: "p256dh-key",
+  },
+};
+
+describe("web push helper", () => {
+  beforeEach(() => {
+    sendNotificationMock.mockReset();
+    setVapidDetailsMock.mockReset();
+    vi.stubEnv("NEXT_PUBLIC_APP_URL", "https://woodpecker.example.test");
+    vi.stubEnv("NEXT_PUBLIC_VAPID_PUBLIC_KEY", "public-key");
+    vi.stubEnv("VAPID_PRIVATE_KEY", "private-key");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("configures VAPID details from env", () => {
+    setVapidDetails();
+
+    expect(setVapidDetailsMock).toHaveBeenCalledWith(
+      "https://woodpecker.example.test",
+      "public-key",
+      "private-key",
+    );
+  });
+
+  it("sends a JSON encoded payload", async () => {
+    sendNotificationMock.mockResolvedValue({ statusCode: 201 });
+
+    const result = await sendPush(SUBSCRIPTION, { title: "Review due" });
+
+    expect(sendNotificationMock).toHaveBeenCalledWith(
+      SUBSCRIPTION,
+      JSON.stringify({ title: "Review due" }),
+    );
+    expect(result).toEqual({ ok: true });
+  });
+
+  it("marks expired subscriptions as gone", async () => {
+    sendNotificationMock.mockRejectedValue({ statusCode: 410 });
+
+    await expect(
+      sendPush(SUBSCRIPTION, { title: "Review due" }),
+    ).resolves.toEqual({
+      gone: true,
+      ok: false,
+    });
+  });
+
+  it("throws when VAPID env is missing", () => {
+    vi.stubEnv("VAPID_PRIVATE_KEY", "");
+
+    expect(() => setVapidDetails()).toThrow(
+      "VAPID_PRIVATE_KEY is required for Web Push dispatch.",
+    );
+  });
+});

--- a/src/lib/webPush/index.test.ts
+++ b/src/lib/webPush/index.test.ts
@@ -52,6 +52,7 @@ describe("web push helper", () => {
       SUBSCRIPTION,
       JSON.stringify({ title: "Review due" }),
     );
+    expect(setVapidDetailsMock).not.toHaveBeenCalled();
     expect(result).toEqual({ ok: true });
   });
 
@@ -63,6 +64,22 @@ describe("web push helper", () => {
     ).resolves.toEqual({
       gone: true,
       ok: false,
+      statusCode: 410,
+    });
+  });
+
+  it("returns provider failure context for non-expired errors", async () => {
+    sendNotificationMock.mockRejectedValue({
+      body: "provider temporarily unavailable",
+      statusCode: 503,
+    });
+
+    await expect(
+      sendPush(SUBSCRIPTION, { title: "Review due" }),
+    ).resolves.toEqual({
+      ok: false,
+      reason: "provider temporarily unavailable",
+      statusCode: 503,
     });
   });
 

--- a/src/lib/webPush/index.ts
+++ b/src/lib/webPush/index.ts
@@ -5,13 +5,21 @@ export type WebPushSendResultType =
   | {
       ok: true;
       gone?: never;
+      reason?: never;
+      statusCode?: never;
     }
   | {
       ok: false;
       gone?: boolean;
+      reason?: unknown;
+      statusCode?: number;
     };
 
-export type WebPushPayloadType = Record<string, unknown>;
+export type WebPushPayloadType = {
+  body?: string;
+  data?: Record<string, unknown>;
+  title: string;
+};
 
 function getRequiredEnv(name: string): string {
   const value = process.env[name];
@@ -35,12 +43,47 @@ function getVapidSubject(): string {
   return subject;
 }
 
-function hasGoneStatus(error: unknown): boolean {
+function getWebPushStatusCode(error: unknown): number | undefined {
   if (typeof error !== "object" || error === null || !("statusCode" in error)) {
-    return false;
+    return undefined;
   }
 
-  return error.statusCode === 404 || error.statusCode === 410;
+  return typeof error.statusCode === "number" ? error.statusCode : undefined;
+}
+
+function getWebPushFailureReason(error: unknown): unknown {
+  if (typeof error === "object" && error !== null && "body" in error) {
+    return error.body;
+  }
+
+  if (error instanceof Error) {
+    return { message: error.message, name: error.name };
+  }
+
+  if (typeof error === "string") {
+    return error;
+  }
+
+  return undefined;
+}
+
+function createFailureResult(error: unknown): WebPushSendResultType {
+  const statusCode = getWebPushStatusCode(error);
+  const reason = getWebPushFailureReason(error);
+  const result: WebPushSendResultType =
+    statusCode === 404 || statusCode === 410
+      ? { gone: true, ok: false }
+      : { ok: false };
+
+  if (statusCode !== undefined) {
+    result.statusCode = statusCode;
+  }
+
+  if (reason !== undefined) {
+    result.reason = reason;
+  }
+
+  return result;
 }
 
 export function setVapidDetails(): void {
@@ -55,16 +98,10 @@ export async function sendPush(
   subscription: PushSubscription,
   payload: WebPushPayloadType,
 ): Promise<WebPushSendResultType> {
-  setVapidDetails();
-
   try {
     await webpush.sendNotification(subscription, JSON.stringify(payload));
     return { ok: true };
   } catch (error) {
-    if (hasGoneStatus(error)) {
-      return { gone: true, ok: false };
-    }
-
-    return { ok: false };
+    return createFailureResult(error);
   }
 }

--- a/src/lib/webPush/index.ts
+++ b/src/lib/webPush/index.ts
@@ -1,0 +1,70 @@
+import type { PushSubscription } from "web-push";
+import * as webpush from "web-push";
+
+export type WebPushSendResultType =
+  | {
+      ok: true;
+      gone?: never;
+    }
+  | {
+      ok: false;
+      gone?: boolean;
+    };
+
+export type WebPushPayloadType = Record<string, unknown>;
+
+function getRequiredEnv(name: string): string {
+  const value = process.env[name];
+
+  if (!value) {
+    throw new Error(`${name} is required for Web Push dispatch.`);
+  }
+
+  return value;
+}
+
+function getVapidSubject(): string {
+  const subject = process.env.NEXT_PUBLIC_APP_URL ?? process.env.APP_URL;
+
+  if (!subject) {
+    throw new Error(
+      "NEXT_PUBLIC_APP_URL or APP_URL is required for Web Push dispatch.",
+    );
+  }
+
+  return subject;
+}
+
+function hasGoneStatus(error: unknown): boolean {
+  if (typeof error !== "object" || error === null || !("statusCode" in error)) {
+    return false;
+  }
+
+  return error.statusCode === 404 || error.statusCode === 410;
+}
+
+export function setVapidDetails(): void {
+  webpush.setVapidDetails(
+    getVapidSubject(),
+    getRequiredEnv("NEXT_PUBLIC_VAPID_PUBLIC_KEY"),
+    getRequiredEnv("VAPID_PRIVATE_KEY"),
+  );
+}
+
+export async function sendPush(
+  subscription: PushSubscription,
+  payload: WebPushPayloadType,
+): Promise<WebPushSendResultType> {
+  setVapidDetails();
+
+  try {
+    await webpush.sendNotification(subscription, JSON.stringify(payload));
+    return { ok: true };
+  } catch (error) {
+    if (hasGoneStatus(error)) {
+      return { gone: true, ok: false };
+    }
+
+    return { ok: false };
+  }
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "crons": [
+    {
+      "path": "/api/cron/dispatch-notifications",
+      "schedule": "*/5 * * * *"
+    }
+  ]
+}


### PR DESCRIPTION
## 개요

복습 알림 발송 파이프라인의 마지막 단계로, Vercel Cron이 5분마다 호출하는 디스패처 라우트와 `web-push` 라이브러리 래퍼를 구현했습니다.

## PR 유형

- [x] 새로운 기능 추가
- [x] 버그 수정
- [x] 빌드/패키지 설정 변경

## 관련 이슈

closes #175

## 작업 내용

- `vercel.json`에 `*/5 * * * *` 스케줄로 `/api/cron/dispatch-notifications` 등록 (Vercel Pro/Team 플랜 전제)
- `src/app/api/cron/dispatch-notifications/route.ts` — `CRON_SECRET` 인증, 도래한 review_log를 RPC(`claim_due_review_logs`)로 클레임 후 알림 row 보장 + 사용자별 push subscription에 병렬(동시 8건) 전송. 410/404 응답은 만료 구독으로 정리.
- `src/lib/webPush/index.ts` — `web-push` SDK 래퍼. VAPID 설정/페이로드 직렬화/실패 사유 추출/만료 구독 식별을 담당.
- `.env.example`/`README.md`에 `CRON_SECRET` 및 Cron 운영 메모 추가.
- (fix) 앱 푸시 누락 버그 수정 — VAPID 초기화 누락 및 dispatch flow에서 push 단계가 일부 케이스에서 건너뛰어지던 문제 보정.

## 테스트 방법

1. `.env.local`에 `CRON_SECRET`, `NEXT_PUBLIC_VAPID_PUBLIC_KEY`, `VAPID_PRIVATE_KEY`, `NEXT_PUBLIC_APP_URL` 설정
2. `npm run test -- src/app/api/cron/dispatch-notifications src/lib/webPush` — 신규 유닛/통합 테스트 통과 확인 (route.test.ts 397줄, webPush index.test.ts 93줄)
3. 로컬에서 `Authorization: Bearer $CRON_SECRET` 헤더로 `/api/cron/dispatch-notifications` 직접 호출 → 도래한 review_log가 dispatched로 전이되고 push subscription이 살아있는 경우 실제 알림 수신
4. 시크릿 누락/오답 시 500/401 응답 확인

## 리뷰 요구사항 (선택)

- `CLAIM_LIMIT=200`, `CLAIM_CONCURRENCY=8` 값이 5분 사이클에 적절한지
- 만료 구독(410/404) 정리 로직이 사용자 단위가 아니라 endpoint 단위로 동작하는지 재확인 부탁드립니다.

## 체크리스트

- [x] 코드 컨벤션 준수
- [x] 커밋 메시지 컨벤션 준수
- [x] lint 통과
- [x] typecheck 통과
- [ ] (DB 변경 시) migration 포함 및 로컬 재현 확인 — 본 PR은 RPC 호출만 추가 (마이그레이션은 #172/#174에서 선행)
- [ ] (권한/RLS 영향 시) 정책 변경 요약 기재 — admin client + CRON_SECRET 인증으로만 호출, RLS 정책 변경 없음
- [x] 셀프 리뷰 완료