### PR TITLE
fix: #202 - 아바타 삭제 시 DB 업데이트 먼저 실행하도록 순서 수정

### DIFF
--- a/src/features/mypage/actions.ts
+++ b/src/features/mypage/actions.ts
@@ -111,15 +111,6 @@ export async function deleteAvatarAction() {
 
   if (!user) return { error: "인증이 필요합니다" };
 
-  const { error: removeError } = await supabase.storage
-    .from("avatars")
-    .remove([`${user.id}/avatar`]);
-
-  if (removeError) {
-    console.error("아바타 파일 삭제 실패:", removeError.message);
-    return { error: "아바타 삭제에 실패했습니다" };
-  }
-
   const { data, error } = await supabase
     .from("profiles")
     .update({ avatar_url: null })
@@ -128,6 +119,14 @@ export async function deleteAvatarAction() {
     .single();
 
   if (error) return { error: "아바타 삭제에 실패했습니다" };
+
+  const { error: removeError } = await supabase.storage
+    .from("avatars")
+    .remove([`${user.id}/avatar`]);
+
+  if (removeError) {
+    console.error("아바타 파일 삭제 실패:", removeError.message);
+  }
 
   return { data };
 }

--- a/src/features/mypage/tests/actions.test.ts
+++ b/src/features/mypage/tests/actions.test.ts
@@ -175,14 +175,25 @@ describe("deleteAvatarAction", () => {
     expect(result).toEqual({ error: "인증이 필요합니다" });
   });
 
-  it("storage 삭제 실패 시 에러 반환하고 DB 업데이트 안 함", async () => {
+  it("storage 삭제 실패 시 DB 업데이트 후 data 반환", async () => {
     const { supabase } = makeSupabaseMock({
       removeError: { message: "remove failed" },
     });
     createClientMock.mockResolvedValue(supabase);
 
     const result = await deleteAvatarAction();
+    expect(result).toEqual({ data: { id: "user-123" } });
+    expect(supabase.from).toHaveBeenCalled();
+  });
+
+  it("DB 업데이트 실패 시 에러 반환하고 storage 삭제 안 함", async () => {
+    const { supabase } = makeSupabaseMock({
+      updateError: { message: "update failed" },
+    });
+    createClientMock.mockResolvedValue(supabase);
+
+    const result = await deleteAvatarAction();
     expect(result).toEqual({ error: "아바타 삭제에 실패했습니다" });
-    expect(supabase.from).not.toHaveBeenCalled();
+    expect(supabase.storage.from).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## 개요

아바타 삭제 시 Storage 파일 삭제 → DB 업데이트 순서로 실행되던 것을,
DB 업데이트 → Storage 파일 삭제 순서로 변경.

기존 순서에서는 Storage 삭제 성공 후 DB 업데이트가 실패하면
존재하지 않는 파일을 가리키는 URL이 DB에 잔존해
next/image가 Supabase Storage에 요청 시 400 에러가 발생했음.

## PR 유형

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] UI 디자인 변경
- [ ] 코드 리팩토링
- [ ] 테스트 추가/수정
- [ ] 문서 수정
- [ ] 빌드/패키지 설정 변경

## 관련 이슈

closes #202

## 작업 내용

- `deleteAvatarAction` 실행 순서 변경
  - 기존: Storage 삭제 → DB `avatar_url = null`
  - 변경: DB `avatar_url = null` → Storage 삭제
- Storage 삭제 실패 시 에러 반환 제거 → `console.error`로 로깅만 처리
  (URL이 이미 null이므로 사용자에게 에러를 노출할 필요 없음)

## 테스트 방법

1. 아바타 이미지 업로드
2. 아바타 삭제
3. 헤더에 이니셜이 표시되는지 확인
4. 서버 콘솔에 upstream image 400 에러가 없는지 확인

## 스크린샷 (FE 변경 시)

해당 없음

## 리뷰 요구사항 (선택)

Storage 삭제 실패 시 고아 파일이 남을 수 있음. 추후 orphan 정리 로직이 필요하면 별도 이슈로 처리 예정.

## 체크리스트

- [x] 코드 컨벤션 준수
- [x] 커밋 메시지 컨벤션 준수
- [x] lint 통과
- [x] typecheck 통과
- [ ] (DB 변경 시) migration 포함 및 로컬 재현 확인
- [ ] (권한/RLS 영향 시) 정책 변경 요약 기재
- [ ] UI 변경 시 스크린샷/짧은 설명 첨부
- [x] 셀프 리뷰 완료