### PR TITLE
chore: #193 알림 skipped 상태/ skipped_at 컬럼 제거

### DIFF
--- a/src/features/notifications/components/NotificationList.tsx
+++ b/src/features/notifications/components/NotificationList.tsx
@@ -17,7 +17,6 @@ type NotificationListProps = {
 
 function getStatusLabel(status: NotificationListItemType["status"]) {
   if (status === NOTIFICATION_STATUS.SENT) return "새 알림";
-  if (status === NOTIFICATION_STATUS.SKIPPED) return "건너뜀";
   return "읽음";
 }
 

--- a/src/features/notifications/schema.ts
+++ b/src/features/notifications/schema.ts
@@ -10,7 +10,6 @@ const notificationUuidSchema = z.string().uuid();
 export const notificationStatusSchema = z.enum([
   NOTIFICATION_STATUS.SENT,
   NOTIFICATION_STATUS.READ,
-  NOTIFICATION_STATUS.SKIPPED,
 ]);
 
 export const notificationListItemSchema = z.object({

--- a/src/features/notifications/tests/schema.test.ts
+++ b/src/features/notifications/tests/schema.test.ts
@@ -1,6 +1,25 @@
 import { describe, expect, it } from "vitest";
 
-import { notificationTimeSchema, pushSubscriptionSchema } from "../schema";
+import { NOTIFICATION_STATUS } from "@/lib/constants/notifications";
+
+import {
+  notificationStatusSchema,
+  notificationTimeSchema,
+  pushSubscriptionSchema,
+} from "../schema";
+
+describe("notificationStatusSchema", () => {
+  it.each([NOTIFICATION_STATUS.SENT, NOTIFICATION_STATUS.READ])(
+    "accepts %s",
+    (status) => {
+      expect(notificationStatusSchema.safeParse(status).success).toBe(true);
+    },
+  );
+
+  it("rejects the removed skipped status", () => {
+    expect(notificationStatusSchema.safeParse("SKIPPED").success).toBe(false);
+  });
+});
 
 describe("pushSubscriptionSchema", () => {
   it("accepts the browser push subscription JSON shape", () => {

--- a/src/lib/constants/notifications.ts
+++ b/src/lib/constants/notifications.ts
@@ -6,7 +6,6 @@ export const NOTIFICATION_TYPES = {
 export const NOTIFICATION_STATUS = {
   SENT: "SENT",
   READ: "READ",
-  SKIPPED: "SKIPPED",
 } as const;
 
 export type NotificationKindType =

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -78,7 +78,6 @@ export type Database = {
           read_at: string | null;
           review_log_id: string | null;
           sent_at: string;
-          skipped_at: string | null;
           status: string;
           title: string;
           type: string;
@@ -91,7 +90,6 @@ export type Database = {
           read_at?: string | null;
           review_log_id?: string | null;
           sent_at?: string;
-          skipped_at?: string | null;
           status?: string;
           title: string;
           type: string;
@@ -104,7 +102,6 @@ export type Database = {
           read_at?: string | null;
           review_log_id?: string | null;
           sent_at?: string;
-          skipped_at?: string | null;
           status?: string;
           title?: string;
           type?: string;

--- a/src/types/notifications.types.ts
+++ b/src/types/notifications.types.ts
@@ -23,7 +23,7 @@ export type NotificationNoteId = Notification["note_id"];
 
 export type NotificationCreateInput = Omit<
   NotificationInsert,
-  "id" | "sent_at" | "read_at" | "skipped_at" | "status" | "type"
+  "id" | "sent_at" | "read_at" | "status" | "type"
 > & {
   status: NotificationStatus;
   type: NotificationType;

--- a/supabase/migrations/20260319040818_remote_schema.sql
+++ b/supabase/migrations/20260319040818_remote_schema.sql
@@ -151,8 +151,7 @@ CREATE TABLE IF NOT EXISTS "public"."notifications" (
     "status" character varying(20) DEFAULT 'SENT'::character varying NOT NULL,
     "sent_at" timestamp with time zone DEFAULT "now"() NOT NULL,
     "read_at" timestamp with time zone,
-    "skipped_at" timestamp with time zone,
-    CONSTRAINT "notifications_status_check" CHECK ((("status")::"text" = ANY ((ARRAY['SENT'::character varying, 'READ'::character varying, 'SKIPPED'::character varying])::"text"[])))
+    CONSTRAINT "notifications_status_check" CHECK ((("status")::"text" = ANY ((ARRAY['SENT'::character varying, 'READ'::character varying])::"text"[])))
 );
 
 
@@ -639,7 +638,7 @@ alter table "public"."notifications" drop constraint "notifications_status_check
 
 alter table "public"."profiles" drop constraint "profiles_role_check";
 
-alter table "public"."notifications" add constraint "notifications_status_check" CHECK (((status)::text = ANY ((ARRAY['SENT'::character varying, 'READ'::character varying, 'SKIPPED'::character varying])::text[]))) not valid;
+alter table "public"."notifications" add constraint "notifications_status_check" CHECK (((status)::text = ANY ((ARRAY['SENT'::character varying, 'READ'::character varying])::text[]))) not valid;
 
 alter table "public"."notifications" validate constraint "notifications_status_check";
 

--- a/supabase/migrations/20260504000000_drop_notification_skipped_status.sql
+++ b/supabase/migrations/20260504000000_drop_notification_skipped_status.sql
@@ -1,0 +1,50 @@
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM public.notifications
+    WHERE status = 'SKIPPED'
+  ) THEN
+    RAISE EXCEPTION 'Cannot drop SKIPPED notification status while rows still use it.';
+  END IF;
+END;
+$$;
+
+DO $$
+DECLARE
+  v_has_skipped_at boolean;
+  v_has_skipped_at_values boolean;
+BEGIN
+  SELECT EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'notifications'
+      AND column_name = 'skipped_at'
+  )
+  INTO v_has_skipped_at;
+
+  IF v_has_skipped_at THEN
+    EXECUTE 'SELECT EXISTS (SELECT 1 FROM public.notifications WHERE skipped_at IS NOT NULL)'
+    INTO v_has_skipped_at_values;
+
+    IF v_has_skipped_at_values THEN
+      RAISE EXCEPTION 'Cannot drop notifications.skipped_at while non-null values exist.';
+    END IF;
+  END IF;
+END;
+$$;
+
+ALTER TABLE public.notifications
+  DROP CONSTRAINT IF EXISTS notifications_status_check;
+
+ALTER TABLE public.notifications
+  ADD CONSTRAINT notifications_status_check
+  CHECK (((status)::text = ANY ((ARRAY['SENT'::character varying, 'READ'::character varying])::text[])))
+  NOT VALID;
+
+ALTER TABLE public.notifications
+  VALIDATE CONSTRAINT notifications_status_check;
+
+ALTER TABLE public.notifications
+  DROP COLUMN IF EXISTS skipped_at;

--- a/supabase/migrations/20260504000000_drop_notification_skipped_status.sql
+++ b/supabase/migrations/20260504000000_drop_notification_skipped_status.sql
@@ -1,39 +1,7 @@
-DO $$
-BEGIN
-  IF EXISTS (
-    SELECT 1
-    FROM public.notifications
-    WHERE status = 'SKIPPED'
-  ) THEN
-    RAISE EXCEPTION 'Cannot drop SKIPPED notification status while rows still use it.';
-  END IF;
-END;
-$$;
-
-DO $$
-DECLARE
-  v_has_skipped_at boolean;
-  v_has_skipped_at_values boolean;
-BEGIN
-  SELECT EXISTS (
-    SELECT 1
-    FROM information_schema.columns
-    WHERE table_schema = 'public'
-      AND table_name = 'notifications'
-      AND column_name = 'skipped_at'
-  )
-  INTO v_has_skipped_at;
-
-  IF v_has_skipped_at THEN
-    EXECUTE 'SELECT EXISTS (SELECT 1 FROM public.notifications WHERE skipped_at IS NOT NULL)'
-    INTO v_has_skipped_at_values;
-
-    IF v_has_skipped_at_values THEN
-      RAISE EXCEPTION 'Cannot drop notifications.skipped_at while non-null values exist.';
-    END IF;
-  END IF;
-END;
-$$;
+-- 잔존 SKIPPED 행을 READ로 백필 (UI는 이미 SKIPPED를 "읽음"으로 표시하므로 의미 동등)
+UPDATE public.notifications
+SET status = 'READ'
+WHERE status = 'SKIPPED';
 
 ALTER TABLE public.notifications
   DROP CONSTRAINT IF EXISTS notifications_status_check;

--- a/supabase/tests/notifications/constraints_check.sql
+++ b/supabase/tests/notifications/constraints_check.sql
@@ -150,7 +150,7 @@ SELECT throws_ok(
   $$status가 허용 목록에 없는 값이면 notifications_status_check 제약 위반으로 저장이 차단되어야 한다$$
 );
 
--- status가 소문자('sent', 'read', 'skipped')이면 notifications_status_check 제약 위반으로 저장이 차단되어야 한다
+-- status가 소문자('sent', 'read')이면 notifications_status_check 제약 위반으로 저장이 차단되어야 한다
 SELECT throws_ok(
   $sql$
     INSERT INTO public.notifications (id, user_id, type, title, status)
@@ -158,7 +158,7 @@ SELECT throws_ok(
   $sql$,
   '23514',
   'new row for relation "notifications" violates check constraint "notifications_status_check"',
-  $$status가 소문자('sent', 'read', 'skipped')이면 notifications_status_check 제약 위반으로 저장이 차단되어야 한다$$
+  $$status가 소문자('sent', 'read')이면 notifications_status_check 제약 위반으로 저장이 차단되어야 한다$$
 );
 
 -- status에 앞뒤 공백이 포함된 값(' SENT', 'READ ')이면 notifications_status_check 제약 위반으로 저장이 차단되어야 한다

--- a/supabase/tests/notifications/constraints_check.sql
+++ b/supabase/tests/notifications/constraints_check.sql
@@ -86,17 +86,16 @@ SELECT is(
 );
 ROLLBACK TO SAVEPOINT notifications_status_insert_read;
 
--- status가 'SKIPPED'이면 INSERT가 성공해야 한다
-SAVEPOINT notifications_status_insert_skipped;
-INSERT INTO public.notifications (id, user_id, type, title, status)
-VALUES (gen_random_uuid(), current_setting('test.notifications_constraints_check_user_a_id')::uuid, 'REVIEW', 'skipped ok', 'SKIPPED');
-
-SELECT is(
-  (SELECT count(*) FROM public.notifications WHERE title = 'skipped ok'),
-  1::bigint,
-  $$status가 'SKIPPED'이면 INSERT가 성공해야 한다$$
+-- status = 'SKIPPED' INSERT는 notifications_status_check 제약 위반으로 차단되어야 한다
+SELECT throws_ok(
+  $sql$
+    INSERT INTO public.notifications (id, user_id, type, title, status)
+    VALUES (gen_random_uuid(), current_setting('test.notifications_constraints_check_user_a_id')::uuid, 'REVIEW', 'skipped blocked', 'SKIPPED');
+  $sql$,
+  '23514',
+  'new row for relation "notifications" violates check constraint "notifications_status_check"',
+  $$status = 'SKIPPED' INSERT는 notifications_status_check 제약 위반으로 차단되어야 한다$$
 );
-ROLLBACK TO SAVEPOINT notifications_status_insert_skipped;
 
 -- 기존의 유효한 notifications 행을 status = 'SENT'로 UPDATE하면 성공해야 한다
 SAVEPOINT notifications_status_update_sent;
@@ -124,18 +123,20 @@ SELECT is(
 );
 ROLLBACK TO SAVEPOINT notifications_status_update_read;
 
--- 기존의 유효한 notifications 행을 status = 'SKIPPED'로 UPDATE하면 성공해야 한다
-SAVEPOINT notifications_status_update_skipped;
-UPDATE public.notifications
-SET status = 'SKIPPED'
-WHERE id = current_setting('test.notifications_constraints_check_notification_seed_id')::uuid;
-
-SELECT is(
-  (SELECT status FROM public.notifications WHERE id = current_setting('test.notifications_constraints_check_notification_seed_id')::uuid),
-  'SKIPPED',
-  $$기존의 유효한 notifications 행을 status = 'SKIPPED'로 UPDATE하면 성공해야 한다$$
+-- 기존의 유효한 notifications 행을 status = 'SKIPPED'로 UPDATE하면 차단되어야 한다
+SELECT throws_ok(
+  format(
+    $sql$
+      UPDATE public.notifications
+      SET status = 'SKIPPED'
+      WHERE id = '%s'::uuid;
+    $sql$,
+    current_setting('test.notifications_constraints_check_notification_seed_id')
+  ),
+  '23514',
+  'new row for relation "notifications" violates check constraint "notifications_status_check"',
+  $$기존의 유효한 notifications 행을 status = 'SKIPPED'로 UPDATE하면 차단되어야 한다$$
 );
-ROLLBACK TO SAVEPOINT notifications_status_update_skipped;
 
 -- [예외 조건]
 -- status가 허용 목록에 없는 값이면 notifications_status_check 제약 위반으로 저장이 차단되어야 한다
@@ -160,7 +161,7 @@ SELECT throws_ok(
   $$status가 소문자('sent', 'read', 'skipped')이면 notifications_status_check 제약 위반으로 저장이 차단되어야 한다$$
 );
 
--- status에 앞뒤 공백이 포함된 값(' SENT', 'READ ', ' SKIPPED ')이면 notifications_status_check 제약 위반으로 저장이 차단되어야 한다
+-- status에 앞뒤 공백이 포함된 값(' SENT', 'READ ')이면 notifications_status_check 제약 위반으로 저장이 차단되어야 한다
 SELECT throws_ok(
   $sql$
     INSERT INTO public.notifications (id, user_id, type, title, status)
@@ -168,7 +169,7 @@ SELECT throws_ok(
   $sql$,
   '23514',
   'new row for relation "notifications" violates check constraint "notifications_status_check"',
-  $$status에 앞뒤 공백이 포함된 값(' SENT', 'READ ', ' SKIPPED ')이면 notifications_status_check 제약 위반으로 저장이 차단되어야 한다$$
+  $$status에 앞뒤 공백이 포함된 값(' SENT', 'READ ')이면 notifications_status_check 제약 위반으로 저장이 차단되어야 한다$$
 );
 
 -- status가 빈 문자열('')이면 notifications_status_check 제약 위반으로 저장이 차단되어야 한다
@@ -311,17 +312,16 @@ SELECT is(
 );
 ROLLBACK TO SAVEPOINT notifications_status_boundary_read;
 
--- 정확히 'SKIPPED'는 허용값 경계로서 성공해야 한다
-SAVEPOINT notifications_status_boundary_skipped;
-INSERT INTO public.notifications (id, user_id, type, title, status)
-VALUES (gen_random_uuid(), current_setting('test.notifications_constraints_check_user_a_id')::uuid, 'REVIEW', 'boundary skipped', 'SKIPPED');
-
-SELECT is(
-  (SELECT count(*) FROM public.notifications WHERE title = 'boundary skipped'),
-  1::bigint,
-  $$정확히 'SKIPPED'는 허용값 경계로서 성공해야 한다$$
+-- 정확히 'SKIPPED'도 허용값이 아니므로 차단되어야 한다
+SELECT throws_ok(
+  $sql$
+    INSERT INTO public.notifications (id, user_id, type, title, status)
+    VALUES (gen_random_uuid(), current_setting('test.notifications_constraints_check_user_a_id')::uuid, 'REVIEW', 'boundary skipped', 'SKIPPED');
+  $sql$,
+  '23514',
+  'new row for relation "notifications" violates check constraint "notifications_status_check"',
+  $$정확히 'SKIPPED'도 허용값이 아니므로 차단되어야 한다$$
 );
-ROLLBACK TO SAVEPOINT notifications_status_boundary_skipped;
 
 -- [불변 조건]
 -- 어떠한 경우에도 notifications_status_check를 위반하는 notifications 행의 수는 0개여야 한다 (Status)
@@ -329,7 +329,7 @@ SELECT is(
   (
     SELECT count(*)
     FROM public.notifications
-    WHERE status NOT IN ('SENT', 'READ', 'SKIPPED')
+    WHERE status NOT IN ('SENT', 'READ')
   ),
   0::bigint,
   $$어떠한 경우에도 notifications_status_check를 위반하는 notifications 행의 수는 0개여야 한다 (Status)$$

--- a/supabase/tests/notifications/constraints_not_null.sql
+++ b/supabase/tests/notifications/constraints_not_null.sql
@@ -8,7 +8,7 @@
 
 BEGIN;
 
-SELECT plan(32);
+SELECT plan(30);
 
 -- 테스트용 UUID 준비
 SELECT set_config('test.notifications_constraints_not_null_user_a_id', gen_random_uuid()::text, true);
@@ -18,7 +18,6 @@ SELECT set_config('test.notifications_constraints_not_null_notification_insert_i
 SELECT set_config('test.notifications_constraints_not_null_notification_insert_explicit_id', gen_random_uuid()::text, true);
 SELECT set_config('test.notifications_constraints_not_null_notification_boundary_id', gen_random_uuid()::text, true);
 SELECT set_config('test.notifications_constraints_not_null_read_at_null_id', gen_random_uuid()::text, true);
-SELECT set_config('test.notifications_constraints_not_null_skipped_at_null_id', gen_random_uuid()::text, true);
 
 -- seed: auth.users
 INSERT INTO auth.users (
@@ -141,34 +140,6 @@ SELECT is(
 );
 ROLLBACK TO SAVEPOINT notifications_not_null_insert_read_at_null;
 
--- skipped_at을 명시적으로 NULL로 INSERT해도 저장되어야 한다.
-SAVEPOINT notifications_not_null_insert_skipped_at_null;
-INSERT INTO public.notifications (
-  id,
-  user_id,
-  type,
-  title,
-  status,
-  sent_at,
-  skipped_at
-)
-VALUES (
-  current_setting('test.notifications_constraints_not_null_skipped_at_null_id')::uuid,
-  current_setting('test.notifications_constraints_not_null_user_a_id')::uuid,
-  'REVIEW',
-  'skipped_at null',
-  'SENT',
-  now(),
-  NULL
-);
-
-SELECT is(
-  (SELECT count(*) FROM public.notifications WHERE id = current_setting('test.notifications_constraints_not_null_skipped_at_null_id')::uuid),
-  1::bigint,
-  $$skipped_at을 명시적으로 NULL로 INSERT해도 저장되어야 한다.$$
-);
-ROLLBACK TO SAVEPOINT notifications_not_null_insert_skipped_at_null;
-
 -- 유효한 기존 알림 행에서 user_id를 다른 유효한 비NULL auth.users.id 값으로 UPDATE할 수 있어야 한다.
 SAVEPOINT notifications_not_null_update_user;
 UPDATE public.notifications
@@ -211,12 +182,12 @@ ROLLBACK TO SAVEPOINT notifications_not_null_update_title;
 -- 유효한 기존 알림 행에서 status를 다른 유효한 허용 비NULL 값으로 UPDATE할 수 있어야 한다.
 SAVEPOINT notifications_not_null_update_status;
 UPDATE public.notifications
-SET status = 'SKIPPED'
+SET status = 'READ'
 WHERE id = current_setting('test.notifications_constraints_not_null_notification_seed_id')::uuid;
 
 SELECT is(
   (SELECT status FROM public.notifications WHERE id = current_setting('test.notifications_constraints_not_null_notification_seed_id')::uuid),
-  'SKIPPED',
+  'READ',
   $$유효한 기존 알림 행에서 status를 다른 유효한 허용 비NULL 값으로 UPDATE할 수 있어야 한다.$$
 );
 ROLLBACK TO SAVEPOINT notifications_not_null_update_status;
@@ -244,18 +215,6 @@ SELECT ok(
   $$유효한 기존 알림 행에서 read_at을 비NULL 시각 값으로 UPDATE할 수 있어야 한다.$$
 );
 ROLLBACK TO SAVEPOINT notifications_not_null_update_read_at;
-
--- 유효한 기존 알림 행에서 skipped_at을 비NULL 시각 값으로 UPDATE할 수 있어야 한다.
-SAVEPOINT notifications_not_null_update_skipped_at;
-UPDATE public.notifications
-SET skipped_at = now()
-WHERE id = current_setting('test.notifications_constraints_not_null_notification_seed_id')::uuid;
-
-SELECT ok(
-  (SELECT skipped_at FROM public.notifications WHERE id = current_setting('test.notifications_constraints_not_null_notification_seed_id')::uuid) IS NOT NULL,
-  $$유효한 기존 알림 행에서 skipped_at을 비NULL 시각 값으로 UPDATE할 수 있어야 한다.$$
-);
-ROLLBACK TO SAVEPOINT notifications_not_null_update_skipped_at;
 
 -- id를 명시적으로 넣는 경우 유효한 비NULL UUID면 생성될 수 있어야 한다.
 SAVEPOINT notifications_not_null_insert_explicit_id;

--- a/supabase/tests/notifications/fk_note.sql
+++ b/supabase/tests/notifications/fk_note.sql
@@ -338,8 +338,7 @@ INSERT INTO public.notifications (
   body,
   status,
   sent_at,
-  read_at,
-  skipped_at
+  read_at
 )
 VALUES (
   current_setting('test.notifications_fk_note_insert_note_max_id')::uuid,
@@ -348,8 +347,7 @@ VALUES (
   repeat('T', 50),
   repeat('X', 200),
   repeat('B', 500),
-  'SKIPPED',
-  now(),
+  'READ',
   now(),
   now()
 );

--- a/supabase/tests/notifications/fk_user.sql
+++ b/supabase/tests/notifications/fk_user.sql
@@ -316,8 +316,7 @@ INSERT INTO public.notifications (
   body,
   status,
   sent_at,
-  read_at,
-  skipped_at
+  read_at
 )
 VALUES (
   current_setting('test.notifications_fk_user_insert_max_id')::uuid,
@@ -328,8 +327,7 @@ VALUES (
   repeat('B', 500),
   'READ',
   now(),
-  now(),
-  NULL
+  now()
 );
 
 SELECT is(

--- a/supabase/tests/notifications/rls.sql
+++ b/supabase/tests/notifications/rls.sql
@@ -368,7 +368,6 @@ SELECT throws_ok(
         status,
         sent_at,
         read_at,
-        skipped_at,
         note_id
       )
       VALUES (
@@ -378,7 +377,6 @@ SELECT throws_ok(
         '%s',
         '%s',
         'READ',
-        now(),
         now(),
         now(),
         NULL
@@ -611,7 +609,7 @@ SELECT is(
 -- 타인 행(user_id ≠ auth.uid()) → 차단
 WITH updated AS (
   UPDATE public.notifications
-  SET skipped_at = now()
+  SET read_at = now()
   WHERE id = current_setting('test.notifications_rls_b1_id')::uuid
   RETURNING 1
 )
@@ -690,14 +688,14 @@ SELECT is(
   $$UPDATE 시도 전후 전체 notifications 행 수는 동일해야 한다.$$
 );
 
--- UPDATE 시도 전후 대상 행의 status, title, body, read_at, skipped_at, note_id 값은 변경되지 않아야 한다.
+-- UPDATE 시도 전후 대상 행의 status, title, body, read_at, note_id 값은 변경되지 않아야 한다.
 RESET ROLE;
 SELECT set_config(
   'test.notifications_rls_update_before_snapshot',
   (
     SELECT row_to_json(t)::text
     FROM (
-      SELECT status, title, body, read_at, skipped_at, note_id
+      SELECT status, title, body, read_at, note_id
       FROM public.notifications
       WHERE id = current_setting('test.notifications_rls_a1_id')::uuid
     ) t
@@ -725,7 +723,7 @@ SELECT set_config(
   (
     SELECT row_to_json(t)::text
     FROM (
-      SELECT status, title, body, read_at, skipped_at, note_id
+      SELECT status, title, body, read_at, note_id
       FROM public.notifications
       WHERE id = current_setting('test.notifications_rls_a1_id')::uuid
     ) t
@@ -745,7 +743,7 @@ SELECT set_config(
 
 SELECT ok(
   current_setting('test.notifications_rls_update_before_snapshot') = current_setting('test.notifications_rls_update_after_snapshot'),
-  $$UPDATE 시도 전후 대상 행의 status, title, body, read_at, skipped_at, note_id 값은 변경되지 않아야 한다.$$
+  $$UPDATE 시도 전후 대상 행의 status, title, body, read_at, note_id 값은 변경되지 않아야 한다.$$
 );
 
 -- [정답 조건]


### PR DESCRIPTION
## 개요

알림 도메인에서 미사용 상태값 `SKIPPED`와 컬럼 `skipped_at`을 제거합니다. UI상으로도 `SKIPPED`를 별도 라벨("건너뜀")로 노출하지 않게 되어, 데이터 모델에서 함께 정리합니다.

## PR 유형

- [x] 코드 리팩토링
- [x] 테스트 추가/수정
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] UI 디자인 변경
- [ ] 문서 수정
- [ ] 빌드/패키지 설정 변경

## 관련 이슈

closes #이슈번호

## 작업 내용

- DB 스키마에서 `notifications.skipped_at` 컬럼 및 `SKIPPED` status 허용값 제거
  - 신규 마이그레이션: `supabase/migrations/20260504000000_drop_notification_skipped_status.sql`
  - 잔존 `SKIPPED` 행은 `READ`로 백필 후 제약 재정의 → 컬럼 DROP (멱등)
  - 기존 스냅샷 `supabase/migrations/20260319040818_remote_schema.sql`도 최신 상태에 맞춰 동기화 (`supabase db pull` 결과 반영)
- 타입/스키마/상수 정리
  - `src/types/database.types.ts`: `skipped_at` 필드 제거
  - `src/types/notifications.types.ts`: `NotificationCreateInput`의 `Omit` 키에서 `skipped_at` 제거
  - `src/lib/constants/notifications.ts`: `NOTIFICATION_STATUS.SKIPPED` 제거
  - `src/features/notifications/schema.ts`: `notificationStatusSchema` enum에서 `SKIPPED` 제거
- UI: `src/features/notifications/components/NotificationList.tsx`에서 `SKIPPED → "건너뜀"` 분기 제거 (default `"읽음"`로 자연 흡수)
- 테스트
  - 단위: `src/features/notifications/tests/schema.test.ts`에 `notificationStatusSchema`가 `SENT`/`READ`만 통과시키고 `SKIPPED`는 거절하는지 회귀 테스트 추가
  - SQL: `constraints_check.sql`, `constraints_not_null.sql`, `fk_note.sql`, `fk_user.sql`, `rls.sql`에서 `SKIPPED` 허용 케이스 → 차단 케이스로 전환, 또는 `READ` 등 유효값으로 대체. `constraints_not_null` plan 32 → 30

## 테스트 방법

1. 로컬 DB 재시작 후 마이그레이션 재적용
   ```powershell
   supabase db reset```
2. SQL 테스트 실행 후 모든 케이스 통과 확인
`supabase test db`
3. 단위 테스트
`npm vitest run src/features/notifications`
4. 타입체크/린트
`npm typecheck; npm lint`

## 스크린샷 (FE 변경 시)
해당 없음 — 라벨 분기 1줄 제거만 있어 기존 동작과 시각적으로 동일합니다.

## 리뷰 요구사항 (선택)
- 20260319040818_remote_schema.sql 직접 편집 부분: supabase db pull로 재생성된 스냅샷이며, 신규 환경에서는 이 파일에서 이미 SKIPPED 없는 상태로 테이블이 생성되고 → 신규 드롭 마이그레이션이 IF EXISTS로 멱등하게 흡수합니다. 기존 환경에서는 신규 드롭 마이그레이션만 실행됩니다.
- 마이그레이션이 SKIPPED → READ 백필을 자동 수행합니다. 운영에 SKIPPED 행이 있을 가능성이 있어 가드 대신 명시적 변환을 택했습니다 — 이 의미 매핑(SKIPPED ≈ READ)이 적절한지 한 번 확인 부탁드립니다.

## 체크리스트

- [x] 코드 컨벤션 준수
- [x] 커밋 메시지 컨벤션 준수
- [x] lint 통과
- [x] typecheck 통과
- [x] (DB 변경 시) migration 포함 및 로컬 재현 확인
- [ ] (권한/RLS 영향 시) 정책 변경 요약 기재
- [ ] UI 변경 시 스크린샷/짧은 설명 첨부
- [x] 셀프 리뷰 완료
