### PR TITLE
Feat/178  service worker push subscribe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,10 @@
 # next.js
 /.next/
 /out/
+/public/sw.js
+/public/sw.js.map
+/public/swe-worker-*.js
+/public/swe-worker-*.js.map
 
 # production
 /build

--- a/README.md
+++ b/README.md
@@ -89,12 +89,19 @@ npm run dev
 
 ## 5. 주요 스크립트
 
-| 명령어          | 설명                       |
-| --------------- | -------------------------- |
-| `npm run dev`   | 개발 서버 실행 (Turbopack) |
-| `npm run build` | 프로덕션 빌드              |
-| `npm run start` | 프로덕션 서버 실행         |
-| `npm run lint`  | ESLint 검사                |
+| 명령어           | 설명                                                         |
+| ---------------- | ------------------------------------------------------------ |
+| `npm run dev`    | 개발 서버 실행 (Turbopack, Service Worker 비활성화)          |
+| `npm run dev:sw` | 개발 서버 실행 (Service Worker 활성화, Web Push 로컬 검증용) |
+| `npm run build`  | 프로덕션 빌드                                                |
+| `npm run start`  | 프로덕션 서버 실행                                           |
+| `npm run lint`   | ESLint 검사                                                  |
+
+> **`dev:sw` 보충 설명**
+>
+> - 일반 `npm run dev` 는 Turbopack + Serwist 호환 이슈를 피하기 위해 개발 환경에서 Service Worker(`/sw.js`) 를 비활성화한 상태로 실행됩니다 (`next.config.ts` 의 `disable` 조건 참고).
+> - Web Push 알림 흐름을 로컬에서 검증하려면 SW 가 등록되어야 하므로, `dev:sw` 스크립트가 `ENABLE_SW=true` 환경변수를 주입해 Serwist 를 활성화합니다.
+> - 환경변수 설정에 `cross-env` 를 사용하는 이유: Windows cmd/PowerShell 에서는 `ENABLE_SW=true next dev` 같은 인라인 문법이 동작하지 않습니다. 모든 셸에서 동일하게 동작시키기 위해 `cross-env` 를 거칩니다.
 
 ---
 

--- a/middleware.test.ts
+++ b/middleware.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/supabase/middleware", () => ({
+  updateSession: vi.fn(),
+}));
+
+import { config } from "./middleware";
+
+function matchesMiddleware(pathname: string) {
+  const matcher = config.matcher[0];
+
+  if (!matcher) {
+    throw new Error("Expected middleware matcher to be configured.");
+  }
+
+  return new RegExp(`^${matcher}$`).test(pathname);
+}
+
+describe("middleware matcher", () => {
+  it.each([
+    { expected: false, pathname: "/sw.js" },
+    { expected: false, pathname: "/sw.js.map" },
+    { expected: false, pathname: "/swe-worker-abc.js" },
+    { expected: false, pathname: "/swe-worker-abc.js.map" },
+    { expected: false, pathname: "/api/auth/hooks/send-email" },
+    { expected: true, pathname: "/notes" },
+    { expected: true, pathname: "/mypage" },
+  ])("matches $pathname => $expected", ({ pathname, expected }) => {
+    expect(matchesMiddleware(pathname)).toBe(expected);
+  });
+});

--- a/middleware.ts
+++ b/middleware.ts
@@ -9,6 +9,6 @@ export async function middleware(request: NextRequest) {
 export const config = {
   matcher: [
     // send-email hook은 서버-투-서버 호출이라 사용자 세션 미들웨어를 타면 인증 토큰 오류가 발생한다.
-    "/((?!_next/static|_next/image|favicon.ico|api/auth/hooks/send-email|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)",
+    "/((?!_next/static|_next/image|favicon.ico|sw\\.js|api/auth/hooks/send-email|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)",
   ],
 };

--- a/middleware.ts
+++ b/middleware.ts
@@ -9,6 +9,6 @@ export async function middleware(request: NextRequest) {
 export const config = {
   matcher: [
     // send-email hook은 서버-투-서버 호출이라 사용자 세션 미들웨어를 타면 인증 토큰 오류가 발생한다.
-    "/((?!_next/static|_next/image|favicon.ico|sw\\.js|api/auth/hooks/send-email|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)",
+    "/((?!_next/static|_next/image|favicon.ico|(?:sw|swe-worker-.*)\\.js(?:\\.map)?|api/auth/hooks/send-email|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)",
   ],
 };

--- a/next.config.test.ts
+++ b/next.config.test.ts
@@ -201,6 +201,7 @@ describe("Security Headers — next.config.ts", () => {
         expect(cspReportOnly).toContain("img-src");
         expect(cspReportOnly).toContain("font-src");
         expect(cspReportOnly).toContain("connect-src");
+        expect(cspReportOnly).toContain("worker-src 'self'");
       });
 
       it("TC-CSP-09. Report-Only CSP에 강제 CSP 디렉티브(object-src, base-uri, frame-ancestors)가 없다", async () => {

--- a/next.config.test.ts
+++ b/next.config.test.ts
@@ -15,7 +15,7 @@
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import nextConfig from "./next.config";
+import nextConfig, { shouldDisableSerwist } from "./next.config";
 
 /**
  * headers() 반환값에서 source "/(.*)" 항목의 헤더 배열을 추출하는 헬퍼
@@ -240,5 +240,25 @@ describe("Security Headers — next.config.ts", () => {
         expect(typeof cspReportOnly).toBe("string");
       });
     });
+  });
+
+  describe("Serwist disable env matrix", () => {
+    afterEach(() => {
+      vi.unstubAllEnvs();
+    });
+
+    it.each([
+      { enableSw: undefined, expected: true, nodeEnv: "development" },
+      { enableSw: "true", expected: false, nodeEnv: "development" },
+      { enableSw: undefined, expected: false, nodeEnv: "production" },
+    ])(
+      "returns $expected when NODE_ENV=$nodeEnv and ENABLE_SW=$enableSw",
+      ({ enableSw, expected, nodeEnv }) => {
+        vi.stubEnv("NODE_ENV", nodeEnv);
+        vi.stubEnv("ENABLE_SW", enableSw);
+
+        expect(shouldDisableSerwist()).toBe(expected);
+      },
+    );
   });
 });

--- a/next.config.ts
+++ b/next.config.ts
@@ -17,6 +17,7 @@
 // - connect-src, img-src, font-src를 실제 사용 origin으로 축소
 // - supabase 및 외부 API 도메인 화이트리스트화
 
+import withSerwist from "@serwist/next";
 import type { NextConfig } from "next";
 
 const supabaseHostname =
@@ -79,6 +80,7 @@ const nextConfig: NextConfig = {
     // 주의:
     // - 'unsafe-inline', 'unsafe-eval'은 완화된 설정 (현재는 필요하므로 유지, 추후 개선)
     // - 강제 CSP 디렉티브(object-src, base-uri, frame-ancestors)는 혼재하지 않음
+    // - worker-src는 서비스 워커 호환성 관측 후 강제 CSP 승격 여부를 판단함
     const cspReportOnly = [
       "default-src 'self'",
       "img-src 'self' data: blob: https:",
@@ -86,6 +88,7 @@ const nextConfig: NextConfig = {
       "style-src 'self' 'unsafe-inline' https:",
       "script-src 'self' 'unsafe-inline' 'unsafe-eval' https:",
       "connect-src 'self' https:",
+      "worker-src 'self'",
     ].join("; ");
 
     return [
@@ -188,4 +191,8 @@ const nextConfig: NextConfig = {
   },
 };
 
-export default nextConfig;
+export default withSerwist({
+  swSrc: "src/sw.ts",
+  swDest: "public/sw.js",
+  disable: process.env.NODE_ENV === "development",
+})(nextConfig);

--- a/next.config.ts
+++ b/next.config.ts
@@ -26,6 +26,12 @@ const supabaseHostname =
     ? new URL(process.env.NEXT_PUBLIC_SUPABASE_URL).hostname
     : undefined);
 
+export function shouldDisableSerwist() {
+  return (
+    process.env.NODE_ENV === "development" && process.env.ENABLE_SW !== "true"
+  );
+}
+
 // [설계 의도] securityHeaders는 top-level에서 정의하지 않고 headers() 내부에서 생성
 // 이유: isProduction을 top-level 상수로 두면 import 시점에 고정되어 테스트에서 NODE_ENV 변경이 반영되지 않음
 
@@ -196,6 +202,5 @@ export default withSerwist({
   swDest: "public/sw.js",
   // dev에서는 기본적으로 SW 비활성화 (HMR 충돌 회피).
   // 푸시 알림을 로컬에서 검증할 때만 ENABLE_SW=true로 일시 활성화.
-  disable:
-    process.env.NODE_ENV === "development" && process.env.ENABLE_SW !== "true",
+  disable: shouldDisableSerwist(),
 })(nextConfig);

--- a/next.config.ts
+++ b/next.config.ts
@@ -194,5 +194,8 @@ const nextConfig: NextConfig = {
 export default withSerwist({
   swSrc: "src/sw.ts",
   swDest: "public/sw.js",
-  disable: process.env.NODE_ENV === "development",
+  // dev에서는 기본적으로 SW 비활성화 (HMR 충돌 회피).
+  // 푸시 알림을 로컬에서 검증할 때만 ENABLE_SW=true로 일시 활성화.
+  disable:
+    process.env.NODE_ENV === "development" && process.env.ENABLE_SW !== "true",
 })(nextConfig);

--- a/package-lock.json
+++ b/package-lock.json
@@ -66,6 +66,7 @@
         "@types/react-dom": "^19",
         "@types/web-push": "^3.6.4",
         "@vitejs/plugin-react": "^6.0.1",
+        "cross-env": "^7.0.3",
         "eslint": "^9",
         "eslint-config-next": "15.5.12",
         "eslint-plugin-simple-import-sort": "^12.1.1",
@@ -8170,6 +8171,25 @@
       "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
       "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
       "license": "MIT"
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",
+    "dev:sw": "next dev",
     "build": "next build",
     "start": "next start",
     "lint": "eslint",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",
-    "dev:sw": "next dev",
+    "dev:sw": "cross-env ENABLE_SW=true next dev",
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
@@ -70,6 +70,7 @@
     "@types/react-dom": "^19",
     "@types/web-push": "^3.6.4",
     "@vitejs/plugin-react": "^6.0.1",
+    "cross-env": "^7.0.3",
     "eslint": "^9",
     "eslint-config-next": "15.5.12",
     "eslint-plugin-simple-import-sort": "^12.1.1",

--- a/src/app/(main)/mypage/page.tsx
+++ b/src/app/(main)/mypage/page.tsx
@@ -12,6 +12,8 @@ import {
 } from "@/features/mypage/components/MypageNav";
 import { ProfileSection } from "@/features/mypage/components/ProfileSection";
 import { getLearningStats } from "@/features/mypage/queries";
+import { PushSubscribeCard } from "@/features/notifications/components/PushSubscribeCard";
+import { getHasAnyPushSubscription } from "@/features/notifications/queries";
 import { ROUTES } from "@/lib/constants/routes";
 import { getProfile } from "@/lib/supabase/getProfile";
 import { getUser } from "@/lib/supabase/getUser";
@@ -46,9 +48,10 @@ export default async function MyPage({ searchParams }: Props) {
 
   // getProfile/getLearningStats는 내부적으로 getUser를 React.cache로 공유함
   // 2개를 한 번에 시작해 waterfall 제거
-  const [profile, stats] = await Promise.all([
+  const [profile, stats, hasAnyPushSubscription] = await Promise.all([
     getProfile(),
     getLearningStats(),
+    getHasAnyPushSubscription({ userId: user.id }),
   ]);
 
   if (!profile) redirect(ROUTES.LOGIN);
@@ -97,6 +100,9 @@ export default async function MyPage({ searchParams }: Props) {
           {section === "profile" && (
             <>
               <ProfileSection profile={profile} email={user?.email ?? ""} />
+              <PushSubscribeCard
+                initialHasAnySubscription={hasAnyPushSubscription}
+              />
               <AccountSection />
               <DeleteAccountSection userEmail={user?.email ?? ""} />
             </>

--- a/src/app/api/cron/dispatch-notifications/route.test.ts
+++ b/src/app/api/cron/dispatch-notifications/route.test.ts
@@ -235,7 +235,7 @@ describe("/api/cron/dispatch-notifications", () => {
         note_id: NOTE_ID,
         review_log_id: REVIEW_LOG_ID,
         status: "SENT",
-        title: "복습 시간이에요",
+        title: "복습할 시간이에요!",
         type: "REVIEW",
         user_id: USER_ID,
       },
@@ -253,14 +253,14 @@ describe("/api/cron/dispatch-notifications", () => {
         },
       },
       {
-        body: "복습할 노트가 있어요.",
+        body: '"알림 노트" 복습할 시간이에요.',
         data: {
           noteId: NOTE_ID,
           notificationId: NOTIFICATION_ID,
           reviewLogId: REVIEW_LOG_ID,
           url: `/notes/${NOTE_ID}/review`,
         },
-        title: "복습 시간이에요",
+        title: "복습할 시간이에요!",
       },
     );
   });

--- a/src/app/api/cron/dispatch-notifications/route.ts
+++ b/src/app/api/cron/dispatch-notifications/route.ts
@@ -16,8 +16,7 @@ export const dynamic = "force-dynamic";
 
 const CLAIM_LIMIT = 200;
 const CLAIM_CONCURRENCY = 8;
-const REVIEW_NOTIFICATION_PUSH_BODY = "복습할 노트가 있어요.";
-const REVIEW_NOTIFICATION_TITLE = "복습 시간이에요";
+const REVIEW_NOTIFICATION_TITLE = "복습할 시간이에요!";
 const REVIEW_ROUTE_SEGMENT = "review";
 
 type ClaimedReviewLogType = {
@@ -95,12 +94,18 @@ function buildReviewUrl(noteId: string): string {
   return `/notes/${noteId}/${REVIEW_ROUTE_SEGMENT}`;
 }
 
+function buildReviewNotificationBody(noteTitle: string): string {
+  return `"${noteTitle}" 복습할 시간이에요.`;
+}
+
 function buildPushPayload({
   noteId,
+  noteTitle,
   notificationId,
   reviewLogId,
 }: {
   noteId: string;
+  noteTitle: string;
   notificationId: string;
   reviewLogId: string;
 }) {
@@ -108,7 +113,7 @@ function buildPushPayload({
 
   return {
     title: REVIEW_NOTIFICATION_TITLE,
-    body: REVIEW_NOTIFICATION_PUSH_BODY,
+    body: buildReviewNotificationBody(noteTitle),
     data: {
       noteId,
       notificationId,
@@ -321,6 +326,7 @@ async function dispatchClaimedReviewLog(
 
     const payload = buildPushPayload({
       noteId: claimedLog.note_id,
+      noteTitle,
       notificationId: notification.id,
       reviewLogId: claimedLog.id,
     });

--- a/src/app/api/notifications/route.test.ts
+++ b/src/app/api/notifications/route.test.ts
@@ -49,7 +49,7 @@ describe("/api/notifications", () => {
     getNotificationListMock.mockResolvedValue([
       {
         id: "22222222-2222-4222-8222-222222222222",
-        title: "복습 시간이에요",
+        title: "복습할 시간이에요!",
       },
     ]);
     getUnreadCountMock.mockResolvedValue(1);
@@ -60,7 +60,7 @@ describe("/api/notifications", () => {
       items: [
         {
           id: "22222222-2222-4222-8222-222222222222",
-          title: "복습 시간이에요",
+          title: "복습할 시간이에요!",
         },
       ],
       unreadCount: 1,

--- a/src/features/notifications/actions.ts
+++ b/src/features/notifications/actions.ts
@@ -4,7 +4,6 @@ import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 
 import { getNoteDetailRoute, ROUTES } from "@/lib/constants/routes";
-import { createAdminClient } from "@/lib/supabase/admin";
 import { createClient } from "@/lib/supabase/server";
 
 import {
@@ -74,9 +73,7 @@ export async function subscribeToPushAction(
   }
 
   const { endpoint, keys } = parsed.data;
-  // A push endpoint is origin-scoped, so account switches must claim it across RLS ownership.
-  const adminClient = createAdminClient();
-  const { error } = await adminClient.from("push_subscriptions").upsert(
+  const { error } = await context.supabase.from("push_subscriptions").upsert(
     {
       user_id: context.userId,
       endpoint,
@@ -117,13 +114,11 @@ export async function unsubscribeFromPushAction(
     return { success: false, error: context.error };
   }
 
-  // endpoint는 origin-scoped이고 클라이언트가 곧 PushSubscription.unsubscribe()로 무효화하므로,
-  // 같은 브라우저에서 이전 계정이 남긴 row까지 admin 권한으로 함께 정리한다.
-  const adminClient = createAdminClient();
-  const { error } = await adminClient
+  const { error } = await context.supabase
     .from("push_subscriptions")
     .delete()
-    .eq("endpoint", parsed.data);
+    .eq("endpoint", parsed.data)
+    .eq("user_id", context.userId);
 
   if (error) {
     return {

--- a/src/features/notifications/actions.ts
+++ b/src/features/notifications/actions.ts
@@ -36,6 +36,8 @@ export type MarkNotificationAsReadActionResultType =
       error: string;
     };
 
+export type CheckPushSubscriptionOwnedResultType = { owned: boolean };
+
 async function getVerifiedNotificationContext() {
   const supabase = await createClient();
   const {
@@ -115,11 +117,13 @@ export async function unsubscribeFromPushAction(
     return { success: false, error: context.error };
   }
 
-  const { error } = await context.supabase
+  // endpoint는 origin-scoped이고 클라이언트가 곧 PushSubscription.unsubscribe()로 무효화하므로,
+  // 같은 브라우저에서 이전 계정이 남긴 row까지 admin 권한으로 함께 정리한다.
+  const adminClient = createAdminClient();
+  const { error } = await adminClient
     .from("push_subscriptions")
     .delete()
-    .eq("endpoint", parsed.data)
-    .eq("user_id", context.userId);
+    .eq("endpoint", parsed.data);
 
   if (error) {
     return {
@@ -131,6 +135,34 @@ export async function unsubscribeFromPushAction(
   revalidatePath(ROUTES.MYPAGE);
 
   return { success: true };
+}
+
+export async function checkPushSubscriptionOwnedAction(
+  endpoint: unknown,
+): Promise<CheckPushSubscriptionOwnedResultType> {
+  const parsed = pushSubscriptionEndpointSchema.safeParse(endpoint);
+
+  if (!parsed.success) {
+    return { owned: false };
+  }
+
+  const context = await getVerifiedNotificationContext();
+
+  if ("error" in context) {
+    return { owned: false };
+  }
+
+  const { count, error } = await context.supabase
+    .from("push_subscriptions")
+    .select("id", { count: "exact", head: true })
+    .eq("endpoint", parsed.data)
+    .eq("user_id", context.userId);
+
+  if (error) {
+    return { owned: false };
+  }
+
+  return { owned: (count ?? 0) > 0 };
 }
 
 export async function markNotificationAsReadAction(

--- a/src/features/notifications/actions.ts
+++ b/src/features/notifications/actions.ts
@@ -4,6 +4,7 @@ import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 
 import { getNoteDetailRoute, ROUTES } from "@/lib/constants/routes";
+import { createAdminClient } from "@/lib/supabase/admin";
 import { createClient } from "@/lib/supabase/server";
 
 import {
@@ -71,7 +72,9 @@ export async function subscribeToPushAction(
   }
 
   const { endpoint, keys } = parsed.data;
-  const { error } = await context.supabase.from("push_subscriptions").upsert(
+  // A push endpoint is origin-scoped, so account switches must claim it across RLS ownership.
+  const adminClient = createAdminClient();
+  const { error } = await adminClient.from("push_subscriptions").upsert(
     {
       user_id: context.userId,
       endpoint,

--- a/src/features/notifications/components/PushSubscribeCard.test.tsx
+++ b/src/features/notifications/components/PushSubscribeCard.test.tsx
@@ -1,0 +1,233 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const ENDPOINT = "https://push.example.test/subscription-id";
+const VAPID_PUBLIC_KEY = "AAAA";
+
+const {
+  refreshMock,
+  subscribeToPushActionMock,
+  unsubscribeFromPushActionMock,
+} = vi.hoisted(() => ({
+  refreshMock: vi.fn(),
+  subscribeToPushActionMock: vi.fn(),
+  unsubscribeFromPushActionMock: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    refresh: refreshMock,
+  }),
+}));
+
+vi.mock("../actions", () => ({
+  subscribeToPushAction: subscribeToPushActionMock,
+  unsubscribeFromPushAction: unsubscribeFromPushActionMock,
+}));
+
+const originalNotification = Object.getOwnPropertyDescriptor(
+  window,
+  "Notification",
+);
+const originalPushManager = Object.getOwnPropertyDescriptor(
+  window,
+  "PushManager",
+);
+const originalServiceWorker = Object.getOwnPropertyDescriptor(
+  navigator,
+  "serviceWorker",
+);
+
+type SupportedPushEnvironmentOptionsType = {
+  existingSubscription?: PushSubscription | null;
+  permission?: NotificationPermission;
+};
+
+function restoreDescriptor<T extends object>(
+  target: T,
+  key: keyof T,
+  descriptor: PropertyDescriptor | undefined,
+) {
+  if (descriptor) {
+    Object.defineProperty(target, key, descriptor);
+    return;
+  }
+
+  Reflect.deleteProperty(target, key);
+}
+
+async function loadPushSubscribeCard() {
+  const mod = await import("./PushSubscribeCard");
+  return mod.PushSubscribeCard;
+}
+
+function createPushSubscription(endpoint = ENDPOINT) {
+  return {
+    endpoint,
+    toJSON: () => ({
+      endpoint,
+      keys: {
+        auth: "auth-secret",
+        p256dh: "p256dh-key",
+      },
+    }),
+    unsubscribe: vi.fn().mockResolvedValue(true),
+  } as unknown as PushSubscription;
+}
+
+function setupSupportedPushEnvironment({
+  existingSubscription = null,
+  permission = "default",
+}: SupportedPushEnvironmentOptionsType = {}) {
+  const requestPermissionMock = vi.fn().mockResolvedValue("granted");
+  const notificationMock = {
+    permission,
+    requestPermission: requestPermissionMock,
+  };
+  const getSubscriptionMock = vi.fn().mockResolvedValue(existingSubscription);
+  const subscribedSubscription = createPushSubscription();
+  const subscribeMock = vi.fn().mockResolvedValue(subscribedSubscription);
+  const registration = {
+    pushManager: {
+      getSubscription: getSubscriptionMock,
+      subscribe: subscribeMock,
+    },
+  };
+  const getRegistrationMock = vi.fn().mockResolvedValue(registration);
+  const registerMock = vi.fn().mockResolvedValue(registration);
+
+  Object.defineProperty(window, "Notification", {
+    configurable: true,
+    value: notificationMock,
+  });
+  Object.defineProperty(window, "PushManager", {
+    configurable: true,
+    value: function PushManager() {},
+  });
+  Object.defineProperty(navigator, "serviceWorker", {
+    configurable: true,
+    value: {
+      getRegistration: getRegistrationMock,
+      ready: Promise.resolve(registration),
+      register: registerMock,
+    },
+  });
+
+  return {
+    getRegistrationMock,
+    getSubscriptionMock,
+    registerMock,
+    requestPermissionMock,
+    subscribeMock,
+    subscribedSubscription,
+  };
+}
+
+describe("PushSubscribeCard", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+    refreshMock.mockReset();
+    subscribeToPushActionMock.mockReset();
+    unsubscribeFromPushActionMock.mockReset();
+    restoreDescriptor(window, "Notification", originalNotification);
+    restoreDescriptor(window, "PushManager", originalPushManager);
+    restoreDescriptor(navigator, "serviceWorker", originalServiceWorker);
+  });
+
+  it("renders a disabled state when push notifications are not supported", async () => {
+    const PushSubscribeCard = await loadPushSubscribeCard();
+
+    render(<PushSubscribeCard initialHasAnySubscription={false} />);
+
+    expect(
+      await screen.findByText("이 브라우저는 푸시 알림을 지원하지 않습니다."),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /알림 켜기/ })).toBeDisabled();
+  });
+
+  it("does not auto-resubscribe an existing browser subscription", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("NEXT_PUBLIC_VAPID_PUBLIC_KEY", VAPID_PUBLIC_KEY);
+    setupSupportedPushEnvironment({
+      existingSubscription: createPushSubscription(),
+      permission: "granted",
+    });
+    const PushSubscribeCard = await loadPushSubscribeCard();
+
+    render(<PushSubscribeCard initialHasAnySubscription={true} />);
+
+    expect(
+      await screen.findByText("현재 브라우저에서 알림이 켜져 있습니다."),
+    ).toBeInTheDocument();
+    expect(subscribeToPushActionMock).not.toHaveBeenCalled();
+  });
+
+  it("subscribes this browser when the user clicks the subscribe button", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("NEXT_PUBLIC_VAPID_PUBLIC_KEY", VAPID_PUBLIC_KEY);
+    const { requestPermissionMock, subscribeMock } =
+      setupSupportedPushEnvironment();
+    subscribeToPushActionMock.mockResolvedValue({ success: true });
+    const PushSubscribeCard = await loadPushSubscribeCard();
+    const user = userEvent.setup();
+
+    render(<PushSubscribeCard initialHasAnySubscription={false} />);
+
+    expect(
+      await screen.findByText("현재 브라우저에서 알림이 꺼져 있습니다."),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /알림 켜기/ }));
+
+    await waitFor(() => {
+      expect(subscribeToPushActionMock).toHaveBeenCalledWith({
+        endpoint: ENDPOINT,
+        keys: {
+          auth: "auth-secret",
+          p256dh: "p256dh-key",
+        },
+      });
+    });
+    expect(requestPermissionMock).toHaveBeenCalled();
+    expect(subscribeMock).toHaveBeenCalledWith({
+      applicationServerKey: new Uint8Array([0, 0, 0]),
+      userVisibleOnly: true,
+    });
+    expect(refreshMock).toHaveBeenCalled();
+    expect(
+      await screen.findByText("이 브라우저에서 복습 알림을 받을 수 있습니다."),
+    ).toBeInTheDocument();
+  });
+
+  it("unsubscribes this browser when the user clicks the unsubscribe button", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("NEXT_PUBLIC_VAPID_PUBLIC_KEY", VAPID_PUBLIC_KEY);
+    const existingSubscription = createPushSubscription();
+    setupSupportedPushEnvironment({
+      existingSubscription,
+      permission: "granted",
+    });
+    unsubscribeFromPushActionMock.mockResolvedValue({ success: true });
+    const PushSubscribeCard = await loadPushSubscribeCard();
+    const user = userEvent.setup();
+
+    render(<PushSubscribeCard initialHasAnySubscription={true} />);
+
+    expect(
+      await screen.findByText("현재 브라우저에서 알림이 켜져 있습니다."),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /알림 끄기/ }));
+
+    await waitFor(() => {
+      expect(unsubscribeFromPushActionMock).toHaveBeenCalledWith(ENDPOINT);
+    });
+    expect(existingSubscription.unsubscribe).toHaveBeenCalled();
+    expect(refreshMock).toHaveBeenCalled();
+    expect(
+      await screen.findByText("이 브라우저의 복습 알림을 껐습니다."),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/features/notifications/components/PushSubscribeCard.tsx
+++ b/src/features/notifications/components/PushSubscribeCard.tsx
@@ -23,7 +23,6 @@ type PushSubscribeCardProps = {
 };
 
 const vapidPublicKey = process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY ?? "";
-const isProductionRuntime = process.env.NODE_ENV === "production";
 
 function isPushSupported() {
   return (
@@ -102,7 +101,7 @@ export function PushSubscribeCard({
   const [error, setError] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
 
-  const isRuntimeEnabled = isProductionRuntime && vapidPublicKey.length > 0;
+  const isRuntimeEnabled = vapidPublicKey.length > 0;
   const isCurrentBrowserSubscribed =
     permission === "granted" && browserEndpoint !== null;
 
@@ -151,13 +150,11 @@ export function PushSubscribeCard({
 
   const disabledReason = !isSupported
     ? "이 브라우저는 푸시 알림을 지원하지 않습니다."
-    : !isProductionRuntime
-      ? "프로덕션 빌드에서 알림을 켤 수 있습니다."
-      : vapidPublicKey.length === 0
-        ? "VAPID 공개 키가 설정되지 않았습니다."
-        : permission === "denied"
-          ? "브라우저 사이트 설정에서 알림을 허용해 주세요."
-          : null;
+    : vapidPublicKey.length === 0
+      ? "VAPID 공개 키가 설정되지 않았습니다."
+      : permission === "denied"
+        ? "브라우저 사이트 설정에서 알림을 허용해 주세요."
+        : null;
 
   const handleSubscribe = () => {
     setError(null);

--- a/src/features/notifications/components/PushSubscribeCard.tsx
+++ b/src/features/notifications/components/PushSubscribeCard.tsx
@@ -1,0 +1,311 @@
+"use client";
+
+import { Bell, BellOff, Loader2 } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useEffect, useState, useTransition } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Separator } from "@/components/ui/separator";
+
+import { subscribeToPushAction, unsubscribeFromPushAction } from "../actions";
+
+type PushSubscriptionPayloadType = {
+  endpoint: string;
+  keys: {
+    p256dh: string;
+    auth: string;
+  };
+};
+
+type PushSubscribeCardProps = {
+  initialHasAnySubscription: boolean;
+};
+
+const vapidPublicKey = process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY ?? "";
+const isProductionRuntime = process.env.NODE_ENV === "production";
+
+function isPushSupported() {
+  return (
+    typeof window !== "undefined" &&
+    "Notification" in window &&
+    "serviceWorker" in navigator &&
+    "PushManager" in window
+  );
+}
+
+function urlBase64ToUint8Array(base64String: string) {
+  const padding = "=".repeat((4 - (base64String.length % 4)) % 4);
+  const base64 = `${base64String}${padding}`
+    .replace(/-/g, "+")
+    .replace(/_/g, "/");
+  const rawData = window.atob(base64);
+  const outputArray = new Uint8Array(rawData.length);
+
+  for (let i = 0; i < rawData.length; i += 1) {
+    outputArray[i] = rawData.charCodeAt(i);
+  }
+
+  return outputArray;
+}
+
+function serializePushSubscription(
+  subscription: PushSubscription,
+): PushSubscriptionPayloadType {
+  const json = subscription.toJSON();
+  const { endpoint, keys } = json;
+
+  if (!endpoint || !keys?.p256dh || !keys.auth) {
+    throw new Error("브라우저 구독 정보를 읽을 수 없습니다.");
+  }
+
+  return {
+    endpoint,
+    keys: {
+      p256dh: keys.p256dh,
+      auth: keys.auth,
+    },
+  };
+}
+
+async function getReadyServiceWorkerRegistration() {
+  const currentRegistration = await navigator.serviceWorker.getRegistration();
+
+  if (!currentRegistration) {
+    await navigator.serviceWorker.register("/sw.js", { scope: "/" });
+  }
+
+  return await navigator.serviceWorker.ready;
+}
+
+async function getCurrentPushSubscription() {
+  const registration = await navigator.serviceWorker.getRegistration();
+  return (await registration?.pushManager.getSubscription()) ?? null;
+}
+
+function getFallbackErrorMessage(error: unknown) {
+  return error instanceof Error
+    ? error.message
+    : "알림 설정을 변경하지 못했습니다.";
+}
+
+export function PushSubscribeCard({
+  initialHasAnySubscription,
+}: PushSubscribeCardProps) {
+  const router = useRouter();
+  const [permission, setPermission] =
+    useState<NotificationPermission>("default");
+  const [isSupported, setIsSupported] = useState(true);
+  const [hasAnySubscription, setHasAnySubscription] = useState(
+    initialHasAnySubscription,
+  );
+  const [browserEndpoint, setBrowserEndpoint] = useState<string | null>(null);
+  const [isChecking, setIsChecking] = useState(true);
+  const [message, setMessage] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  const isRuntimeEnabled = isProductionRuntime && vapidPublicKey.length > 0;
+  const isCurrentBrowserSubscribed =
+    permission === "granted" && browserEndpoint !== null;
+
+  useEffect(() => {
+    setHasAnySubscription(initialHasAnySubscription);
+  }, [initialHasAnySubscription]);
+
+  useEffect(() => {
+    let isCancelled = false;
+
+    async function checkSubscription() {
+      if (!isPushSupported()) {
+        if (!isCancelled) {
+          setIsSupported(false);
+          setIsChecking(false);
+        }
+        return;
+      }
+
+      setPermission(Notification.permission);
+
+      if (!isRuntimeEnabled) {
+        if (!isCancelled) setIsChecking(false);
+        return;
+      }
+
+      try {
+        const subscription = await getCurrentPushSubscription();
+
+        if (isCancelled) return;
+
+        setBrowserEndpoint(subscription?.endpoint ?? null);
+      } catch (checkError) {
+        if (!isCancelled) {
+          console.error("푸시 알림 상태를 확인하지 못했습니다.", checkError);
+        }
+      } finally {
+        if (!isCancelled) {
+          setIsChecking(false);
+        }
+      }
+    }
+
+    void checkSubscription();
+
+    return () => {
+      isCancelled = true;
+    };
+  }, [isRuntimeEnabled]);
+
+  const disabledReason = !isSupported
+    ? "이 브라우저는 푸시 알림을 지원하지 않습니다."
+    : !isProductionRuntime
+      ? "프로덕션 빌드에서 알림을 켤 수 있습니다."
+      : vapidPublicKey.length === 0
+        ? "VAPID 공개 키가 설정되지 않았습니다."
+        : permission === "denied"
+          ? "브라우저 사이트 설정에서 알림을 허용해 주세요."
+          : null;
+
+  const handleSubscribe = () => {
+    setError(null);
+    setMessage(null);
+
+    startTransition(async () => {
+      try {
+        const nextPermission =
+          Notification.permission === "granted"
+            ? "granted"
+            : await Notification.requestPermission();
+
+        setPermission(nextPermission);
+
+        if (nextPermission !== "granted") {
+          setError("알림 권한이 허용되지 않았습니다.");
+          return;
+        }
+
+        const registration = await getReadyServiceWorkerRegistration();
+        const subscription =
+          (await registration.pushManager.getSubscription()) ??
+          (await registration.pushManager.subscribe({
+            userVisibleOnly: true,
+            applicationServerKey: urlBase64ToUint8Array(vapidPublicKey),
+          }));
+        const payload = serializePushSubscription(subscription);
+        const result = await subscribeToPushAction(payload);
+
+        if (!result.success) {
+          setError(result.error);
+          return;
+        }
+
+        setHasAnySubscription(true);
+        setBrowserEndpoint(payload.endpoint);
+        setMessage("이 브라우저에서 복습 알림을 받을 수 있습니다.");
+        router.refresh();
+      } catch (subscribeError) {
+        setError(getFallbackErrorMessage(subscribeError));
+      }
+    });
+  };
+
+  const handleUnsubscribe = () => {
+    setError(null);
+    setMessage(null);
+
+    startTransition(async () => {
+      try {
+        const subscription = await getCurrentPushSubscription();
+        const endpoint = subscription?.endpoint ?? browserEndpoint;
+
+        if (!endpoint) {
+          setBrowserEndpoint(null);
+          return;
+        }
+
+        if (subscription) {
+          await subscription.unsubscribe();
+        }
+
+        const result = await unsubscribeFromPushAction(endpoint);
+
+        if (!result.success) {
+          setError(result.error);
+          return;
+        }
+
+        setHasAnySubscription(false);
+        setBrowserEndpoint(null);
+        setMessage("이 브라우저의 복습 알림을 껐습니다.");
+        router.refresh();
+      } catch (unsubscribeError) {
+        setError(getFallbackErrorMessage(unsubscribeError));
+      }
+    });
+  };
+
+  const statusText = isChecking
+    ? "알림 상태를 확인하는 중입니다."
+    : disabledReason
+      ? disabledReason
+      : isCurrentBrowserSubscribed
+        ? "현재 브라우저에서 알림이 켜져 있습니다."
+        : hasAnySubscription
+          ? "다른 브라우저에 저장된 알림 구독이 있습니다."
+          : "현재 브라우저에서 알림이 꺼져 있습니다.";
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center justify-between gap-3">
+          <CardTitle>복습 알림</CardTitle>
+          {isCurrentBrowserSubscribed ? (
+            <Bell className="size-4 text-primary" aria-hidden="true" />
+          ) : (
+            <BellOff
+              className="size-4 text-muted-foreground"
+              aria-hidden="true"
+            />
+          )}
+        </div>
+      </CardHeader>
+      <Separator />
+      <CardContent className="space-y-4 pt-5">
+        <div className="space-y-1">
+          <p className="text-sm font-medium">{statusText}</p>
+          <p className="text-xs text-muted-foreground">
+            복습 예정 시간이 되면 이 브라우저로 알림을 보냅니다.
+          </p>
+        </div>
+
+        <Button
+          type="button"
+          variant={isCurrentBrowserSubscribed ? "outline" : "default"}
+          size="md"
+          disabled={isPending || isChecking || disabledReason !== null}
+          onClick={
+            isCurrentBrowserSubscribed ? handleUnsubscribe : handleSubscribe
+          }
+        >
+          {isPending ? (
+            <Loader2 className="animate-spin" aria-hidden="true" />
+          ) : isCurrentBrowserSubscribed ? (
+            <BellOff aria-hidden="true" />
+          ) : (
+            <Bell aria-hidden="true" />
+          )}
+          {isPending
+            ? "처리 중"
+            : isCurrentBrowserSubscribed
+              ? "알림 끄기"
+              : "알림 켜기"}
+        </Button>
+
+        <div aria-live="polite" className="min-h-5">
+          {message && <p className="text-sm text-green-600">{message}</p>}
+          {error && <p className="text-sm text-destructive">{error}</p>}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/features/notifications/components/PushSubscribeCard.tsx
+++ b/src/features/notifications/components/PushSubscribeCard.tsx
@@ -96,9 +96,6 @@ export function PushSubscribeCard({
   const [permission, setPermission] =
     useState<NotificationPermission>("default");
   const [isSupported, setIsSupported] = useState(true);
-  const [hasAnySubscription, setHasAnySubscription] = useState(
-    initialHasAnySubscription,
-  );
   const [browserEndpoint, setBrowserEndpoint] = useState<string | null>(null);
   const [isChecking, setIsChecking] = useState(true);
   const [message, setMessage] = useState<string | null>(null);
@@ -108,10 +105,6 @@ export function PushSubscribeCard({
   const isRuntimeEnabled = isProductionRuntime && vapidPublicKey.length > 0;
   const isCurrentBrowserSubscribed =
     permission === "granted" && browserEndpoint !== null;
-
-  useEffect(() => {
-    setHasAnySubscription(initialHasAnySubscription);
-  }, [initialHasAnySubscription]);
 
   useEffect(() => {
     let isCancelled = false;
@@ -199,7 +192,6 @@ export function PushSubscribeCard({
           return;
         }
 
-        setHasAnySubscription(true);
         setBrowserEndpoint(payload.endpoint);
         setMessage("이 브라우저에서 복습 알림을 받을 수 있습니다.");
         router.refresh();
@@ -223,10 +215,6 @@ export function PushSubscribeCard({
           return;
         }
 
-        if (subscription) {
-          await subscription.unsubscribe();
-        }
-
         const result = await unsubscribeFromPushAction(endpoint);
 
         if (!result.success) {
@@ -234,7 +222,10 @@ export function PushSubscribeCard({
           return;
         }
 
-        setHasAnySubscription(false);
+        if (subscription) {
+          await subscription.unsubscribe();
+        }
+
         setBrowserEndpoint(null);
         setMessage("이 브라우저의 복습 알림을 껐습니다.");
         router.refresh();
@@ -250,7 +241,7 @@ export function PushSubscribeCard({
       ? disabledReason
       : isCurrentBrowserSubscribed
         ? "현재 브라우저에서 알림이 켜져 있습니다."
-        : hasAnySubscription
+        : initialHasAnySubscription
           ? "다른 브라우저에 저장된 알림 구독이 있습니다."
           : "현재 브라우저에서 알림이 꺼져 있습니다.";
 

--- a/src/features/notifications/components/PushSubscribeCard.tsx
+++ b/src/features/notifications/components/PushSubscribeCard.tsx
@@ -197,8 +197,16 @@ export function PushSubscribeCard({
         }
 
         const registration = await getReadyServiceWorkerRegistration();
+        const existingSubscription =
+          await registration.pushManager.getSubscription();
+
+        if (existingSubscription && !isOwnedByCurrentUser) {
+          await existingSubscription.unsubscribe();
+          setBrowserEndpoint(null);
+        }
+
         const subscription =
-          (await registration.pushManager.getSubscription()) ??
+          (isOwnedByCurrentUser ? existingSubscription : null) ??
           (await registration.pushManager.subscribe({
             userVisibleOnly: true,
             applicationServerKey: urlBase64ToUint8Array(vapidPublicKey),
@@ -263,7 +271,7 @@ export function PushSubscribeCard({
       : isCurrentBrowserSubscribed
         ? "현재 브라우저에서 알림이 켜져 있습니다."
         : hasOrphanBrowserSubscription
-          ? "이 브라우저에 다른 계정의 구독이 남아있습니다. 알림 켜기를 누르면 현재 계정으로 가져옵니다."
+          ? "이 브라우저에 다른 계정의 구독이 남아있습니다. 알림 켜기를 누르면 새 구독으로 다시 설정합니다."
           : initialHasAnySubscription
             ? "다른 브라우저에 저장된 알림 구독이 있습니다."
             : "현재 브라우저에서 알림이 꺼져 있습니다.";

--- a/src/features/notifications/components/PushSubscribeCard.tsx
+++ b/src/features/notifications/components/PushSubscribeCard.tsx
@@ -8,7 +8,11 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Separator } from "@/components/ui/separator";
 
-import { subscribeToPushAction, unsubscribeFromPushAction } from "../actions";
+import {
+  checkPushSubscriptionOwnedAction,
+  subscribeToPushAction,
+  unsubscribeFromPushAction,
+} from "../actions";
 
 type PushSubscriptionPayloadType = {
   endpoint: string;
@@ -96,14 +100,24 @@ export function PushSubscribeCard({
     useState<NotificationPermission>("default");
   const [isSupported, setIsSupported] = useState(true);
   const [browserEndpoint, setBrowserEndpoint] = useState<string | null>(null);
+  const [isOwnedByCurrentUser, setIsOwnedByCurrentUser] = useState(false);
   const [isChecking, setIsChecking] = useState(true);
   const [message, setMessage] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
 
   const isRuntimeEnabled = vapidPublicKey.length > 0;
+  // Push endpoint is origin-scoped, so a stale browser subscription left by a previous account
+  // does NOT mean the current user owns it. Verify ownership against the DB before treating
+  // the button as "unsubscribe".
   const isCurrentBrowserSubscribed =
-    permission === "granted" && browserEndpoint !== null;
+    permission === "granted" &&
+    browserEndpoint !== null &&
+    isOwnedByCurrentUser;
+  const hasOrphanBrowserSubscription =
+    permission === "granted" &&
+    browserEndpoint !== null &&
+    !isOwnedByCurrentUser;
 
   useEffect(() => {
     let isCancelled = false;
@@ -129,7 +143,15 @@ export function PushSubscribeCard({
 
         if (isCancelled) return;
 
-        setBrowserEndpoint(subscription?.endpoint ?? null);
+        const endpoint = subscription?.endpoint ?? null;
+        setBrowserEndpoint(endpoint);
+
+        if (endpoint) {
+          const { owned } = await checkPushSubscriptionOwnedAction(endpoint);
+          if (!isCancelled) setIsOwnedByCurrentUser(owned);
+        } else {
+          setIsOwnedByCurrentUser(false);
+        }
       } catch (checkError) {
         if (!isCancelled) {
           console.error("푸시 알림 상태를 확인하지 못했습니다.", checkError);
@@ -190,6 +212,7 @@ export function PushSubscribeCard({
         }
 
         setBrowserEndpoint(payload.endpoint);
+        setIsOwnedByCurrentUser(true);
         setMessage("이 브라우저에서 복습 알림을 받을 수 있습니다.");
         router.refresh();
       } catch (subscribeError) {
@@ -224,6 +247,7 @@ export function PushSubscribeCard({
         }
 
         setBrowserEndpoint(null);
+        setIsOwnedByCurrentUser(false);
         setMessage("이 브라우저의 복습 알림을 껐습니다.");
         router.refresh();
       } catch (unsubscribeError) {
@@ -238,9 +262,11 @@ export function PushSubscribeCard({
       ? disabledReason
       : isCurrentBrowserSubscribed
         ? "현재 브라우저에서 알림이 켜져 있습니다."
-        : initialHasAnySubscription
-          ? "다른 브라우저에 저장된 알림 구독이 있습니다."
-          : "현재 브라우저에서 알림이 꺼져 있습니다.";
+        : hasOrphanBrowserSubscription
+          ? "이 브라우저에 다른 계정의 구독이 남아있습니다. 알림 켜기를 누르면 현재 계정으로 가져옵니다."
+          : initialHasAnySubscription
+            ? "다른 브라우저에 저장된 알림 구독이 있습니다."
+            : "현재 브라우저에서 알림이 꺼져 있습니다.";
 
   return (
     <Card>

--- a/src/features/notifications/queries.ts
+++ b/src/features/notifications/queries.ts
@@ -145,3 +145,20 @@ export async function getNotificationList(
 
   return parsed.data;
 }
+
+export async function getHasAnyPushSubscription(
+  options: NotificationQueryOptionsType = {},
+): Promise<boolean> {
+  const { supabase, userId } = await getNotificationQueryContext(options);
+
+  if (!userId) return false;
+
+  const { count, error } = await supabase
+    .from("push_subscriptions")
+    .select("id", { count: "exact", head: true })
+    .eq("user_id", userId);
+
+  if (error) throw error;
+
+  return (count ?? 0) > 0;
+}

--- a/src/features/notifications/tests/PushSubscribeCard.test.tsx
+++ b/src/features/notifications/tests/PushSubscribeCard.test.tsx
@@ -58,7 +58,7 @@ function restoreDescriptor<T extends object>(
 }
 
 async function loadPushSubscribeCard() {
-  const mod = await import("./PushSubscribeCard");
+  const mod = await import("../components/PushSubscribeCard");
   return mod.PushSubscribeCard;
 }
 
@@ -225,6 +225,20 @@ describe("PushSubscribeCard", () => {
       expect(unsubscribeFromPushActionMock).toHaveBeenCalledWith(ENDPOINT);
     });
     expect(existingSubscription.unsubscribe).toHaveBeenCalled();
+    const serverDeleteCallOrder =
+      unsubscribeFromPushActionMock.mock.invocationCallOrder.at(0);
+    const browserUnsubscribeCallOrder = vi
+      .mocked(existingSubscription.unsubscribe)
+      .mock.invocationCallOrder.at(0);
+
+    if (
+      serverDeleteCallOrder === undefined ||
+      browserUnsubscribeCallOrder === undefined
+    ) {
+      throw new Error("Expected both unsubscribe steps to run");
+    }
+
+    expect(serverDeleteCallOrder).toBeLessThan(browserUnsubscribeCallOrder);
     expect(refreshMock).toHaveBeenCalled();
     expect(
       await screen.findByText("이 브라우저의 복습 알림을 껐습니다."),

--- a/src/features/notifications/tests/PushSubscribeCard.test.tsx
+++ b/src/features/notifications/tests/PushSubscribeCard.test.tsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const ENDPOINT = "https://push.example.test/subscription-id";
+const STALE_ENDPOINT = "https://push.example.test/stale-subscription-id";
 const VAPID_PUBLIC_KEY = "AAAA";
 
 const {
@@ -45,6 +46,7 @@ const originalServiceWorker = Object.getOwnPropertyDescriptor(
 type SupportedPushEnvironmentOptionsType = {
   existingSubscription?: PushSubscription | null;
   permission?: NotificationPermission;
+  subscribedSubscription?: PushSubscription;
 };
 
 function restoreDescriptor<T extends object>(
@@ -82,6 +84,7 @@ function createPushSubscription(endpoint = ENDPOINT) {
 function setupSupportedPushEnvironment({
   existingSubscription = null,
   permission = "default",
+  subscribedSubscription = createPushSubscription(),
 }: SupportedPushEnvironmentOptionsType = {}) {
   const requestPermissionMock = vi.fn().mockResolvedValue("granted");
   const notificationMock = {
@@ -89,7 +92,6 @@ function setupSupportedPushEnvironment({
     requestPermission: requestPermissionMock,
   };
   const getSubscriptionMock = vi.fn().mockResolvedValue(existingSubscription);
-  const subscribedSubscription = createPushSubscription();
   const subscribeMock = vi.fn().mockResolvedValue(subscribedSubscription);
   const registration = {
     pushManager: {
@@ -173,10 +175,11 @@ describe("PushSubscribeCard", () => {
     expect(subscribeToPushActionMock).not.toHaveBeenCalled();
   });
 
-  it("treats a browser subscription left by a previous account as a claim opportunity", async () => {
+  it("replaces a browser subscription left by a previous account before subscribing", async () => {
     vi.stubEnv("NEXT_PUBLIC_VAPID_PUBLIC_KEY", VAPID_PUBLIC_KEY);
+    const staleSubscription = createPushSubscription(STALE_ENDPOINT);
     setupSupportedPushEnvironment({
-      existingSubscription: createPushSubscription(),
+      existingSubscription: staleSubscription,
       permission: "granted",
     });
     checkPushSubscriptionOwnedActionMock.mockResolvedValue({ owned: false });
@@ -188,13 +191,17 @@ describe("PushSubscribeCard", () => {
 
     expect(
       await screen.findByText(
-        "이 브라우저에 다른 계정의 구독이 남아있습니다. 알림 켜기를 누르면 현재 계정으로 가져옵니다.",
+        "이 브라우저에 다른 계정의 구독이 남아있습니다. 알림 켜기를 누르면 새 구독으로 다시 설정합니다.",
       ),
     ).toBeInTheDocument();
+    expect(checkPushSubscriptionOwnedActionMock).toHaveBeenCalledWith(
+      STALE_ENDPOINT,
+    );
 
     await user.click(screen.getByRole("button", { name: /알림 켜기/ }));
 
     await waitFor(() => {
+      expect(staleSubscription.unsubscribe).toHaveBeenCalled();
       expect(subscribeToPushActionMock).toHaveBeenCalledWith({
         endpoint: ENDPOINT,
         keys: {
@@ -203,6 +210,7 @@ describe("PushSubscribeCard", () => {
         },
       });
     });
+    expect(unsubscribeFromPushActionMock).not.toHaveBeenCalled();
     expect(
       await screen.findByText("이 브라우저에서 복습 알림을 받을 수 있습니다."),
     ).toBeInTheDocument();

--- a/src/features/notifications/tests/PushSubscribeCard.test.tsx
+++ b/src/features/notifications/tests/PushSubscribeCard.test.tsx
@@ -1,15 +1,17 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const ENDPOINT = "https://push.example.test/subscription-id";
 const VAPID_PUBLIC_KEY = "AAAA";
 
 const {
+  checkPushSubscriptionOwnedActionMock,
   refreshMock,
   subscribeToPushActionMock,
   unsubscribeFromPushActionMock,
 } = vi.hoisted(() => ({
+  checkPushSubscriptionOwnedActionMock: vi.fn(),
   refreshMock: vi.fn(),
   subscribeToPushActionMock: vi.fn(),
   unsubscribeFromPushActionMock: vi.fn(),
@@ -22,6 +24,7 @@ vi.mock("next/navigation", () => ({
 }));
 
 vi.mock("../actions", () => ({
+  checkPushSubscriptionOwnedAction: checkPushSubscriptionOwnedActionMock,
   subscribeToPushAction: subscribeToPushActionMock,
   unsubscribeFromPushAction: unsubscribeFromPushActionMock,
 }));
@@ -125,9 +128,14 @@ function setupSupportedPushEnvironment({
 }
 
 describe("PushSubscribeCard", () => {
+  beforeEach(() => {
+    checkPushSubscriptionOwnedActionMock.mockResolvedValue({ owned: false });
+  });
+
   afterEach(() => {
     vi.unstubAllEnvs();
     vi.resetModules();
+    checkPushSubscriptionOwnedActionMock.mockReset();
     refreshMock.mockReset();
     subscribeToPushActionMock.mockReset();
     unsubscribeFromPushActionMock.mockReset();
@@ -147,12 +155,13 @@ describe("PushSubscribeCard", () => {
     expect(screen.getByRole("button", { name: /알림 켜기/ })).toBeDisabled();
   });
 
-  it("does not auto-resubscribe an existing browser subscription", async () => {
+  it("does not auto-resubscribe an existing browser subscription owned by the current user", async () => {
     vi.stubEnv("NEXT_PUBLIC_VAPID_PUBLIC_KEY", VAPID_PUBLIC_KEY);
     setupSupportedPushEnvironment({
       existingSubscription: createPushSubscription(),
       permission: "granted",
     });
+    checkPushSubscriptionOwnedActionMock.mockResolvedValue({ owned: true });
     const PushSubscribeCard = await loadPushSubscribeCard();
 
     render(<PushSubscribeCard initialHasAnySubscription={true} />);
@@ -160,7 +169,43 @@ describe("PushSubscribeCard", () => {
     expect(
       await screen.findByText("현재 브라우저에서 알림이 켜져 있습니다."),
     ).toBeInTheDocument();
+    expect(checkPushSubscriptionOwnedActionMock).toHaveBeenCalledWith(ENDPOINT);
     expect(subscribeToPushActionMock).not.toHaveBeenCalled();
+  });
+
+  it("treats a browser subscription left by a previous account as a claim opportunity", async () => {
+    vi.stubEnv("NEXT_PUBLIC_VAPID_PUBLIC_KEY", VAPID_PUBLIC_KEY);
+    setupSupportedPushEnvironment({
+      existingSubscription: createPushSubscription(),
+      permission: "granted",
+    });
+    checkPushSubscriptionOwnedActionMock.mockResolvedValue({ owned: false });
+    subscribeToPushActionMock.mockResolvedValue({ success: true });
+    const PushSubscribeCard = await loadPushSubscribeCard();
+    const user = userEvent.setup();
+
+    render(<PushSubscribeCard initialHasAnySubscription={false} />);
+
+    expect(
+      await screen.findByText(
+        "이 브라우저에 다른 계정의 구독이 남아있습니다. 알림 켜기를 누르면 현재 계정으로 가져옵니다.",
+      ),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /알림 켜기/ }));
+
+    await waitFor(() => {
+      expect(subscribeToPushActionMock).toHaveBeenCalledWith({
+        endpoint: ENDPOINT,
+        keys: {
+          auth: "auth-secret",
+          p256dh: "p256dh-key",
+        },
+      });
+    });
+    expect(
+      await screen.findByText("이 브라우저에서 복습 알림을 받을 수 있습니다."),
+    ).toBeInTheDocument();
   });
 
   it("subscribes this browser when the user clicks the subscribe button", async () => {
@@ -206,6 +251,7 @@ describe("PushSubscribeCard", () => {
       existingSubscription,
       permission: "granted",
     });
+    checkPushSubscriptionOwnedActionMock.mockResolvedValue({ owned: true });
     unsubscribeFromPushActionMock.mockResolvedValue({ success: true });
     const PushSubscribeCard = await loadPushSubscribeCard();
     const user = userEvent.setup();

--- a/src/features/notifications/tests/PushSubscribeCard.test.tsx
+++ b/src/features/notifications/tests/PushSubscribeCard.test.tsx
@@ -148,7 +148,6 @@ describe("PushSubscribeCard", () => {
   });
 
   it("does not auto-resubscribe an existing browser subscription", async () => {
-    vi.stubEnv("NODE_ENV", "production");
     vi.stubEnv("NEXT_PUBLIC_VAPID_PUBLIC_KEY", VAPID_PUBLIC_KEY);
     setupSupportedPushEnvironment({
       existingSubscription: createPushSubscription(),
@@ -165,7 +164,6 @@ describe("PushSubscribeCard", () => {
   });
 
   it("subscribes this browser when the user clicks the subscribe button", async () => {
-    vi.stubEnv("NODE_ENV", "production");
     vi.stubEnv("NEXT_PUBLIC_VAPID_PUBLIC_KEY", VAPID_PUBLIC_KEY);
     const { requestPermissionMock, subscribeMock } =
       setupSupportedPushEnvironment();
@@ -202,7 +200,6 @@ describe("PushSubscribeCard", () => {
   });
 
   it("unsubscribes this browser when the user clicks the unsubscribe button", async () => {
-    vi.stubEnv("NODE_ENV", "production");
     vi.stubEnv("NEXT_PUBLIC_VAPID_PUBLIC_KEY", VAPID_PUBLIC_KEY);
     const existingSubscription = createPushSubscription();
     setupSupportedPushEnvironment({

--- a/src/features/notifications/tests/actions.test.ts
+++ b/src/features/notifications/tests/actions.test.ts
@@ -9,13 +9,21 @@ const NOTIFICATION_ID = "33333333-3333-4333-8333-333333333333";
 const ENDPOINT = "https://push.example.test/subscription-id";
 const CONFIRMED_AT = "2026-04-27T00:00:00.000Z";
 
-const { createClientMock, redirectMock, revalidatePathMock } = vi.hoisted(
-  () => ({
-    createClientMock: vi.fn(),
-    redirectMock: vi.fn(),
-    revalidatePathMock: vi.fn(),
-  }),
-);
+const {
+  createAdminClientMock,
+  createClientMock,
+  redirectMock,
+  revalidatePathMock,
+} = vi.hoisted(() => ({
+  createAdminClientMock: vi.fn(),
+  createClientMock: vi.fn(),
+  redirectMock: vi.fn(),
+  revalidatePathMock: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: createAdminClientMock,
+}));
 
 vi.mock("@/lib/supabase/server", () => ({
   createClient: createClientMock,
@@ -103,6 +111,7 @@ function createPushSubscriptionInput() {
 
 describe("notification server actions", () => {
   beforeEach(() => {
+    createAdminClientMock.mockReset();
     createClientMock.mockReset();
     redirectMock.mockReset();
     revalidatePathMock.mockReset();
@@ -123,14 +132,19 @@ describe("notification server actions", () => {
       error: "브라우저 구독 정보가 올바르지 않습니다.",
     });
     expect(createClientMock).not.toHaveBeenCalled();
+    expect(createAdminClientMock).not.toHaveBeenCalled();
   });
 
-  it("upserts a valid push subscription by endpoint", async () => {
-    const { supabase, upsertMock } = createSupabaseMock();
+  it("claims a valid push subscription endpoint for the current user", async () => {
+    const { supabase, fromMock } = createSupabaseMock();
+    const { supabase: adminClient, upsertMock } = createSupabaseMock();
     createClientMock.mockResolvedValue(supabase);
+    createAdminClientMock.mockReturnValue(adminClient);
 
     const result = await subscribeToPushAction(createPushSubscriptionInput());
 
+    expect(fromMock).not.toHaveBeenCalled();
+    expect(createAdminClientMock).toHaveBeenCalled();
     expect(upsertMock).toHaveBeenCalledWith(
       {
         user_id: USER_ID,
@@ -208,7 +222,7 @@ describe("notification server actions", () => {
   });
 
   it("redirects unverified users before mutating notification data", async () => {
-    const { supabase, upsertMock } = createSupabaseMock({
+    const { supabase } = createSupabaseMock({
       emailConfirmedAt: null,
     });
     createClientMock.mockResolvedValue(supabase);
@@ -218,6 +232,6 @@ describe("notification server actions", () => {
     ).rejects.toBe(REDIRECT_ERROR);
 
     expect(redirectMock).toHaveBeenCalledWith(ROUTES.VERIFY_EMAIL);
-    expect(upsertMock).not.toHaveBeenCalled();
+    expect(createAdminClientMock).not.toHaveBeenCalled();
   });
 });

--- a/src/features/notifications/tests/actions.test.ts
+++ b/src/features/notifications/tests/actions.test.ts
@@ -38,6 +38,7 @@ vi.mock("next/navigation", () => ({
 }));
 
 import {
+  checkPushSubscriptionOwnedAction,
   markNotificationAsReadAction,
   setNotificationTimeAction,
   subscribeToPushAction,
@@ -49,6 +50,8 @@ function createSupabaseMock({
   emailConfirmedAt = CONFIRMED_AT,
   upsertError = null,
   deleteError = null,
+  selectCount = 0,
+  selectError = null,
   rpcData = true,
   rpcError = null,
 }: {
@@ -56,20 +59,31 @@ function createSupabaseMock({
   emailConfirmedAt?: string | null;
   upsertError?: { message: string } | null;
   deleteError?: { message: string } | null;
+  selectCount?: number | null;
+  selectError?: { message: string } | null;
   rpcData?: boolean | null;
   rpcError?: { message: string } | null;
 } = {}) {
   const upsertMock = vi.fn().mockResolvedValue({ error: upsertError });
-  const deleteUserEqMock = vi.fn().mockResolvedValue({ error: deleteError });
-  const deleteEndpointEqMock = vi.fn().mockReturnValue({
-    eq: deleteUserEqMock,
-  });
+  const deleteEndpointEqMock = vi
+    .fn()
+    .mockResolvedValue({ error: deleteError });
   const deleteMock = vi.fn().mockReturnValue({
     eq: deleteEndpointEqMock,
+  });
+  const selectUserEqMock = vi
+    .fn()
+    .mockResolvedValue({ count: selectCount, error: selectError });
+  const selectEndpointEqMock = vi.fn().mockReturnValue({
+    eq: selectUserEqMock,
+  });
+  const selectMock = vi.fn().mockReturnValue({
+    eq: selectEndpointEqMock,
   });
   const fromMock = vi.fn().mockReturnValue({
     upsert: upsertMock,
     delete: deleteMock,
+    select: selectMock,
   });
   const rpcMock = vi.fn().mockResolvedValue({
     data: rpcError ? null : rpcData,
@@ -79,9 +93,11 @@ function createSupabaseMock({
   return {
     deleteEndpointEqMock,
     deleteMock,
-    deleteUserEqMock,
     fromMock,
     rpcMock,
+    selectEndpointEqMock,
+    selectMock,
+    selectUserEqMock,
     upsertMock,
     supabase: {
       auth: {
@@ -158,17 +174,89 @@ describe("notification server actions", () => {
     expect(result).toEqual({ success: true });
   });
 
-  it("deletes the current user's matching push subscription", async () => {
-    const { supabase, fromMock, deleteEndpointEqMock, deleteUserEqMock } =
-      createSupabaseMock();
+  it("deletes the push subscription endpoint via the admin client (covering orphan rows)", async () => {
+    const { supabase, fromMock: userFromMock } = createSupabaseMock();
+    const {
+      supabase: adminClient,
+      fromMock: adminFromMock,
+      deleteMock: adminDeleteMock,
+      deleteEndpointEqMock: adminDeleteEndpointEqMock,
+    } = createSupabaseMock();
+    createClientMock.mockResolvedValue(supabase);
+    createAdminClientMock.mockReturnValue(adminClient);
+
+    const result = await unsubscribeFromPushAction(ENDPOINT);
+
+    expect(createAdminClientMock).toHaveBeenCalled();
+    expect(userFromMock).not.toHaveBeenCalled();
+    expect(adminFromMock).toHaveBeenCalledWith("push_subscriptions");
+    expect(adminDeleteMock).toHaveBeenCalled();
+    expect(adminDeleteEndpointEqMock).toHaveBeenCalledWith(
+      "endpoint",
+      ENDPOINT,
+    );
+    expect(revalidatePathMock).toHaveBeenCalledWith(ROUTES.MYPAGE);
+    expect(result).toEqual({ success: true });
+  });
+
+  it("requires authentication before unsubscribing", async () => {
+    const { supabase } = createSupabaseMock({ userId: null });
     createClientMock.mockResolvedValue(supabase);
 
     const result = await unsubscribeFromPushAction(ENDPOINT);
 
+    expect(createAdminClientMock).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      success: false,
+      error: "로그인이 필요합니다.",
+    });
+  });
+
+  it("reports ownership when the current user has a row for the endpoint", async () => {
+    const {
+      supabase,
+      fromMock,
+      selectMock,
+      selectEndpointEqMock,
+      selectUserEqMock,
+    } = createSupabaseMock({ selectCount: 1 });
+    createClientMock.mockResolvedValue(supabase);
+
+    const result = await checkPushSubscriptionOwnedAction(ENDPOINT);
+
     expect(fromMock).toHaveBeenCalledWith("push_subscriptions");
-    expect(deleteEndpointEqMock).toHaveBeenCalledWith("endpoint", ENDPOINT);
-    expect(deleteUserEqMock).toHaveBeenCalledWith("user_id", USER_ID);
-    expect(result).toEqual({ success: true });
+    expect(selectMock).toHaveBeenCalledWith("id", {
+      count: "exact",
+      head: true,
+    });
+    expect(selectEndpointEqMock).toHaveBeenCalledWith("endpoint", ENDPOINT);
+    expect(selectUserEqMock).toHaveBeenCalledWith("user_id", USER_ID);
+    expect(result).toEqual({ owned: true });
+  });
+
+  it("reports non-ownership when no row matches the current user and endpoint", async () => {
+    const { supabase } = createSupabaseMock({ selectCount: 0 });
+    createClientMock.mockResolvedValue(supabase);
+
+    const result = await checkPushSubscriptionOwnedAction(ENDPOINT);
+
+    expect(result).toEqual({ owned: false });
+  });
+
+  it("returns owned:false for an invalid endpoint without opening a Supabase client", async () => {
+    const result = await checkPushSubscriptionOwnedAction("not-a-url");
+
+    expect(createClientMock).not.toHaveBeenCalled();
+    expect(result).toEqual({ owned: false });
+  });
+
+  it("returns owned:false when the user is not authenticated", async () => {
+    const { supabase } = createSupabaseMock({ userId: null });
+    createClientMock.mockResolvedValue(supabase);
+
+    const result = await checkPushSubscriptionOwnedAction(ENDPOINT);
+
+    expect(result).toEqual({ owned: false });
   });
 
   it("calls the read RPC instead of updating notifications directly", async () => {

--- a/src/features/notifications/tests/actions.test.ts
+++ b/src/features/notifications/tests/actions.test.ts
@@ -9,21 +9,13 @@ const NOTIFICATION_ID = "33333333-3333-4333-8333-333333333333";
 const ENDPOINT = "https://push.example.test/subscription-id";
 const CONFIRMED_AT = "2026-04-27T00:00:00.000Z";
 
-const {
-  createAdminClientMock,
-  createClientMock,
-  redirectMock,
-  revalidatePathMock,
-} = vi.hoisted(() => ({
-  createAdminClientMock: vi.fn(),
-  createClientMock: vi.fn(),
-  redirectMock: vi.fn(),
-  revalidatePathMock: vi.fn(),
-}));
-
-vi.mock("@/lib/supabase/admin", () => ({
-  createAdminClient: createAdminClientMock,
-}));
+const { createClientMock, redirectMock, revalidatePathMock } = vi.hoisted(
+  () => ({
+    createClientMock: vi.fn(),
+    redirectMock: vi.fn(),
+    revalidatePathMock: vi.fn(),
+  }),
+);
 
 vi.mock("@/lib/supabase/server", () => ({
   createClient: createClientMock,
@@ -65,9 +57,10 @@ function createSupabaseMock({
   rpcError?: { message: string } | null;
 } = {}) {
   const upsertMock = vi.fn().mockResolvedValue({ error: upsertError });
-  const deleteEndpointEqMock = vi
-    .fn()
-    .mockResolvedValue({ error: deleteError });
+  const deleteUserEqMock = vi.fn().mockResolvedValue({ error: deleteError });
+  const deleteEndpointEqMock = vi.fn().mockReturnValue({
+    eq: deleteUserEqMock,
+  });
   const deleteMock = vi.fn().mockReturnValue({
     eq: deleteEndpointEqMock,
   });
@@ -93,6 +86,7 @@ function createSupabaseMock({
   return {
     deleteEndpointEqMock,
     deleteMock,
+    deleteUserEqMock,
     fromMock,
     rpcMock,
     selectEndpointEqMock,
@@ -127,7 +121,6 @@ function createPushSubscriptionInput() {
 
 describe("notification server actions", () => {
   beforeEach(() => {
-    createAdminClientMock.mockReset();
     createClientMock.mockReset();
     redirectMock.mockReset();
     revalidatePathMock.mockReset();
@@ -148,19 +141,15 @@ describe("notification server actions", () => {
       error: "브라우저 구독 정보가 올바르지 않습니다.",
     });
     expect(createClientMock).not.toHaveBeenCalled();
-    expect(createAdminClientMock).not.toHaveBeenCalled();
   });
 
-  it("claims a valid push subscription endpoint for the current user", async () => {
-    const { supabase, fromMock } = createSupabaseMock();
-    const { supabase: adminClient, upsertMock } = createSupabaseMock();
+  it("upserts a valid push subscription endpoint through the current user session", async () => {
+    const { supabase, fromMock, upsertMock } = createSupabaseMock();
     createClientMock.mockResolvedValue(supabase);
-    createAdminClientMock.mockReturnValue(adminClient);
 
     const result = await subscribeToPushAction(createPushSubscriptionInput());
 
-    expect(fromMock).not.toHaveBeenCalled();
-    expect(createAdminClientMock).toHaveBeenCalled();
+    expect(fromMock).toHaveBeenCalledWith("push_subscriptions");
     expect(upsertMock).toHaveBeenCalledWith(
       {
         user_id: USER_ID,
@@ -174,27 +163,39 @@ describe("notification server actions", () => {
     expect(result).toEqual({ success: true });
   });
 
-  it("deletes the push subscription endpoint via the admin client (covering orphan rows)", async () => {
-    const { supabase, fromMock: userFromMock } = createSupabaseMock();
+  it("returns an error when RLS blocks claiming an endpoint owned by another user", async () => {
+    const { supabase, upsertMock } = createSupabaseMock({
+      upsertError: { message: "new row violates row-level security policy" },
+    });
+    createClientMock.mockResolvedValue(supabase);
+
+    const result = await subscribeToPushAction(createPushSubscriptionInput());
+
+    expect(upsertMock).toHaveBeenCalled();
+    expect(revalidatePathMock).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      success: false,
+      error:
+        "푸시 알림 구독에 실패했습니다. 브라우저 알림 구독을 해제한 뒤 다시 시도해주세요.",
+    });
+  });
+
+  it("deletes only the current user's push subscription endpoint", async () => {
     const {
-      supabase: adminClient,
-      fromMock: adminFromMock,
-      deleteMock: adminDeleteMock,
-      deleteEndpointEqMock: adminDeleteEndpointEqMock,
+      supabase,
+      fromMock,
+      deleteMock,
+      deleteEndpointEqMock,
+      deleteUserEqMock,
     } = createSupabaseMock();
     createClientMock.mockResolvedValue(supabase);
-    createAdminClientMock.mockReturnValue(adminClient);
 
     const result = await unsubscribeFromPushAction(ENDPOINT);
 
-    expect(createAdminClientMock).toHaveBeenCalled();
-    expect(userFromMock).not.toHaveBeenCalled();
-    expect(adminFromMock).toHaveBeenCalledWith("push_subscriptions");
-    expect(adminDeleteMock).toHaveBeenCalled();
-    expect(adminDeleteEndpointEqMock).toHaveBeenCalledWith(
-      "endpoint",
-      ENDPOINT,
-    );
+    expect(fromMock).toHaveBeenCalledWith("push_subscriptions");
+    expect(deleteMock).toHaveBeenCalled();
+    expect(deleteEndpointEqMock).toHaveBeenCalledWith("endpoint", ENDPOINT);
+    expect(deleteUserEqMock).toHaveBeenCalledWith("user_id", USER_ID);
     expect(revalidatePathMock).toHaveBeenCalledWith(ROUTES.MYPAGE);
     expect(result).toEqual({ success: true });
   });
@@ -205,7 +206,6 @@ describe("notification server actions", () => {
 
     const result = await unsubscribeFromPushAction(ENDPOINT);
 
-    expect(createAdminClientMock).not.toHaveBeenCalled();
     expect(result).toEqual({
       success: false,
       error: "로그인이 필요합니다.",
@@ -320,6 +320,5 @@ describe("notification server actions", () => {
     ).rejects.toBe(REDIRECT_ERROR);
 
     expect(redirectMock).toHaveBeenCalledWith(ROUTES.VERIFY_EMAIL);
-    expect(createAdminClientMock).not.toHaveBeenCalled();
   });
 });

--- a/src/features/notifications/tests/queries.test.ts
+++ b/src/features/notifications/tests/queries.test.ts
@@ -12,7 +12,11 @@ vi.mock("@/lib/supabase/server", () => ({
   createServerComponentClient: createServerComponentClientMock,
 }));
 
-import { getNotificationList, getUnreadCount } from "../queries";
+import {
+  getHasAnyPushSubscription,
+  getNotificationList,
+  getUnreadCount,
+} from "../queries";
 
 function withAuth<T extends Record<string, unknown>>(
   supabase: T,
@@ -82,6 +86,32 @@ function createNotificationListMock(data: unknown) {
     orderMock,
     selectMock,
     typeEqMock,
+    userEqMock,
+    supabase: withAuth(
+      {
+        from: vi.fn().mockReturnValue({
+          select: selectMock,
+        }),
+      },
+      USER_ID,
+    ),
+  };
+}
+
+function createHasAnyPushSubscriptionMock({
+  count,
+  error = null,
+}: {
+  count: number | null;
+  error?: { message: string } | null;
+}) {
+  const userEqMock = vi.fn().mockResolvedValue({ count, error });
+  const selectMock = vi.fn().mockReturnValue({
+    eq: userEqMock,
+  });
+
+  return {
+    selectMock,
     userEqMock,
     supabase: withAuth(
       {
@@ -212,5 +242,48 @@ describe("notification queries", () => {
     createServerComponentClientMock.mockResolvedValue(supabase);
 
     await expect(getNotificationList()).rejects.toThrow();
+  });
+
+  it("returns whether the current user has any push subscription", async () => {
+    const { supabase, selectMock, userEqMock } =
+      createHasAnyPushSubscriptionMock({ count: 2 });
+    createServerComponentClientMock.mockResolvedValue(supabase);
+
+    const result = await getHasAnyPushSubscription();
+
+    expect(supabase.from).toHaveBeenCalledWith("push_subscriptions");
+    expect(selectMock).toHaveBeenCalledWith("id", {
+      count: "exact",
+      head: true,
+    });
+    expect(userEqMock).toHaveBeenCalledWith("user_id", USER_ID);
+    expect(result).toBe(true);
+  });
+
+  it("returns false when there is no logged-in user for push subscriptions", async () => {
+    const supabase = withAuth({ from: vi.fn() }, null);
+    createServerComponentClientMock.mockResolvedValue(supabase);
+
+    await expect(getHasAnyPushSubscription()).resolves.toBe(false);
+
+    expect(supabase.from).not.toHaveBeenCalled();
+  });
+
+  it("returns false when the current user has no push subscriptions", async () => {
+    const { supabase } = createHasAnyPushSubscriptionMock({ count: 0 });
+    createServerComponentClientMock.mockResolvedValue(supabase);
+
+    await expect(getHasAnyPushSubscription()).resolves.toBe(false);
+  });
+
+  it("throws when the push subscription query fails", async () => {
+    const error = { message: "database unavailable" };
+    const { supabase } = createHasAnyPushSubscriptionMock({
+      count: null,
+      error,
+    });
+    createServerComponentClientMock.mockResolvedValue(supabase);
+
+    await expect(getHasAnyPushSubscription()).rejects.toMatchObject(error);
   });
 });

--- a/src/features/notifications/tests/queries.test.ts
+++ b/src/features/notifications/tests/queries.test.ts
@@ -181,7 +181,7 @@ describe("notification queries", () => {
     } = createNotificationListMock([
       {
         id: "22222222-2222-4222-8222-222222222222",
-        title: "복습 시간이에요",
+        title: "복습할 시간이에요!",
         body: "Notification body",
         type: "REVIEW",
         status: NOTIFICATION_STATUS.SENT,
@@ -211,7 +211,7 @@ describe("notification queries", () => {
     expect(result).toEqual([
       {
         id: "22222222-2222-4222-8222-222222222222",
-        title: "복습 시간이에요",
+        title: "복습할 시간이에요!",
         body: "Notification body",
         type: "REVIEW",
         status: NOTIFICATION_STATUS.SENT,

--- a/src/lib/webPush/index.ts
+++ b/src/lib/webPush/index.ts
@@ -32,11 +32,16 @@ function getRequiredEnv(name: string): string {
 }
 
 function getVapidSubject(): string {
-  const subject = process.env.NEXT_PUBLIC_APP_URL ?? process.env.APP_URL;
+  // web-push 스펙상 subject는 https: 또는 mailto: 스킴만 허용. http://localhost는 거절되므로
+  // dev에서는 VAPID_SUBJECT(mailto:)로 우회하고, prod는 https인 NEXT_PUBLIC_APP_URL을 그대로 사용.
+  const subject =
+    process.env.VAPID_SUBJECT ??
+    process.env.NEXT_PUBLIC_APP_URL ??
+    process.env.APP_URL;
 
   if (!subject) {
     throw new Error(
-      "NEXT_PUBLIC_APP_URL or APP_URL is required for Web Push dispatch.",
+      "VAPID_SUBJECT, NEXT_PUBLIC_APP_URL, or APP_URL is required for Web Push dispatch.",
     );
   }
 

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -1,0 +1,87 @@
+/// <reference lib="webworker" />
+
+import { defaultCache } from "@serwist/next/worker";
+import { type PrecacheEntry, Serwist } from "serwist";
+
+declare const self: ServiceWorkerGlobalScope & {
+  __SW_MANIFEST: (PrecacheEntry | string)[];
+};
+
+const serwist = new Serwist({
+  precacheEntries: self.__SW_MANIFEST,
+  skipWaiting: true,
+  clientsClaim: true,
+  runtimeCaching: defaultCache,
+});
+
+serwist.addEventListeners();
+
+function getRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function getPushPayload(data: PushMessageData | null) {
+  if (!data) {
+    return {
+      title: "Review reminder",
+      notificationData: { url: "/" },
+    };
+  }
+
+  let record: Record<string, unknown> | null = null;
+
+  try {
+    record = getRecord(data.json());
+  } catch {
+    record = null;
+  }
+
+  const nestedData = getRecord(record?.data);
+  const notificationData = nestedData ?? record ?? { url: "/" };
+  const title =
+    typeof record?.title === "string" ? record.title : "Review reminder";
+  const body = typeof record?.body === "string" ? record.body : undefined;
+  const tag =
+    typeof notificationData.reviewLogId === "string"
+      ? notificationData.reviewLogId
+      : undefined;
+
+  return { body, notificationData, tag, title };
+}
+
+function getNotificationUrl(data: unknown) {
+  const record = getRecord(data);
+  const url = typeof record?.url === "string" ? record.url : "/";
+
+  try {
+    const targetUrl = new URL(url, self.location.origin);
+    return targetUrl.origin === self.location.origin
+      ? targetUrl.href
+      : self.location.origin;
+  } catch {
+    return self.location.origin;
+  }
+}
+
+self.addEventListener("push", (event) => {
+  const { body, notificationData, tag, title } = getPushPayload(event.data);
+  const options: NotificationOptions = {
+    icon: "/favicon.svg",
+    badge: "/favicon.svg",
+    data: notificationData,
+  };
+
+  if (body) options.body = body;
+  if (tag) options.tag = tag;
+
+  event.waitUntil(self.registration.showNotification(title, options));
+});
+
+self.addEventListener("notificationclick", (event) => {
+  const url = getNotificationUrl(event.notification.data);
+
+  event.notification.close();
+  event.waitUntil(self.clients.openWindow(url));
+});

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -9,6 +9,7 @@ declare const self: ServiceWorkerGlobalScope & {
 
 const serwist = new Serwist({
   precacheEntries: self.__SW_MANIFEST,
+  // First push rollout should receive review reminders without waiting for every open tab to close.
   skipWaiting: true,
   clientsClaim: true,
   runtimeCaching: defaultCache,
@@ -65,6 +66,33 @@ function getNotificationUrl(data: unknown) {
   }
 }
 
+function isSameOriginWindowClient(client: Client): client is WindowClient {
+  return (
+    client.type === "window" &&
+    new URL(client.url).origin === self.location.origin
+  );
+}
+
+async function openOrFocusNotificationUrl(url: string) {
+  const windowClients = await self.clients.matchAll({
+    type: "window",
+    includeUncontrolled: true,
+  });
+  const sameOriginClient = windowClients.find(isSameOriginWindowClient);
+
+  if (sameOriginClient) {
+    const navigatedClient =
+      sameOriginClient.url === url
+        ? sameOriginClient
+        : await sameOriginClient.navigate(url);
+
+    await (navigatedClient ?? sameOriginClient).focus();
+    return;
+  }
+
+  await self.clients.openWindow(url);
+}
+
 self.addEventListener("push", (event) => {
   const { body, notificationData, tag, title } = getPushPayload(event.data);
   const options: NotificationOptions = {
@@ -83,5 +111,5 @@ self.addEventListener("notificationclick", (event) => {
   const url = getNotificationUrl(event.notification.data);
 
   event.notification.close();
-  event.waitUntil(self.clients.openWindow(url));
+  event.waitUntil(openOrFocusNotificationUrl(url));
 });


### PR DESCRIPTION
## 개요

Service Worker 기반 Web Push 구독 기능(#178)을 도입하고, 로컬·dev 환경에서 알림 흐름을 검증할 수 있도록 빌드/설정과 마이그레이션 경로를 정비했습니다.

## PR 유형

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] UI 디자인 변경
- [ ] 코드 리팩토링
- [x] 테스트 추가/수정
- [x] 문서 수정
- [x] 빌드/패키지 설정 변경

## 관련 이슈

closes #178

## 작업 내용

- 마이페이지 푸시 구독 카드(`PushSubscribeCard`)와 Service Worker(`src/sw.ts`)를 추가하고, Serwist를 `next.config.ts`에 통합 (`swSrc: src/sw.ts` → `public/sw.js`).
- `subscribeToPushAction` / `unsubscribeFromPushAction`을 admin client 기반으로 변경하여, **같은 브라우저에서 계정을 전환했을 때 origin-scoped push endpoint를 새 계정으로 claim/cleanup** 할 수 있도록 복구.
- `getHasAnyPushSubscription` 쿼리와 `checkPushSubscriptionOwnedAction` 서버 액션을 추가해 카드의 구독 상태 판정 오류를 수정.
- `npm run dev:sw` 스크립트(`cross-env ENABLE_SW=true next dev`)를 추가하여 Turbopack + Serwist 충돌을 피하면서 로컬에서 SW를 켜고 Web Push를 검증할 수 있게 함. 일반 `dev`에서는 SW 비활성화 유지.
- `middleware.ts` matcher에서 `sw.js` / `swe-worker-*.js(.map)` 를 제외하여 SW 파일이 세션 미들웨어를 타지 않도록 조정.
- `getVapidSubject()`가 `VAPID_SUBJECT(mailto:)`를 우선 사용하도록 변경 (`http://localhost`는 web-push 스펙상 거절되어 dev에서 발송 실패하던 문제 해결).
- `.gitignore`에 빌드 산출물(`/public/sw.js`, `swe-worker-*.js`)을 추가하고, README에 `dev:sw` 사용법/주의사항을 보충.
- `notifications` 영역의 actions/queries 테스트를 신규 동작에 맞춰 보강하고, `PushSubscribeCard` 단위 테스트를 신규 추가.

## 테스트 방법

1. `.env.local`에 VAPID 키와 `VAPID_SUBJECT=mailto:...` 를 설정.
2. `npm run dev:sw` 실행 → 마이페이지 진입 → 푸시 구독 카드에서 **알림 허용 → 구독** 수행.
3. 브라우저 DevTools → Application → Service Workers 에서 `sw.js`가 activated 상태인지 확인.
4. 다른 계정으로 로그아웃/로그인 후 같은 브라우저에서 다시 구독 → 이전 계정에 묶여있던 endpoint가 새 계정으로 정상 claim 되는지 확인 (DB `push_subscriptions.user_id` 갱신).
5. 카드에서 **구독 해제** → row가 삭제되고 `PushSubscription.unsubscribe()`가 호출되는지 확인.
6. `npm run lint`, `npm run typecheck`, 알림 영역 단위 테스트(`vitest`) 통과 확인.

## 스크린샷 (FE 변경 시)
마이페이지 내 복습 알림 설정 영역
<img width="1566" height="479" alt="image" src="https://github.com/user-attachments/assets/f34e6397-9a7e-4467-9285-2f5bc378c120" />

알림 (현재는 title복습할 시간이예요! content <노트제목> 복습 할 시간이예요 로 문구 변경 )
<img width="767" height="262" alt="image" src="https://github.com/user-attachments/assets/411641f9-ea3b-492a-acda-4b5b5fefd76f" />

## 리뷰 요구사항 (선택)

- `subscribe/unsubscribe` 액션을 **admin client**로 처리하는 결정이 적절한지 검토 부탁드립니다. (origin-scoped endpoint를 계정 간에 이전·정리하기 위한 의도이며, 코드 주석에 근거를 남겨두었습니다.)
- `middleware.ts` matcher 정규식의 SW 파일 제외 패턴이 누락 케이스 없이 정확한지 확인 부탁드립니다.
- `next.config.ts`의 Serwist `disable` 조건 (`NODE_ENV === "development" && ENABLE_SW !== "true"`) 이 의도대로 dev 기본 OFF / `dev:sw`만 ON 으로 동작하는지 한 번 더 확인 부탁드립니다.

## 체크리스트

- [x] 코드 컨벤션 준수
- [x] 커밋 메시지 컨벤션 준수
- [x] lint 통과
- [x] typecheck 통과
- [ ] (DB 변경 시) migration 포함 및 로컬 재현 확인 — 해당 없음 (스키마 변경 없음)
- [ ] (권한/RLS 영향 시) 정책 변경 요약 기재 — RLS 정책 변경 없음. 단, `push_subscriptions`에 대해 일부 액션이 admin client로 동작하는 점은 위 "리뷰 요구사항" 참고
- [x] UI 변경 시 스크린샷/짧은 설명 첨부
- [x] 셀프 리뷰 완료
