### PR TITLE
fix: #195 노트 제목 넘치는 ui 수정 & 서비스 워커 오류 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",
-    "dev:sw": "cross-env ENABLE_SW=true next dev",
+    "dev:sw": "cross-env ENABLE_SW=true NEXT_PUBLIC_ENABLE_SW=true next dev",
     "build": "next build",
     "start": "next start",
     "lint": "eslint",

--- a/src/app/(main)/notes/[noteId]/page.test.tsx
+++ b/src/app/(main)/notes/[noteId]/page.test.tsx
@@ -150,9 +150,9 @@ describe("NoteDetailPage", () => {
     );
 
     expect(getNoteByIdMock).toHaveBeenCalledWith("note-123", "user-123");
-    expect(
-      screen.getByRole("heading", { name: "Test note" }),
-    ).toBeInTheDocument();
+    const titleHeading = screen.getByRole("heading", { name: "Test note" });
+    expect(titleHeading).toBeInTheDocument();
+    expect(titleHeading).toHaveClass("break-words", "break-keep");
     expect(screen.getByTestId("note-viewer")).toHaveTextContent("note body");
     expect(screen.getByTestId("notification-time-picker")).toHaveTextContent(
       "note-123:21:30:00",

--- a/src/app/(main)/notes/[noteId]/page.tsx
+++ b/src/app/(main)/notes/[noteId]/page.tsx
@@ -89,7 +89,7 @@ export default async function NoteDetailPage({
             </span>
           )}
         </div>
-        <h1 className="mt-4 text-3xl font-bold text-foreground">
+        <h1 className="mt-4 break-words break-keep text-3xl font-bold text-foreground">
           {note.title}
         </h1>
         <div className="mt-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,6 +7,7 @@ import "./globals.css";
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 
+import { DevelopmentServiceWorkerCleanup } from "@/components/providers/DevelopmentServiceWorkerCleanup";
 import { QueryProvider } from "@/components/providers/QueryProvider";
 import { SessionProvider } from "@/components/providers/SessionProvider";
 import { ToasterProvider } from "@/components/providers/ToasterProvider";
@@ -91,6 +92,7 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
+        <DevelopmentServiceWorkerCleanup />
         <SessionProvider>
           <QueryProvider>{children}</QueryProvider>
           <ToasterProvider />

--- a/src/components/providers/DevelopmentServiceWorkerCleanup.tsx
+++ b/src/components/providers/DevelopmentServiceWorkerCleanup.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { useEffect } from "react";
+
+const shouldCleanupServiceWorker =
+  process.env.NODE_ENV === "development" &&
+  process.env.NEXT_PUBLIC_ENABLE_SW !== "true";
+
+export function DevelopmentServiceWorkerCleanup() {
+  useEffect(() => {
+    if (
+      !shouldCleanupServiceWorker ||
+      !("serviceWorker" in navigator) ||
+      !window.isSecureContext
+    ) {
+      return;
+    }
+
+    async function cleanupServiceWorkers() {
+      const registrations = await navigator.serviceWorker.getRegistrations();
+
+      if (registrations.length === 0) {
+        return;
+      }
+
+      await Promise.all(
+        registrations.map((registration) => registration.unregister()),
+      );
+
+      if (navigator.serviceWorker.controller) {
+        window.location.reload();
+      }
+    }
+
+    void cleanupServiceWorkers();
+  }, []);
+
+  return null;
+}

--- a/src/features/notes/components/DeleteNoteDialog.tsx
+++ b/src/features/notes/components/DeleteNoteDialog.tsx
@@ -61,7 +61,7 @@ export function DeleteNoteDialog({ noteId, noteTitle }: DeleteNoteDialogProps) {
             삭제한 노트는 되돌릴 수 없습니다. 아래 노트를 영구적으로
             삭제하시겠습니까?
           </p>
-          <p className="rounded-lg bg-muted px-3 py-2 text-sm font-medium text-foreground">
+          <p className="min-w-0 max-w-full whitespace-normal break-keep rounded-lg bg-muted px-3 py-2 text-sm font-medium text-foreground [overflow-wrap:anywhere]">
             {noteTitle}
           </p>
           {error && <p className="text-sm text-destructive">{error}</p>}

--- a/src/features/notes/tests/DeleteNoteDialog.test.tsx
+++ b/src/features/notes/tests/DeleteNoteDialog.test.tsx
@@ -1,0 +1,40 @@
+import "./setup";
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { DeleteNoteDialog } from "../components/DeleteNoteDialog";
+
+vi.mock("../actions", () => ({
+  deleteNoteAction: vi.fn(),
+}));
+
+function getTriggerButton(container: HTMLElement) {
+  const triggerButton = container.querySelector("button");
+
+  if (!(triggerButton instanceof HTMLButtonElement)) {
+    throw new Error("delete trigger button not found");
+  }
+
+  return triggerButton;
+}
+
+describe("DeleteNoteDialog", () => {
+  it("allows long note titles to wrap inside the dialog", async () => {
+    const user = userEvent.setup();
+    const noteTitle =
+      "LongNoteTitleWithoutSpacesLongNoteTitleWithoutSpacesLongNoteTitle";
+    const { container } = render(
+      <DeleteNoteDialog noteId="note-123" noteTitle={noteTitle} />,
+    );
+
+    await user.click(getTriggerButton(container));
+
+    expect(await screen.findByText(noteTitle)).toHaveClass(
+      "max-w-full",
+      "break-keep",
+      "[overflow-wrap:anywhere]",
+    );
+  });
+});

--- a/src/features/notifications/components/PushSubscribeCard.tsx
+++ b/src/features/notifications/components/PushSubscribeCard.tsx
@@ -27,6 +27,9 @@ type PushSubscribeCardProps = {
 };
 
 const vapidPublicKey = process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY ?? "";
+const isServiceWorkerRuntimeEnabled =
+  process.env.NODE_ENV !== "development" ||
+  process.env.NEXT_PUBLIC_ENABLE_SW === "true";
 
 function isPushSupported() {
   return (
@@ -106,7 +109,8 @@ export function PushSubscribeCard({
   const [error, setError] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
 
-  const isRuntimeEnabled = vapidPublicKey.length > 0;
+  const isRuntimeEnabled =
+    isServiceWorkerRuntimeEnabled && vapidPublicKey.length > 0;
   // Push endpoint is origin-scoped, so a stale browser subscription left by a previous account
   // does NOT mean the current user owns it. Verify ownership against the DB before treating
   // the button as "unsubscribe".
@@ -172,11 +176,13 @@ export function PushSubscribeCard({
 
   const disabledReason = !isSupported
     ? "이 브라우저는 푸시 알림을 지원하지 않습니다."
-    : vapidPublicKey.length === 0
-      ? "VAPID 공개 키가 설정되지 않았습니다."
-      : permission === "denied"
-        ? "브라우저 사이트 설정에서 알림을 허용해 주세요."
-        : null;
+    : !isServiceWorkerRuntimeEnabled
+      ? "개발 서버에서 서비스 워커가 비활성화되어 있습니다. 로컬 알림 검증은 npm run dev:sw로 실행해주세요."
+      : vapidPublicKey.length === 0
+        ? "VAPID 공개 키가 설정되지 않았습니다."
+        : permission === "denied"
+          ? "브라우저 사이트 설정에서 알림을 허용해 주세요."
+          : null;
 
   const handleSubscribe = () => {
     setError(null);

--- a/src/features/review/components/BlankTestPage.test.tsx
+++ b/src/features/review/components/BlankTestPage.test.tsx
@@ -79,6 +79,10 @@ describe("BlankTestPage", () => {
       />,
     );
 
+    expect(screen.getByRole("heading", { level: 1 })).toHaveClass(
+      "break-words",
+      "break-keep",
+    );
     expect(
       screen.getByText(
         "비교를 마쳤다면 이번 복습을 완료 처리하고 다음 간격으로 넘어가세요.",

--- a/src/features/review/components/BlankTestPage.tsx
+++ b/src/features/review/components/BlankTestPage.tsx
@@ -48,7 +48,9 @@ export function BlankTestPage({
             백지 테스트 {reviewRound} / {MAX_REVIEW_ROUND}
           </span>
         </div>
-        <h1 className="text-3xl font-bold text-foreground">{noteTitle}</h1>
+        <h1 className="break-words break-keep text-3xl font-bold text-foreground">
+          {noteTitle}
+        </h1>
         <p className="text-sm text-muted-foreground">
           먼저 기억나는 내용을 적고 제출한 뒤, 원본과 나란히 비교해보세요.
         </p>


### PR DESCRIPTION
## 개요

긴 노트 제목이 영역을 벗어나는 UI 깨짐을 수정하고, 개발 환경에서 이전 푸시 구독 흐름이 남긴 서비스 워커가 계속 살아 있어 발생하던 오류를 해결합니다.

## PR 유형

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [x] UI 디자인 변경
- [ ] 코드 리팩토링
- [x] 테스트 추가/수정
- [ ] 문서 수정
- [ ] 빌드/패키지 설정 변경

## 관련 이슈

closes #195

## 작업 내용

**노트 제목 오버플로우 수정**
- [src/app/(main)/notes/[noteId]/page.tsx](src/app/(main)/notes/[noteId]/page.tsx) 상세 페이지 제목에 `break-words break-keep` 적용
- [src/features/review/components/BlankTestPage.tsx](src/features/review/components/BlankTestPage.tsx) 백지 테스트 헤더 제목에 동일 처리
- [src/features/notes/components/DeleteNoteDialog.tsx](src/features/notes/components/DeleteNoteDialog.tsx) 삭제 확인 다이얼로그의 제목 박스에 `min-w-0 max-w-full whitespace-normal break-keep [overflow-wrap:anywhere]` 적용 — 공백 없는 긴 문자열도 줄바꿈되도록 보강

**서비스 워커 오류 수정**
- [src/components/providers/DevelopmentServiceWorkerCleanup.tsx](src/components/providers/DevelopmentServiceWorkerCleanup.tsx) 신설: dev 환경에서 `NEXT_PUBLIC_ENABLE_SW !== "true"`일 때 등록된 SW를 모두 unregister, controller가 있으면 reload
- [src/app/layout.tsx](src/app/layout.tsx) 루트 레이아웃에 위 컴포넌트 마운트
- [src/features/notifications/components/PushSubscribeCard.tsx](src/features/notifications/components/PushSubscribeCard.tsx) 런타임 활성 조건에 `isServiceWorkerRuntimeEnabled`(NODE_ENV/플래그 기반) 추가 및 비활성 사유 메시지 분기
- [package.json](package.json) `dev:sw` 스크립트에 `NEXT_PUBLIC_ENABLE_SW=true` 추가 — 클라이언트에서도 SW 활성 여부를 인지

**테스트**
- [src/features/notes/tests/DeleteNoteDialog.test.tsx](src/features/notes/tests/DeleteNoteDialog.test.tsx) 신규: 공백 없는 긴 제목이 줄바꿈 클래스를 받는지 검증
- 기존 페이지/페이지컴포넌트 테스트에 제목 줄바꿈 클래스 어서션 추가

## 테스트 방법

1. `npm run dev`로 일반 개발 서버 실행
   - 한 번이라도 `dev:sw`를 켜본 적 있는 브라우저에서 접속해도 SW가 자동 해제되고 새로고침되는지 확인
   - `PushSubscribeCard`가 "개발 서버에서 서비스 워커가 비활성화되어 있습니다…" 메시지를 보여주는지 확인
2. `npm run dev:sw` 실행 시에는 SW가 그대로 유지되고 푸시 구독 카드가 정상 동작하는지 확인
3. 노트 제목에 공백 없는 긴 문자열(예: `LongNoteTitleWithoutSpacesLongNoteTitle...`)을 넣고
   - 노트 상세 페이지
   - 백지 테스트 페이지
   - 삭제 확인 다이얼로그
   세 곳에서 모두 컨테이너 바깥으로 텍스트가 흘러나오지 않는지 확인
4. `npm run lint && npm run typecheck && npm test` 통과

## 스크린샷 (FE 변경 시)
<img width="2880" height="1438" alt="image" src="https://github.com/user-attachments/assets/d1f4e3d8-6d21-4eb5-96a8-61caa440c70a" />
<img width="2880" height="1433" alt="image" src="https://github.com/user-attachments/assets/dd16e503-2b96-4232-8b73-af0716337ca9" />
<img width="2880" height="1444" alt="image" src="https://github.com/user-attachments/assets/d12343a7-1535-4615-9287-5e843f6eaffc" />


## 리뷰 요구사항 (선택)

- `DevelopmentServiceWorkerCleanup`이 루트 레이아웃에 마운트된 위치/타이밍이 적절한지(다른 Provider보다 먼저 unregister 되어야 하는지) 확인 부탁드립니다.


## 체크리스트

- [x] 코드 컨벤션 준수
- [x] 커밋 메시지 컨벤션 준수
- [x] lint 통과
- [x] typecheck 통과
- [ ] (DB 변경 시) migration 포함 및 로컬 재현 확인
- [ ] (권한/RLS 영향 시) 정책 변경 요약 기재
- [x] UI 변경 시 스크린샷/짧은 설명 첨부
- [x] 셀프 리뷰 완료
