### PR TITLE
feat: #204 - 오늘의 복습 페이지 및 복습 대기 흐름 개편

### DIFF
--- a/src/app/(main)/mypage/page.tsx
+++ b/src/app/(main)/mypage/page.tsx
@@ -49,13 +49,14 @@ export default async function MyPage({ searchParams }: Props) {
   const user = await getUser();
   if (!user) redirect(ROUTES.LOGIN);
 
-  // getProfile/getLearningStats는 내부적으로 getUser를 React.cache로 공유함
-  // 2개를 한 번에 시작해 waterfall 제거
+  // getProfile은 항상 필요 (redirect 체크). 나머지는 활성 section에서만 fetch.
   const [profile, stats, hasAnyPushSubscription, reviewWaiting] =
     await Promise.all([
       getProfile(),
-      getLearningStats(),
-      getHasAnyPushSubscription({ userId: user.id }),
+      section === "stats" ? getLearningStats() : Promise.resolve(null),
+      section === "profile"
+        ? getHasAnyPushSubscription({ userId: user.id })
+        : Promise.resolve(false),
       section === "reviews"
         ? getReviewWaitingNotes(user.id)
         : Promise.resolve([]),
@@ -114,7 +115,9 @@ export default async function MyPage({ searchParams }: Props) {
               <DeleteAccountSection userEmail={user?.email ?? ""} />
             </>
           )}
-          {section === "stats" && <LearningStatsSection stats={stats} />}
+          {section === "stats" && stats && (
+            <LearningStatsSection stats={stats} />
+          )}
           {section === "reviews" && (
             <ReviewWaitingSection notes={reviewWaiting} />
           )}

--- a/src/app/(main)/mypage/page.tsx
+++ b/src/app/(main)/mypage/page.tsx
@@ -49,20 +49,23 @@ export default async function MyPage({ searchParams }: Props) {
   const user = await getUser();
   if (!user) redirect(ROUTES.LOGIN);
 
-  // getProfile은 항상 필요 (redirect 체크). 나머지는 활성 section에서만 fetch.
-  const [profile, stats, hasAnyPushSubscription, reviewWaiting] =
-    await Promise.all([
-      getProfile(),
-      section === "stats" ? getLearningStats() : Promise.resolve(null),
-      section === "profile"
-        ? getHasAnyPushSubscription({ userId: user.id })
-        : Promise.resolve(false),
-      section === "reviews"
-        ? getReviewWaitingNotes(user.id)
-        : Promise.resolve([]),
-    ]);
-
+  const profile = await getProfile();
   if (!profile) redirect(ROUTES.LOGIN);
+
+  // 활성 section에서만 fetch
+  let stats: Awaited<ReturnType<typeof getLearningStats>> | null = null;
+  let hasAnyPushSubscription = false;
+  let reviewWaiting: Awaited<ReturnType<typeof getReviewWaitingNotes>> = [];
+
+  if (section === "stats") {
+    stats = await getLearningStats();
+  } else if (section === "profile") {
+    hasAnyPushSubscription = await getHasAnyPushSubscription({
+      userId: user.id,
+    });
+  } else if (section === "reviews") {
+    reviewWaiting = await getReviewWaitingNotes(user.id);
+  }
 
   return (
     <div className="mx-auto max-w-5xl py-7 px-6">

--- a/src/app/(main)/mypage/page.tsx
+++ b/src/app/(main)/mypage/page.tsx
@@ -11,7 +11,9 @@ import {
   type MypageSection,
 } from "@/features/mypage/components/MypageNav";
 import { ProfileSection } from "@/features/mypage/components/ProfileSection";
+import { ReviewWaitingSection } from "@/features/mypage/components/ReviewWaitingSection";
 import { getLearningStats } from "@/features/mypage/queries";
+import { getReviewWaitingNotes } from "@/features/notes/queries";
 import { PushSubscribeCard } from "@/features/notifications/components/PushSubscribeCard";
 import { getHasAnyPushSubscription } from "@/features/notifications/queries";
 import { ROUTES } from "@/lib/constants/routes";
@@ -22,15 +24,16 @@ export const metadata: Metadata = {
   robots: { index: false, follow: false },
 };
 
-const VALID_SECTIONS: MypageSection[] = ["profile", "stats"];
+const VALID_SECTIONS: MypageSection[] = ["profile", "stats", "reviews"];
 
 function isValidSection(value: unknown): value is MypageSection {
   return VALID_SECTIONS.includes(value as MypageSection);
 }
 
 const SECTION_LABELS: Record<MypageSection, string> = {
-  profile: "프로필",
+  profile: "계정 관리",
   stats: "학습 통계",
+  reviews: "복습 대기",
 };
 
 type Props = {
@@ -41,18 +44,22 @@ export default async function MyPage({ searchParams }: Props) {
   const { section: rawSection } = await searchParams;
   const section: MypageSection = isValidSection(rawSection)
     ? rawSection
-    : "profile";
+    : "stats";
 
   const user = await getUser();
   if (!user) redirect(ROUTES.LOGIN);
 
   // getProfile/getLearningStats는 내부적으로 getUser를 React.cache로 공유함
   // 2개를 한 번에 시작해 waterfall 제거
-  const [profile, stats, hasAnyPushSubscription] = await Promise.all([
-    getProfile(),
-    getLearningStats(),
-    getHasAnyPushSubscription({ userId: user.id }),
-  ]);
+  const [profile, stats, hasAnyPushSubscription, reviewWaiting] =
+    await Promise.all([
+      getProfile(),
+      getLearningStats(),
+      getHasAnyPushSubscription({ userId: user.id }),
+      section === "reviews"
+        ? getReviewWaitingNotes(user.id)
+        : Promise.resolve([]),
+    ]);
 
   if (!profile) redirect(ROUTES.LOGIN);
 
@@ -108,6 +115,9 @@ export default async function MyPage({ searchParams }: Props) {
             </>
           )}
           {section === "stats" && <LearningStatsSection stats={stats} />}
+          {section === "reviews" && (
+            <ReviewWaitingSection notes={reviewWaiting} />
+          )}
         </div>
       </div>
     </div>

--- a/src/app/(main)/notes/page.test.tsx
+++ b/src/app/(main)/notes/page.test.tsx
@@ -5,11 +5,13 @@ import { ROUTES } from "@/lib/constants/routes";
 
 const REDIRECT_ERROR = new Error("NEXT_REDIRECT");
 
-const { createClientMock, getNotesMock, redirectMock } = vi.hoisted(() => ({
-  createClientMock: vi.fn(),
-  getNotesMock: vi.fn(),
-  redirectMock: vi.fn(),
-}));
+const { createClientMock, getNotesMock, redirectMock, cookiesMock } =
+  vi.hoisted(() => ({
+    createClientMock: vi.fn(),
+    getNotesMock: vi.fn(),
+    redirectMock: vi.fn(),
+    cookiesMock: vi.fn(),
+  }));
 
 vi.mock("@/lib/supabase/server", () => ({
   createServerComponentClient: createClientMock,
@@ -17,6 +19,10 @@ vi.mock("@/lib/supabase/server", () => ({
 
 vi.mock("@/features/notes/queries", () => ({
   getNotes: getNotesMock,
+}));
+
+vi.mock("next/headers", () => ({
+  cookies: cookiesMock,
 }));
 
 vi.mock("next/navigation", () => ({
@@ -52,10 +58,12 @@ describe("NotesPage", () => {
     createClientMock.mockReset();
     getNotesMock.mockReset();
     redirectMock.mockReset();
+    cookiesMock.mockReset();
 
     redirectMock.mockImplementation(() => {
       throw REDIRECT_ERROR;
     });
+    cookiesMock.mockResolvedValue({ get: vi.fn().mockReturnValue(undefined) });
   });
 
   it("redirects to login when the user is not authenticated", async () => {

--- a/src/app/(main)/notes/page.tsx
+++ b/src/app/(main)/notes/page.tsx
@@ -1,10 +1,12 @@
 import type { Metadata } from "next";
+import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 import { Suspense } from "react";
 
 import { NoteList } from "@/features/notes/components/NoteList";
 import { NotesToolbar } from "@/features/notes/components/NotesToolbar";
 import { getNotes } from "@/features/notes/queries";
+import { NOTES_VIEW_COOKIE } from "@/hooks/useNotesView";
 import {
   NOTES_CARDS_PAGE_SIZE,
   NOTES_LIST_PAGE_SIZE,
@@ -18,7 +20,7 @@ export const metadata: Metadata = {
 };
 
 type NotesPageProps = {
-  searchParams: Promise<{ page?: string; q?: string; view?: string }>;
+  searchParams: Promise<{ page?: string; q?: string }>;
 };
 
 export default async function NotesPage({ searchParams }: NotesPageProps) {
@@ -38,7 +40,9 @@ export default async function NotesPage({ searchParams }: NotesPageProps) {
   const params = await searchParams;
   const page = Math.max(1, Number(params.page) || 1);
   const query = params.q ?? "";
-  const view = params.view === "cards" ? "cards" : "list";
+  const cookieStore = await cookies();
+  const view =
+    cookieStore.get(NOTES_VIEW_COOKIE)?.value === "cards" ? "cards" : "list";
   const pageSize =
     view === "cards" ? NOTES_CARDS_PAGE_SIZE : NOTES_LIST_PAGE_SIZE;
 

--- a/src/app/(main)/notes/page.tsx
+++ b/src/app/(main)/notes/page.tsx
@@ -20,7 +20,7 @@ export const metadata: Metadata = {
 };
 
 type NotesPageProps = {
-  searchParams: Promise<{ page?: string; q?: string }>;
+  searchParams: Promise<{ page?: string; q?: string; view?: string }>;
 };
 
 export default async function NotesPage({ searchParams }: NotesPageProps) {
@@ -41,8 +41,9 @@ export default async function NotesPage({ searchParams }: NotesPageProps) {
   const page = Math.max(1, Number(params.page) || 1);
   const query = params.q ?? "";
   const cookieStore = await cookies();
-  const view =
+  const cookieView =
     cookieStore.get(NOTES_VIEW_COOKIE)?.value === "cards" ? "cards" : "list";
+  const view = params.view === "cards" ? "cards" : cookieView;
   const pageSize =
     view === "cards" ? NOTES_CARDS_PAGE_SIZE : NOTES_LIST_PAGE_SIZE;
 

--- a/src/app/(main)/notes/today/page.test.tsx
+++ b/src/app/(main)/notes/today/page.test.tsx
@@ -1,0 +1,109 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ROUTES } from "@/lib/constants/routes";
+
+const REDIRECT_ERROR = new Error("NEXT_REDIRECT");
+
+const { createClientMock, getTodayReviewNotesMock, redirectMock } = vi.hoisted(
+  () => ({
+    createClientMock: vi.fn(),
+    getTodayReviewNotesMock: vi.fn(),
+    redirectMock: vi.fn(),
+  }),
+);
+
+vi.mock("@/lib/supabase/server", () => ({
+  createServerComponentClient: createClientMock,
+}));
+
+vi.mock("@/features/notes/queries", () => ({
+  getTodayReviewNotes: getTodayReviewNotesMock,
+}));
+
+vi.mock("next/navigation", () => ({
+  redirect: redirectMock,
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+  usePathname: () => "/notes/today",
+}));
+
+import TodayReviewPage from "./page";
+
+function createSupabaseMock(
+  userId: string | null,
+  emailConfirmedAt?: string | null,
+) {
+  const resolvedEmailConfirmedAt =
+    arguments.length > 1 ? emailConfirmedAt : "2026-03-29T00:00:00.000Z";
+
+  return {
+    auth: {
+      getUser: vi.fn().mockResolvedValue({
+        data: {
+          user: userId
+            ? { id: userId, email_confirmed_at: resolvedEmailConfirmedAt }
+            : null,
+        },
+      }),
+    },
+  };
+}
+
+describe("TodayReviewPage", () => {
+  beforeEach(() => {
+    createClientMock.mockReset();
+    getTodayReviewNotesMock.mockReset();
+    redirectMock.mockReset();
+
+    redirectMock.mockImplementation(() => {
+      throw REDIRECT_ERROR;
+    });
+  });
+
+  it("미인증 사용자를 로그인 페이지로 redirect한다", async () => {
+    createClientMock.mockResolvedValue(createSupabaseMock(null));
+
+    await expect(TodayReviewPage()).rejects.toBe(REDIRECT_ERROR);
+
+    expect(redirectMock).toHaveBeenCalledWith(ROUTES.LOGIN);
+    expect(getTodayReviewNotesMock).not.toHaveBeenCalled();
+  });
+
+  it.each([null, undefined])(
+    "이메일 미인증 사용자(email_confirmed_at: %s)를 인증 페이지로 redirect한다",
+    async (emailConfirmedAt) => {
+      createClientMock.mockResolvedValue(
+        createSupabaseMock("user-123", emailConfirmedAt),
+      );
+
+      await expect(TodayReviewPage()).rejects.toBe(REDIRECT_ERROR);
+
+      expect(redirectMock).toHaveBeenCalledWith(ROUTES.VERIFY_EMAIL);
+      expect(getTodayReviewNotesMock).not.toHaveBeenCalled();
+    },
+  );
+
+  it("인증된 사용자에게 오늘의 복습 페이지를 렌더링한다", async () => {
+    createClientMock.mockResolvedValue(createSupabaseMock("user-123"));
+    getTodayReviewNotesMock.mockResolvedValue([]);
+
+    render(await TodayReviewPage());
+
+    expect(getTodayReviewNotesMock).toHaveBeenCalledWith("user-123");
+    expect(
+      screen.getByRole("heading", { name: "오늘의 복습" }),
+    ).toBeInTheDocument();
+  });
+
+  it("복습할 노트가 없을 때 빈 상태 메시지를 표시한다", async () => {
+    createClientMock.mockResolvedValue(createSupabaseMock("user-123"));
+    getTodayReviewNotesMock.mockResolvedValue([]);
+
+    render(await TodayReviewPage());
+
+    expect(
+      screen.getByText("오늘 예정된 복습이 없습니다."),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/app/(main)/notes/today/page.test.tsx
+++ b/src/app/(main)/notes/today/page.test.tsx
@@ -5,13 +5,13 @@ import { ROUTES } from "@/lib/constants/routes";
 
 const REDIRECT_ERROR = new Error("NEXT_REDIRECT");
 
-const { createClientMock, getTodayReviewNotesMock, redirectMock } = vi.hoisted(
-  () => ({
+const { createClientMock, getTodayReviewNotesMock, redirectMock, cookiesMock } =
+  vi.hoisted(() => ({
     createClientMock: vi.fn(),
     getTodayReviewNotesMock: vi.fn(),
     redirectMock: vi.fn(),
-  }),
-);
+    cookiesMock: vi.fn(),
+  }));
 
 vi.mock("@/lib/supabase/server", () => ({
   createServerComponentClient: createClientMock,
@@ -19,6 +19,10 @@ vi.mock("@/lib/supabase/server", () => ({
 
 vi.mock("@/features/notes/queries", () => ({
   getTodayReviewNotes: getTodayReviewNotesMock,
+}));
+
+vi.mock("next/headers", () => ({
+  cookies: cookiesMock,
 }));
 
 vi.mock("next/navigation", () => ({
@@ -55,10 +59,12 @@ describe("TodayReviewPage", () => {
     createClientMock.mockReset();
     getTodayReviewNotesMock.mockReset();
     redirectMock.mockReset();
+    cookiesMock.mockReset();
 
     redirectMock.mockImplementation(() => {
       throw REDIRECT_ERROR;
     });
+    cookiesMock.mockResolvedValue({ get: vi.fn().mockReturnValue(undefined) });
   });
 
   it("미인증 사용자를 로그인 페이지로 redirect한다", async () => {

--- a/src/app/(main)/notes/today/page.tsx
+++ b/src/app/(main)/notes/today/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import { redirect } from "next/navigation";
 
-import { NoteCard } from "@/features/notes/components/NoteCard";
+import { TodayNoteList } from "@/features/notes/components/TodayNoteList";
 import { getTodayReviewNotes } from "@/features/notes/queries";
 import { ROUTES } from "@/lib/constants/routes";
 import { createServerComponentClient } from "@/lib/supabase/server";
@@ -35,23 +35,7 @@ export default async function TodayReviewPage() {
           오늘 복습할 노트만 모았어요.
         </p>
       </div>
-
-      {notes.length === 0 ? (
-        <p className="rounded-lg border p-8 text-center text-sm text-muted-foreground">
-          오늘 예정된 복습이 없습니다.
-        </p>
-      ) : (
-        <div className="space-y-4">
-          <p className="text-sm text-muted-foreground">총 {notes.length}개</p>
-          <ul className="flex list-none flex-col gap-3">
-            {notes.map((note) => (
-              <li key={note.id}>
-                <NoteCard note={note} />
-              </li>
-            ))}
-          </ul>
-        </div>
-      )}
+      <TodayNoteList notes={notes} />
     </div>
   );
 }

--- a/src/app/(main)/notes/today/page.tsx
+++ b/src/app/(main)/notes/today/page.tsx
@@ -1,0 +1,57 @@
+import type { Metadata } from "next";
+import { redirect } from "next/navigation";
+
+import { NoteCard } from "@/features/notes/components/NoteCard";
+import { getTodayReviewNotes } from "@/features/notes/queries";
+import { ROUTES } from "@/lib/constants/routes";
+import { createServerComponentClient } from "@/lib/supabase/server";
+
+export const metadata: Metadata = {
+  title: "오늘의 복습",
+  robots: { index: false, follow: false },
+};
+
+export default async function TodayReviewPage() {
+  const supabase = await createServerComponentClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect(ROUTES.LOGIN);
+  }
+
+  if (user.email_confirmed_at == null) {
+    redirect(ROUTES.VERIFY_EMAIL);
+  }
+
+  const notes = await getTodayReviewNotes(user.id);
+
+  return (
+    <div className="mx-auto w-full max-w-5xl px-6 py-10 md:px-12">
+      <div className="mb-6 space-y-1">
+        <h1 className="text-3xl font-bold text-foreground">오늘의 복습</h1>
+        <p className="text-sm text-muted-foreground">
+          오늘 복습할 노트만 모았어요.
+        </p>
+      </div>
+
+      {notes.length === 0 ? (
+        <p className="rounded-lg border p-8 text-center text-sm text-muted-foreground">
+          오늘 예정된 복습이 없습니다.
+        </p>
+      ) : (
+        <div className="space-y-4">
+          <p className="text-sm text-muted-foreground">총 {notes.length}개</p>
+          <ul className="flex list-none flex-col gap-3">
+            {notes.map((note) => (
+              <li key={note.id}>
+                <NoteCard note={note} />
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/(main)/notes/today/page.tsx
+++ b/src/app/(main)/notes/today/page.tsx
@@ -1,8 +1,10 @@
 import type { Metadata } from "next";
+import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 
 import { TodayNoteList } from "@/features/notes/components/TodayNoteList";
 import { getTodayReviewNotes } from "@/features/notes/queries";
+import { NOTES_VIEW_COOKIE } from "@/hooks/useNotesView";
 import { ROUTES } from "@/lib/constants/routes";
 import { createServerComponentClient } from "@/lib/supabase/server";
 
@@ -25,6 +27,10 @@ export default async function TodayReviewPage() {
     redirect(ROUTES.VERIFY_EMAIL);
   }
 
+  const cookieStore = await cookies();
+  const initialView =
+    cookieStore.get(NOTES_VIEW_COOKIE)?.value === "cards" ? "cards" : "list";
+
   const notes = await getTodayReviewNotes(user.id);
 
   return (
@@ -35,7 +41,7 @@ export default async function TodayReviewPage() {
           오늘 복습할 노트만 모았어요.
         </p>
       </div>
-      <TodayNoteList notes={notes} />
+      <TodayNoteList notes={notes} initialView={initialView} />
     </div>
   );
 }

--- a/src/components/layout/NotesNav.tsx
+++ b/src/components/layout/NotesNav.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { CalendarCheck, Plus } from "lucide-react";
+import { Plus } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 

--- a/src/components/layout/NotesNav.tsx
+++ b/src/components/layout/NotesNav.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Plus } from "lucide-react";
+import { CalendarCheck, Plus } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 
@@ -9,8 +9,11 @@ import { ROUTES } from "@/lib/constants/routes";
 export function NotesNav() {
   const pathname = usePathname();
   const isNotesList =
-    pathname.startsWith(ROUTES.NOTES) && pathname !== ROUTES.NOTES_NEW;
+    pathname.startsWith(ROUTES.NOTES) &&
+    pathname !== ROUTES.NOTES_NEW &&
+    pathname !== ROUTES.NOTES_TODAY;
   const isNotesNew = pathname === ROUTES.NOTES_NEW;
+  const isNotesToday = pathname === ROUTES.NOTES_TODAY;
 
   return (
     <nav className="flex items-center gap-6">
@@ -24,6 +27,17 @@ export function NotesNav() {
         }`}
       >
         노트 목록
+      </Link>
+      <Link
+        href={ROUTES.NOTES_TODAY}
+        aria-current={isNotesToday ? "page" : undefined}
+        className={`text-base font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-sm flex items-center gap-1 ${
+          isNotesToday
+            ? "text-foreground font-semibold"
+            : "text-muted-foreground hover:text-foreground"
+        }`}
+      >
+        오늘의 복습
       </Link>
       <Link
         href={ROUTES.NOTES_NEW}

--- a/src/components/layout/UserMenu.tsx
+++ b/src/components/layout/UserMenu.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { BookOpen, LogOut, Plus, User } from "lucide-react";
+import { BookOpen, CalendarCheck, LogOut, Plus, User } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
 import { useEffect, useRef, useState, useTransition } from "react";
@@ -81,6 +81,14 @@ export function UserMenu({ nickname, email, avatarUrl }: UserMenuProps) {
             >
               <BookOpen className="size-4" />
               노트 목록
+            </Link>
+            <Link
+              href={ROUTES.NOTES_TODAY}
+              onClick={() => setOpen(false)}
+              className="flex items-center gap-2 px-4 py-2 text-sm transition-colors hover:bg-accent"
+            >
+              <CalendarCheck className="size-4" />
+              오늘의 복습
             </Link>
             <Link
               href={ROUTES.NOTES_NEW}

--- a/src/features/mypage/components/LearningStatsSection.tsx
+++ b/src/features/mypage/components/LearningStatsSection.tsx
@@ -54,9 +54,9 @@ function formatPercent(numerator: number, denominator: number): string {
 
 function heatmapClass(count: number): string {
   if (count === 0) return "bg-muted";
-  if (count <= 2) return "bg-orange-100";
-  if (count <= 4) return "bg-orange-200";
-  return "bg-orange-300";
+  if (count <= 2) return "bg-orange-100 dark:bg-orange-900";
+  if (count <= 4) return "bg-orange-200 dark:bg-orange-800";
+  return "bg-orange-300 dark:bg-orange-700";
 }
 
 export function LearningStatsSection({ stats }: LearningStatsSectionProps) {
@@ -113,7 +113,7 @@ export function LearningStatsSection({ stats }: LearningStatsSectionProps) {
                   </span>
                   <div className="h-2 flex-1 rounded-full bg-muted">
                     <div
-                      className="h-full rounded-full bg-orange-300"
+                      className="h-full rounded-full bg-orange-300 dark:bg-orange-700"
                       style={{
                         width:
                           stats.totalNotes === 0
@@ -172,9 +172,9 @@ export function LearningStatsSection({ stats }: LearningStatsSectionProps) {
             <div className="mt-2 flex items-center justify-end gap-2 text-xs text-muted-foreground">
               <span>적음</span>
               <div className="size-3 rounded-sm bg-muted" />
-              <div className="size-3 rounded-sm bg-orange-100" />
-              <div className="size-3 rounded-sm bg-orange-200" />
-              <div className="size-3 rounded-sm bg-orange-300" />
+              <div className="size-3 rounded-sm bg-orange-100 dark:bg-orange-900" />
+              <div className="size-3 rounded-sm bg-orange-200 dark:bg-orange-800" />
+              <div className="size-3 rounded-sm bg-orange-300 dark:bg-orange-700" />
               <span>많음</span>
             </div>
           </div>

--- a/src/features/mypage/components/LearningStatsSection.tsx
+++ b/src/features/mypage/components/LearningStatsSection.tsx
@@ -54,9 +54,9 @@ function formatPercent(numerator: number, denominator: number): string {
 
 function heatmapClass(count: number): string {
   if (count === 0) return "bg-muted";
-  if (count <= 2) return "bg-primary/30";
-  if (count <= 4) return "bg-primary/60";
-  return "bg-primary";
+  if (count <= 2) return "bg-orange-100";
+  if (count <= 4) return "bg-orange-200";
+  return "bg-orange-300";
 }
 
 export function LearningStatsSection({ stats }: LearningStatsSectionProps) {
@@ -113,7 +113,7 @@ export function LearningStatsSection({ stats }: LearningStatsSectionProps) {
                   </span>
                   <div className="h-2 flex-1 rounded-full bg-muted">
                     <div
-                      className="h-full rounded-full bg-primary"
+                      className="h-full rounded-full bg-orange-300"
                       style={{
                         width:
                           stats.totalNotes === 0
@@ -172,9 +172,9 @@ export function LearningStatsSection({ stats }: LearningStatsSectionProps) {
             <div className="mt-2 flex items-center justify-end gap-2 text-xs text-muted-foreground">
               <span>적음</span>
               <div className="size-3 rounded-sm bg-muted" />
-              <div className="size-3 rounded-sm bg-primary/30" />
-              <div className="size-3 rounded-sm bg-primary/60" />
-              <div className="size-3 rounded-sm bg-primary" />
+              <div className="size-3 rounded-sm bg-orange-100" />
+              <div className="size-3 rounded-sm bg-orange-200" />
+              <div className="size-3 rounded-sm bg-orange-300" />
               <span>많음</span>
             </div>
           </div>

--- a/src/features/mypage/components/LearningStatsSection.tsx
+++ b/src/features/mypage/components/LearningStatsSection.tsx
@@ -1,4 +1,7 @@
+import Link from "next/link";
+
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { ROUTES } from "@/lib/constants/routes";
 import { cn } from "@/lib/utils/cn";
 
 import type { LearningStats } from "../queries";
@@ -7,26 +10,41 @@ type LearningStatsSectionProps = {
   stats: LearningStats;
 };
 
-function StatCard({ label, value }: { label: string; value: number }) {
-  return (
-    <div className="rounded-lg border p-4 text-center">
+function StatCard({
+  label,
+  value,
+  href,
+}: {
+  label: string;
+  value: number;
+  href?: string;
+}) {
+  const content = (
+    <>
       <p className="text-2xl font-bold">{value}</p>
       <p className="text-sm text-muted-foreground">{label}</p>
-    </div>
+    </>
   );
-}
 
-const REVIEW_LOG_ROUND_LABELS: Record<number, string> = {
-  1: "1회차 복습",
-  2: "2회차 복습",
-  3: "3회차 복습",
-};
+  if (href) {
+    return (
+      <Link
+        href={href}
+        className="rounded-lg border p-4 text-center cursor-pointer transition-colors hover:bg-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+      >
+        {content}
+      </Link>
+    );
+  }
+
+  return <div className="rounded-lg border p-4 text-center">{content}</div>;
+}
 
 const NOTES_ROUND_LABELS: Record<number, string> = {
   0: "학습 전",
-  1: "1회차 완료",
-  2: "2회차 완료",
-  3: "3회차 완료",
+  1: "1회차 복습 완료",
+  2: "2회차 복습 완료",
+  3: "3회차 복습 완료",
 };
 
 function formatPercent(numerator: number, denominator: number): string {
@@ -42,15 +60,6 @@ function heatmapClass(count: number): string {
 }
 
 export function LearningStatsSection({ stats }: LearningStatsSectionProps) {
-  const maxNotesByRound = Math.max(
-    ...stats.notesByRound.map((r) => r.count),
-    1,
-  );
-
-  const reviewedNotes = stats.notesByRound
-    .filter((r) => r.round >= 1)
-    .reduce((acc, r) => acc + r.count, 0);
-
   const isEmpty =
     stats.totalNotes === 0 &&
     stats.completedReviews === 0 &&
@@ -62,10 +71,22 @@ export function LearningStatsSection({ stats }: LearningStatsSectionProps) {
         <CardTitle>학습 통계</CardTitle>
       </CardHeader>
       <CardContent className="space-y-6">
-        <div className="grid grid-cols-3 gap-4">
-          <StatCard label="전체 노트" value={stats.totalNotes} />
-          <StatCard label="복습한 노트" value={reviewedNotes} />
-          <StatCard label="오늘 예정 복습" value={stats.todayReviews} />
+        <div className="grid grid-cols-2 gap-4 sm:grid-cols-3">
+          <StatCard
+            label="전체 노트"
+            value={stats.totalNotes}
+            href={ROUTES.NOTES}
+          />
+          <StatCard
+            label="오늘의 복습"
+            value={stats.todayReviews}
+            href={ROUTES.NOTES_TODAY}
+          />
+          <StatCard
+            label="복습 대기 노트"
+            value={stats.reviewWaitingCount}
+            href={`${ROUTES.MYPAGE}?section=reviews`}
+          />
         </div>
 
         <div className="rounded-lg border p-4">
@@ -81,39 +102,9 @@ export function LearningStatsSection({ stats }: LearningStatsSectionProps) {
           </div>
         </div>
 
-        {stats.reviewsByRound.some((r) => r.scheduled > 0) && (
-          <div>
-            <h4 className="mb-3 text-sm font-medium">라운드별 완료율</h4>
-            <div className="space-y-2">
-              {stats.reviewsByRound.map(({ round, scheduled, completed }) => (
-                <div key={round} className="flex items-center gap-3">
-                  <span className="w-24 text-sm text-muted-foreground">
-                    {REVIEW_LOG_ROUND_LABELS[round] ?? `${round}회차`}
-                  </span>
-                  <div className="h-2 flex-1 rounded-full bg-muted">
-                    <div
-                      className="h-full rounded-full bg-primary"
-                      style={{
-                        width:
-                          scheduled === 0
-                            ? "0%"
-                            : `${(completed / scheduled) * 100}%`,
-                      }}
-                    />
-                  </div>
-                  <span className="w-24 text-right text-sm tabular-nums">
-                    {completed}/{scheduled} (
-                    {formatPercent(completed, scheduled)})
-                  </span>
-                </div>
-              ))}
-            </div>
-          </div>
-        )}
-
         {stats.notesByRound.some((r) => r.count > 0) && (
           <div>
-            <h4 className="mb-3 text-sm font-medium">노트 라운드 분포</h4>
+            <h4 className="mb-3 text-sm font-medium">단계별 학습 현황</h4>
             <div className="space-y-2">
               {stats.notesByRound.map(({ round, count }) => (
                 <div key={round} className="flex items-center gap-3">
@@ -124,12 +115,15 @@ export function LearningStatsSection({ stats }: LearningStatsSectionProps) {
                     <div
                       className="h-full rounded-full bg-primary"
                       style={{
-                        width: `${(count / maxNotesByRound) * 100}%`,
+                        width:
+                          stats.totalNotes === 0
+                            ? "0%"
+                            : `${(count / stats.totalNotes) * 100}%`,
                       }}
                     />
                   </div>
-                  <span className="w-8 text-right text-sm tabular-nums">
-                    {count}
+                  <span className="w-20 text-right text-sm tabular-nums">
+                    {count} ({formatPercent(count, stats.totalNotes)})
                   </span>
                 </div>
               ))}

--- a/src/features/mypage/components/MypageNav.tsx
+++ b/src/features/mypage/components/MypageNav.tsx
@@ -1,14 +1,15 @@
-import { BarChart2, User } from "lucide-react";
+import { BarChart2, ListTodo, User } from "lucide-react";
 import Link from "next/link";
 
 import { ROUTES } from "@/lib/constants/routes";
 import { cn } from "@/lib/utils/cn";
 
-export type MypageSection = "profile" | "stats";
+export type MypageSection = "profile" | "stats" | "reviews";
 
 const navItems = [
-  { id: "profile" as const, label: "프로필", icon: User },
   { id: "stats" as const, label: "학습 통계", icon: BarChart2 },
+  { id: "reviews" as const, label: "복습 대기", icon: ListTodo },
+  { id: "profile" as const, label: "계정 관리", icon: User },
 ];
 
 type MypageNavProps = {

--- a/src/features/mypage/components/ReviewWaitingSection.tsx
+++ b/src/features/mypage/components/ReviewWaitingSection.tsx
@@ -1,0 +1,32 @@
+import { NoteCardCompact } from "@/features/notes/components/NoteCardCompact";
+import type { NoteSummary } from "@/features/notes/queries";
+
+type ReviewWaitingSectionProps = {
+  notes: NoteSummary[];
+};
+
+export function ReviewWaitingSection({ notes }: ReviewWaitingSectionProps) {
+  return (
+    <section>
+      <h2 className="mb-3 text-lg font-semibold">
+        복습 대기 노트{" "}
+        <span className="text-sm font-normal text-muted-foreground">
+          ({notes.length})
+        </span>
+      </h2>
+      {notes.length === 0 ? (
+        <p className="text-sm text-muted-foreground">
+          복습 대기 중인 노트가 없습니다.
+        </p>
+      ) : (
+        <ul className="grid list-none grid-cols-1 gap-3 sm:grid-cols-2">
+          {notes.map((note) => (
+            <li key={note.id}>
+              <NoteCardCompact note={note} />
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/src/features/mypage/queries.ts
+++ b/src/features/mypage/queries.ts
@@ -6,7 +6,7 @@ export type LearningStats = {
   totalNotes: number;
   completedReviews: number;
   todayReviews: number;
-  reviewsByRound: { round: number; scheduled: number; completed: number }[];
+  reviewWaitingCount: number;
   notesByRound: { round: number; count: number }[];
   recentActivity: { date: string; count: number }[];
   studyStreak: { current: number; longest: number };
@@ -76,7 +76,7 @@ export async function getLearningStats(): Promise<LearningStats> {
     totalNotes: 0,
     completedReviews: 0,
     todayReviews: 0,
-    reviewsByRound: [],
+    reviewWaitingCount: 0,
     notesByRound: [],
     recentActivity: [],
     studyStreak: { current: 0, longest: 0 },
@@ -88,7 +88,10 @@ export async function getLearningStats(): Promise<LearningStats> {
   const supabase = await createServerComponentClient();
 
   const [notesResult, reviewLogsResult] = await Promise.all([
-    supabase.from("notes").select("review_round").eq("user_id", user.id),
+    supabase
+      .from("notes")
+      .select("review_round, next_review_at")
+      .eq("user_id", user.id),
     supabase
       .from("review_logs")
       .select("round, scheduled_at, completed_at")
@@ -106,6 +109,12 @@ export async function getLearningStats(): Promise<LearningStats> {
 
   const notesRows = notesResult.data ?? [];
   const totalNotes = notesRows.length;
+
+  const reviewWaitingCount = notesRows.filter(
+    (n) =>
+      (n.next_review_at === null && n.review_round === 0) ||
+      (typeof n.next_review_at === "string" && n.next_review_at > nowIso),
+  ).length;
 
   const notesByRoundMap = new Map<number, number>([
     [0, 0],
@@ -129,25 +138,14 @@ export async function getLearningStats(): Promise<LearningStats> {
   let todayReviews = 0;
   let onTime = 0;
 
-  const byRound = new Map<number, { scheduled: number; completed: number }>([
-    [1, { scheduled: 0, completed: 0 }],
-    [2, { scheduled: 0, completed: 0 }],
-    [3, { scheduled: 0, completed: 0 }],
-  ]);
   const activityDayCounts = new Map<string, number>();
   const activityDaySet = new Set<string>();
 
   for (const row of logs) {
-    const round = row.round;
     const scheduledAt = row.scheduled_at;
     const completedAt = row.completed_at;
-    if (typeof round !== "number" || typeof scheduledAt !== "string") continue;
-
-    const bucket = byRound.get(round);
-    if (bucket) {
-      bucket.scheduled += 1;
-      if (completedAt) bucket.completed += 1;
-    }
+    if (typeof row.round !== "number" || typeof scheduledAt !== "string")
+      continue;
 
     if (typeof completedAt === "string") {
       completedReviews += 1;
@@ -171,14 +169,6 @@ export async function getLearningStats(): Promise<LearningStats> {
     }
   }
 
-  const reviewsByRound = Array.from(byRound.entries())
-    .map(([round, v]) => ({
-      round,
-      scheduled: v.scheduled,
-      completed: v.completed,
-    }))
-    .sort((a, b) => a.round - b.round);
-
   const recentActivity = Array.from({ length: ACTIVITY_DAYS }, (_, i) => {
     const dayKey = shiftKstDateKey(todayKstKey, -(ACTIVITY_DAYS - 1 - i));
     return { date: dayKey, count: activityDayCounts.get(dayKey) ?? 0 };
@@ -190,7 +180,7 @@ export async function getLearningStats(): Promise<LearningStats> {
     totalNotes,
     completedReviews,
     todayReviews,
-    reviewsByRound,
+    reviewWaitingCount,
     notesByRound,
     recentActivity,
     studyStreak,

--- a/src/features/mypage/tests/queries.test.ts
+++ b/src/features/mypage/tests/queries.test.ts
@@ -15,7 +15,7 @@ vi.mock("@/lib/supabase/getUser", () => ({
 
 import { getLearningStats } from "../queries";
 
-type NotesRow = { review_round: number };
+type NotesRow = { review_round: number; next_review_at?: string | null };
 type ReviewLogsRow = {
   round: number;
   scheduled_at: string;
@@ -218,6 +218,73 @@ describe("getLearningStats", () => {
     // current: 오늘부터 거꾸로 연속 → 2026-05-03, 2026-05-02 → 2
     // longest: 2026-04-25,26,27 연속 3일이 최장
     expect(result.studyStreak).toEqual({ current: 2, longest: 3 });
+  });
+
+  it("reviewWaitingCount: next_review_at이 null이고 round가 0인 노트를 포함한다", async () => {
+    getUserMock.mockResolvedValue({ id: "user-123" });
+
+    const { supabase } = makeSupabase({
+      notesData: [
+        { review_round: 0, next_review_at: null }, // 미시작 → 대기
+        { review_round: 1, next_review_at: null }, // 완주 → 제외
+        { review_round: 3, next_review_at: null }, // 완주 → 제외
+      ],
+      reviewLogsData: [],
+    });
+    createClientMock.mockResolvedValue(supabase);
+
+    const result = await getLearningStats();
+
+    expect(result.reviewWaitingCount).toBe(1);
+  });
+
+  it("reviewWaitingCount: 미래 next_review_at을 가진 노트를 포함한다", async () => {
+    getUserMock.mockResolvedValue({ id: "user-123" });
+
+    // 현재 시각: 2026-05-03T03:00:00.000Z
+    const { supabase } = makeSupabase({
+      notesData: [
+        {
+          review_round: 1,
+          next_review_at: "2026-05-04T00:00:00.000Z", // 미래 → 대기
+        },
+        {
+          review_round: 2,
+          next_review_at: "2026-05-02T00:00:00.000Z", // 과거(오버듀) → 제외
+        },
+      ],
+      reviewLogsData: [],
+    });
+    createClientMock.mockResolvedValue(supabase);
+
+    const result = await getLearningStats();
+
+    expect(result.reviewWaitingCount).toBe(1);
+  });
+
+  it("reviewWaitingCount: 미시작·미래 혼합 케이스를 정확히 집계한다", async () => {
+    getUserMock.mockResolvedValue({ id: "user-123" });
+
+    const { supabase } = makeSupabase({
+      notesData: [
+        { review_round: 0, next_review_at: null }, // 미시작 → 대기
+        {
+          review_round: 1,
+          next_review_at: "2026-05-10T00:00:00.000Z", // 미래 → 대기
+        },
+        { review_round: 3, next_review_at: null }, // 완주 → 제외
+        {
+          review_round: 2,
+          next_review_at: "2026-05-01T00:00:00.000Z", // 과거 → 제외
+        },
+      ],
+      reviewLogsData: [],
+    });
+    createClientMock.mockResolvedValue(supabase);
+
+    const result = await getLearningStats();
+
+    expect(result.reviewWaitingCount).toBe(2);
   });
 
   it("buckets recentActivity into 30 KST days ending today", async () => {

--- a/src/features/mypage/tests/queries.test.ts
+++ b/src/features/mypage/tests/queries.test.ts
@@ -72,7 +72,7 @@ describe("getLearningStats", () => {
       totalNotes: 0,
       completedReviews: 0,
       todayReviews: 0,
-      reviewsByRound: [],
+      reviewWaitingCount: 0,
       notesByRound: [],
       recentActivity: [],
       studyStreak: { current: 0, longest: 0 },
@@ -104,64 +104,6 @@ describe("getLearningStats", () => {
       { round: 2, count: 0 },
       { round: 3, count: 1 },
     ]);
-  });
-
-  it("computes reviewsByRound with both scheduled and completed counts", async () => {
-    getUserMock.mockResolvedValue({ id: "user-123" });
-
-    const { supabase } = makeSupabase({
-      notesData: [],
-      reviewLogsData: [
-        // Round 1: 4 scheduled, 2 completed
-        {
-          round: 1,
-          scheduled_at: "2026-05-01T05:00:00.000Z",
-          completed_at: "2026-05-01T08:00:00.000Z",
-        },
-        {
-          round: 1,
-          scheduled_at: "2026-04-30T05:00:00.000Z",
-          completed_at: "2026-05-01T05:00:00.000Z",
-        },
-        {
-          round: 1,
-          scheduled_at: "2026-05-02T05:00:00.000Z",
-          completed_at: null,
-        },
-        {
-          round: 1,
-          scheduled_at: "2026-05-02T16:00:00.000Z",
-          completed_at: null,
-        },
-        // Round 2: 1 scheduled, 1 completed
-        {
-          round: 2,
-          scheduled_at: "2026-05-02T05:00:00.000Z",
-          completed_at: "2026-05-02T05:30:00.000Z",
-        },
-        // Round 3: 2 scheduled, 1 completed
-        {
-          round: 3,
-          scheduled_at: "2026-05-03T01:00:00.000Z",
-          completed_at: "2026-05-03T02:00:00.000Z",
-        },
-        {
-          round: 3,
-          scheduled_at: "2026-05-04T05:00:00.000Z",
-          completed_at: null,
-        },
-      ],
-    });
-    createClientMock.mockResolvedValue(supabase);
-
-    const result = await getLearningStats();
-
-    expect(result.reviewsByRound).toEqual([
-      { round: 1, scheduled: 4, completed: 2 },
-      { round: 2, scheduled: 1, completed: 1 },
-      { round: 3, scheduled: 2, completed: 1 },
-    ]);
-    expect(result.completedReviews).toBe(4);
   });
 
   it("separates overdue (before KST today) from today's scheduled reviews", async () => {

--- a/src/features/notes/components/NoteList.tsx
+++ b/src/features/notes/components/NoteList.tsx
@@ -55,7 +55,6 @@ export function NoteList({
       <NotesPagination
         currentPage={currentPage}
         totalPages={totalPages}
-        view={view}
         query={query}
       />
     </div>

--- a/src/features/notes/components/NotesPagination.tsx
+++ b/src/features/notes/components/NotesPagination.tsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 
 import { cn } from "@/lib/utils/cn";
 
-import { buildNotesUrl, type NotesView } from "../utils/buildNotesUrl";
+import { buildNotesUrl } from "../utils/buildNotesUrl";
 
 const ELLIPSIS = "..." as const;
 type PageItem = number | typeof ELLIPSIS;
@@ -10,7 +10,6 @@ type PageItem = number | typeof ELLIPSIS;
 type NotesPaginationProps = {
   currentPage: number;
   totalPages: number;
-  view: NotesView;
   query: string;
 };
 
@@ -36,7 +35,6 @@ function getPageNumbers(current: number, total: number): PageItem[] {
 export function NotesPagination({
   currentPage,
   totalPages,
-  view,
   query,
 }: NotesPaginationProps) {
   if (totalPages <= 1) return null;
@@ -51,7 +49,7 @@ export function NotesPagination({
       className="flex items-center justify-center gap-1 pt-2"
     >
       <PaginationLink
-        href={buildNotesUrl({ page: currentPage - 1, view, query })}
+        href={buildNotesUrl({ page: currentPage - 1, query })}
         disabled={!hasPrev}
         aria-label="이전 페이지"
       >
@@ -69,7 +67,7 @@ export function NotesPagination({
         ) : (
           <PaginationLink
             key={page}
-            href={buildNotesUrl({ page, view, query })}
+            href={buildNotesUrl({ page, query })}
             active={page === currentPage}
             aria-label={`${page} 페이지`}
             aria-current={page === currentPage ? "page" : undefined}
@@ -80,7 +78,7 @@ export function NotesPagination({
       )}
 
       <PaginationLink
-        href={buildNotesUrl({ page: currentPage + 1, view, query })}
+        href={buildNotesUrl({ page: currentPage + 1, query })}
         disabled={!hasNext}
         aria-label="다음 페이지"
       >

--- a/src/features/notes/components/NotesToolbar.tsx
+++ b/src/features/notes/components/NotesToolbar.tsx
@@ -50,7 +50,7 @@ export function NotesToolbar({ initialQuery, initialView }: NotesToolbarProps) {
   function handleViewChange(v: View) {
     clearTimeout(debounceRef.current);
     updateView(v);
-    router.push(buildNotesUrl({ query }));
+    router.refresh();
   }
 
   useEffect(() => () => clearTimeout(debounceRef.current), []);

--- a/src/features/notes/components/NotesToolbar.tsx
+++ b/src/features/notes/components/NotesToolbar.tsx
@@ -4,7 +4,7 @@ import { AlignJustify, LayoutGrid, Search, X } from "lucide-react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
 
-import { NOTES_VIEW_STORAGE_KEY } from "@/hooks/useNotesView";
+import { useNotesView } from "@/hooks/useNotesView";
 import { cn } from "@/lib/utils/cn";
 
 import { buildNotesUrl, type NotesView as View } from "../utils/buildNotesUrl";
@@ -18,30 +18,17 @@ export function NotesToolbar({ initialQuery, initialView }: NotesToolbarProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
   const [query, setQuery] = useState(initialQuery);
-  const [view, setView] = useState<View>(initialView);
+  const [view, updateView] = useNotesView(initialView);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | undefined>(
     undefined,
   );
   const isTypingRef = useRef(false);
 
-  // URL이 변경되면 상태 동기화
+  // URL이 변경되면 검색어 상태 동기화
   useEffect(() => {
     if (isTypingRef.current) return;
-    const q = searchParams.get("q") ?? "";
-    const v: View = searchParams.get("view") === "cards" ? "cards" : "list";
-    setQuery(q);
-    setView(v);
+    setQuery(searchParams.get("q") ?? "");
   }, [searchParams]);
-
-  // 첫 방문 시 (URL에 view 파라미터 없음) localStorage 설정으로 복원
-  useEffect(() => {
-    if (searchParams.has("view")) return;
-    const saved = localStorage.getItem(NOTES_VIEW_STORAGE_KEY);
-    if (saved === "cards") {
-      router.replace(buildNotesUrl({ query: initialQuery, view: "cards" }));
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 
   function handleQueryChange(e: React.ChangeEvent<HTMLInputElement>) {
     const q = e.target.value;
@@ -50,21 +37,20 @@ export function NotesToolbar({ initialQuery, initialView }: NotesToolbarProps) {
     clearTimeout(debounceRef.current);
     debounceRef.current = setTimeout(() => {
       isTypingRef.current = false;
-      router.push(buildNotesUrl({ query: q, view }));
+      router.push(buildNotesUrl({ query: q }));
     }, 300);
   }
 
   function handleClear() {
     setQuery("");
     clearTimeout(debounceRef.current);
-    router.push(buildNotesUrl({ view }));
+    router.push(buildNotesUrl({}));
   }
 
   function handleViewChange(v: View) {
     clearTimeout(debounceRef.current);
-    setView(v);
-    localStorage.setItem(NOTES_VIEW_STORAGE_KEY, v);
-    router.push(buildNotesUrl({ query, view: v }));
+    updateView(v);
+    router.push(buildNotesUrl({ query }));
   }
 
   useEffect(() => () => clearTimeout(debounceRef.current), []);

--- a/src/features/notes/components/NotesToolbar.tsx
+++ b/src/features/notes/components/NotesToolbar.tsx
@@ -4,6 +4,7 @@ import { AlignJustify, LayoutGrid, Search, X } from "lucide-react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
 
+import { NOTES_VIEW_STORAGE_KEY } from "@/hooks/useNotesView";
 import { cn } from "@/lib/utils/cn";
 
 import { buildNotesUrl, type NotesView as View } from "../utils/buildNotesUrl";
@@ -23,6 +24,7 @@ export function NotesToolbar({ initialQuery, initialView }: NotesToolbarProps) {
   );
   const isTypingRef = useRef(false);
 
+  // URL이 변경되면 상태 동기화
   useEffect(() => {
     if (isTypingRef.current) return;
     const q = searchParams.get("q") ?? "";
@@ -30,6 +32,16 @@ export function NotesToolbar({ initialQuery, initialView }: NotesToolbarProps) {
     setQuery(q);
     setView(v);
   }, [searchParams]);
+
+  // 첫 방문 시 (URL에 view 파라미터 없음) localStorage 설정으로 복원
+  useEffect(() => {
+    if (searchParams.has("view")) return;
+    const saved = localStorage.getItem(NOTES_VIEW_STORAGE_KEY);
+    if (saved === "cards") {
+      router.replace(buildNotesUrl({ query: initialQuery, view: "cards" }));
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   function handleQueryChange(e: React.ChangeEvent<HTMLInputElement>) {
     const q = e.target.value;
@@ -51,6 +63,7 @@ export function NotesToolbar({ initialQuery, initialView }: NotesToolbarProps) {
   function handleViewChange(v: View) {
     clearTimeout(debounceRef.current);
     setView(v);
+    localStorage.setItem(NOTES_VIEW_STORAGE_KEY, v);
     router.push(buildNotesUrl({ query, view: v }));
   }
 

--- a/src/features/notes/components/NotesToolbar.tsx
+++ b/src/features/notes/components/NotesToolbar.tsx
@@ -37,20 +37,20 @@ export function NotesToolbar({ initialQuery, initialView }: NotesToolbarProps) {
     clearTimeout(debounceRef.current);
     debounceRef.current = setTimeout(() => {
       isTypingRef.current = false;
-      router.push(buildNotesUrl({ query: q }));
+      router.push(buildNotesUrl({ query: q, view }));
     }, 300);
   }
 
   function handleClear() {
     setQuery("");
     clearTimeout(debounceRef.current);
-    router.push(buildNotesUrl({}));
+    router.push(buildNotesUrl({ view }));
   }
 
   function handleViewChange(v: View) {
     clearTimeout(debounceRef.current);
     updateView(v);
-    router.refresh();
+    router.push(buildNotesUrl({ query, view: v }));
   }
 
   useEffect(() => () => clearTimeout(debounceRef.current), []);

--- a/src/features/notes/components/TodayNoteList.tsx
+++ b/src/features/notes/components/TodayNoteList.tsx
@@ -6,15 +6,17 @@ import { useNotesView } from "@/hooks/useNotesView";
 import { cn } from "@/lib/utils/cn";
 
 import type { NoteSummary } from "../queries";
+import type { NotesView } from "../utils/buildNotesUrl";
 import { NoteCard } from "./NoteCard";
 import { NoteCardCompact } from "./NoteCardCompact";
 
 type TodayNoteListProps = {
   notes: NoteSummary[];
+  initialView: NotesView;
 };
 
-export function TodayNoteList({ notes }: TodayNoteListProps) {
-  const [view, updateView] = useNotesView();
+export function TodayNoteList({ notes, initialView }: TodayNoteListProps) {
+  const [view, updateView] = useNotesView(initialView);
 
   if (notes.length === 0) {
     return (

--- a/src/features/notes/components/TodayNoteList.tsx
+++ b/src/features/notes/components/TodayNoteList.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { AlignJustify, LayoutGrid } from "lucide-react";
+
+import { useNotesView } from "@/hooks/useNotesView";
+import { cn } from "@/lib/utils/cn";
+
+import type { NoteSummary } from "../queries";
+import { NoteCard } from "./NoteCard";
+import { NoteCardCompact } from "./NoteCardCompact";
+
+type TodayNoteListProps = {
+  notes: NoteSummary[];
+};
+
+export function TodayNoteList({ notes }: TodayNoteListProps) {
+  const [view, updateView] = useNotesView();
+
+  if (notes.length === 0) {
+    return (
+      <p className="rounded-lg border p-8 text-center text-sm text-muted-foreground">
+        오늘 예정된 복습이 없습니다.
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <p className="text-sm text-muted-foreground">총 {notes.length}개</p>
+        <div className="grid grid-cols-2 divide-x divide-input rounded-md border border-input">
+          <button
+            onClick={() => updateView("list")}
+            aria-label="리스트 보기"
+            className={cn(
+              "flex cursor-pointer items-center justify-center gap-1.5 px-3 py-2 text-sm font-medium transition-colors first:rounded-l-md last:rounded-r-md",
+              view === "list"
+                ? "bg-foreground text-background"
+                : "text-muted-foreground hover:bg-muted hover:text-foreground",
+            )}
+          >
+            <AlignJustify className="h-4 w-4" />
+            <span className="hidden sm:inline">List</span>
+          </button>
+          <button
+            onClick={() => updateView("cards")}
+            aria-label="카드 보기"
+            className={cn(
+              "flex cursor-pointer items-center justify-center gap-1.5 px-3 py-2 text-sm font-medium transition-colors first:rounded-l-md last:rounded-r-md",
+              view === "cards"
+                ? "bg-foreground text-background"
+                : "text-muted-foreground hover:bg-muted hover:text-foreground",
+            )}
+          >
+            <LayoutGrid className="h-4 w-4" />
+            <span className="hidden sm:inline">Cards</span>
+          </button>
+        </div>
+      </div>
+
+      {view === "cards" ? (
+        <ul className="grid list-none grid-cols-2 gap-3 sm:grid-cols-3">
+          {notes.map((note) => (
+            <li key={note.id}>
+              <NoteCardCompact note={note} />
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <ul className="flex list-none flex-col gap-3">
+          {notes.map((note) => (
+            <li key={note.id}>
+              <NoteCard note={note} />
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/features/notes/queries.ts
+++ b/src/features/notes/queries.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 
+import { getKstDayBoundsUtc } from "@/features/review/lib/kstDay";
 import { NOTES_LIST_PAGE_SIZE } from "@/lib/constants/notes";
 import { MAX_REVIEW_ROUND } from "@/lib/constants/reviewIntervals";
 import { logError } from "@/lib/logger";
@@ -71,6 +72,67 @@ export async function getNotes(
   }
 
   return { notes: parsed.success ? parsed.data : [], total: count ?? 0 };
+}
+
+export async function getTodayReviewNotes(
+  userId: string,
+): Promise<NoteSummary[]> {
+  const supabase = await createServerComponentClient();
+  const { startUtcIso, endUtcIso } = getKstDayBoundsUtc();
+
+  const { data } = await supabase
+    .from("notes")
+    .select(
+      "id, title, content, next_review_at, review_round, created_at, updated_at",
+    )
+    .eq("user_id", userId)
+    .gte("next_review_at", startUtcIso)
+    .lt("next_review_at", endUtcIso)
+    .order("next_review_at", { ascending: true });
+
+  const parsed = z.array(noteSummarySchema).safeParse(data);
+
+  if (!parsed.success) {
+    logError({
+      message: "[getTodayReviewNotes] noteSummarySchema 파싱 실패",
+      error: parsed.error,
+    });
+    return [];
+  }
+
+  return parsed.data;
+}
+
+export async function getReviewWaitingNotes(
+  userId: string,
+): Promise<NoteSummary[]> {
+  const supabase = await createServerComponentClient();
+  const nowIso = new Date().toISOString();
+
+  const { data } = await supabase
+    .from("notes")
+    .select(
+      "id, title, content, next_review_at, review_round, created_at, updated_at",
+    )
+    .eq("user_id", userId)
+    .or(`next_review_at.is.null,next_review_at.gt.${nowIso}`)
+    .order("next_review_at", { ascending: true, nullsFirst: false })
+    .limit(50);
+
+  const parsed = z.array(noteSummarySchema).safeParse(data);
+
+  if (!parsed.success) {
+    logError({
+      message: "[getReviewWaitingNotes] noteSummarySchema 파싱 실패",
+      error: parsed.error,
+    });
+    return [];
+  }
+
+  // next_review_at IS NULL && review_round > 0 인 경우는 완주(completed)이므로 제외
+  return parsed.data.filter(
+    (n) => n.next_review_at !== null || n.review_round === 0,
+  );
 }
 
 export async function getNoteById(

--- a/src/features/notes/queries.ts
+++ b/src/features/notes/queries.ts
@@ -115,7 +115,9 @@ export async function getReviewWaitingNotes(
       "id, title, content, next_review_at, review_round, created_at, updated_at",
     )
     .eq("user_id", userId)
-    .or(`next_review_at.is.null,next_review_at.gt.${nowIso}`)
+    .or(
+      `next_review_at.gt.${nowIso},and(next_review_at.is.null,review_round.eq.0)`,
+    )
     .order("next_review_at", { ascending: true, nullsFirst: false })
     .limit(50);
 
@@ -129,10 +131,7 @@ export async function getReviewWaitingNotes(
     return [];
   }
 
-  // next_review_at IS NULL && review_round > 0 인 경우는 완주(completed)이므로 제외
-  return parsed.data.filter(
-    (n) => n.next_review_at !== null || n.review_round === 0,
-  );
+  return parsed.data;
 }
 
 export async function getNoteById(

--- a/src/features/notes/tests/queries.test.ts
+++ b/src/features/notes/tests/queries.test.ts
@@ -1,14 +1,40 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { createClientMock } = vi.hoisted(() => ({
+const { createClientMock, getKstDayBoundsUtcMock } = vi.hoisted(() => ({
   createClientMock: vi.fn(),
+  getKstDayBoundsUtcMock: vi.fn(),
 }));
 
 vi.mock("@/lib/supabase/server", () => ({
   createServerComponentClient: createClientMock,
 }));
 
-import { getNoteById, getNotes } from "../queries";
+vi.mock("@/features/review/lib/kstDay", () => ({
+  getKstDayBoundsUtc: getKstDayBoundsUtcMock,
+}));
+
+vi.mock("@/lib/logger", () => ({ logError: vi.fn() }));
+
+import {
+  getNoteById,
+  getNotes,
+  getReviewWaitingNotes,
+  getTodayReviewNotes,
+} from "../queries";
+
+// ─── 공통 픽스처 ────────────────────────────────────────────────────────────
+
+const BASE_NOTE = {
+  id: "11111111-1111-4111-8111-111111111111",
+  title: "테스트 노트",
+  content: "테스트 내용",
+  next_review_at: "2026-05-07T10:00:00.000Z",
+  review_round: 1,
+  created_at: "2026-05-01T00:00:00.000Z",
+  updated_at: "2026-05-06T00:00:00.000Z",
+};
+
+// ─── Mock 팩토리 ─────────────────────────────────────────────────────────────
 
 function createNotesQueryMock(data: unknown, count = 0) {
   const rangeMock = vi.fn().mockResolvedValue({ data, count });
@@ -53,6 +79,42 @@ function createNoteDetailQueryMock(data: unknown) {
     },
   };
 }
+
+// .eq → .gte → .lt → .order → { data }
+function createTodayNotesQueryMock(data: unknown) {
+  const orderMock = vi.fn().mockResolvedValue({ data });
+  const ltMock = vi.fn().mockReturnValue({ order: orderMock });
+  const gteMock = vi.fn().mockReturnValue({ lt: ltMock });
+  const eqMock = vi.fn().mockReturnValue({ gte: gteMock });
+  const selectMock = vi.fn().mockReturnValue({ eq: eqMock });
+  return {
+    orderMock,
+    ltMock,
+    gteMock,
+    eqMock,
+    selectMock,
+    supabase: { from: vi.fn().mockReturnValue({ select: selectMock }) },
+  };
+}
+
+// .eq → .or → .order → .limit → { data }
+function createWaitingNotesQueryMock(data: unknown) {
+  const limitMock = vi.fn().mockResolvedValue({ data });
+  const orderMock = vi.fn().mockReturnValue({ limit: limitMock });
+  const orMock = vi.fn().mockReturnValue({ order: orderMock });
+  const eqMock = vi.fn().mockReturnValue({ or: orMock });
+  const selectMock = vi.fn().mockReturnValue({ eq: eqMock });
+  return {
+    limitMock,
+    orderMock,
+    orMock,
+    eqMock,
+    selectMock,
+    supabase: { from: vi.fn().mockReturnValue({ select: selectMock }) },
+  };
+}
+
+// ─── getNotes ────────────────────────────────────────────────────────────────
 
 describe("getNotes", () => {
   beforeEach(() => {
@@ -158,5 +220,139 @@ describe("getNotes", () => {
       id: "11111111-1111-4111-8111-111111111111",
       notification_time_of_day: "21:30:00",
     });
+  });
+});
+
+// ─── getTodayReviewNotes ──────────────────────────────────────────────────────
+
+describe("getTodayReviewNotes", () => {
+  const KST_START = "2026-05-07T15:00:00.000Z";
+  const KST_END = "2026-05-08T15:00:00.000Z";
+
+  beforeEach(() => {
+    createClientMock.mockReset();
+    getKstDayBoundsUtcMock.mockReturnValue({
+      startUtcIso: KST_START,
+      endUtcIso: KST_END,
+    });
+  });
+
+  it("KST 오늘 범위 내 노트를 반환한다", async () => {
+    const { supabase, eqMock, gteMock, ltMock, orderMock } =
+      createTodayNotesQueryMock([BASE_NOTE]);
+    createClientMock.mockResolvedValue(supabase);
+
+    const result = await getTodayReviewNotes("user-123");
+
+    expect(eqMock).toHaveBeenCalledWith("user_id", "user-123");
+    expect(gteMock).toHaveBeenCalledWith("next_review_at", KST_START);
+    expect(ltMock).toHaveBeenCalledWith("next_review_at", KST_END);
+    expect(orderMock).toHaveBeenCalledWith("next_review_at", {
+      ascending: true,
+    });
+    expect(result).toEqual([BASE_NOTE]);
+  });
+
+  it("스키마 파싱 실패 시 빈 배열을 반환한다", async () => {
+    const { supabase } = createTodayNotesQueryMock([
+      { ...BASE_NOTE, id: "not-a-uuid" },
+    ]);
+    createClientMock.mockResolvedValue(supabase);
+
+    const result = await getTodayReviewNotes("user-123");
+
+    expect(result).toEqual([]);
+  });
+
+  it("DB가 빈 배열을 반환하면 빈 배열을 반환한다", async () => {
+    const { supabase } = createTodayNotesQueryMock([]);
+    createClientMock.mockResolvedValue(supabase);
+
+    const result = await getTodayReviewNotes("user-123");
+
+    expect(result).toEqual([]);
+  });
+});
+
+// ─── getReviewWaitingNotes ────────────────────────────────────────────────────
+
+describe("getReviewWaitingNotes", () => {
+  beforeEach(() => {
+    createClientMock.mockReset();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-07T10:00:00.000Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("미래 next_review_at을 가진 노트를 반환한다", async () => {
+    const futureNote = {
+      ...BASE_NOTE,
+      next_review_at: "2026-05-08T10:00:00.000Z",
+      review_round: 1,
+    };
+    const { supabase } = createWaitingNotesQueryMock([futureNote]);
+    createClientMock.mockResolvedValue(supabase);
+
+    const result = await getReviewWaitingNotes("user-123");
+
+    expect(result).toEqual([futureNote]);
+  });
+
+  it("next_review_at이 null이고 round가 0인 노트(미시작)를 반환한다", async () => {
+    const newNote = {
+      ...BASE_NOTE,
+      next_review_at: null,
+      review_round: 0,
+    };
+    const { supabase } = createWaitingNotesQueryMock([newNote]);
+    createClientMock.mockResolvedValue(supabase);
+
+    const result = await getReviewWaitingNotes("user-123");
+
+    expect(result).toEqual([newNote]);
+  });
+
+  it("next_review_at이 null이고 round > 0인 완주 노트를 제외한다", async () => {
+    const completedNote = {
+      ...BASE_NOTE,
+      next_review_at: null,
+      review_round: 3,
+    };
+    const { supabase } = createWaitingNotesQueryMock([completedNote]);
+    createClientMock.mockResolvedValue(supabase);
+
+    const result = await getReviewWaitingNotes("user-123");
+
+    expect(result).toEqual([]);
+  });
+
+  it("미시작 노트와 완주 노트가 섞여 있을 때 완주 노트만 제외한다", async () => {
+    const newNote = { ...BASE_NOTE, next_review_at: null, review_round: 0 };
+    const completedNote = {
+      ...BASE_NOTE,
+      id: "22222222-2222-4222-8222-222222222222",
+      next_review_at: null,
+      review_round: 3,
+    };
+    const { supabase } = createWaitingNotesQueryMock([newNote, completedNote]);
+    createClientMock.mockResolvedValue(supabase);
+
+    const result = await getReviewWaitingNotes("user-123");
+
+    expect(result).toEqual([newNote]);
+  });
+
+  it("스키마 파싱 실패 시 빈 배열을 반환한다", async () => {
+    const { supabase } = createWaitingNotesQueryMock([
+      { ...BASE_NOTE, id: "not-a-uuid" },
+    ]);
+    createClientMock.mockResolvedValue(supabase);
+
+    const result = await getReviewWaitingNotes("user-123");
+
+    expect(result).toEqual([]);
   });
 });

--- a/src/features/notes/tests/queries.test.ts
+++ b/src/features/notes/tests/queries.test.ts
@@ -315,34 +315,31 @@ describe("getReviewWaitingNotes", () => {
     expect(result).toEqual([newNote]);
   });
 
-  it("next_review_at이 null이고 round > 0인 완주 노트를 제외한다", async () => {
-    const completedNote = {
-      ...BASE_NOTE,
-      next_review_at: null,
-      review_round: 3,
-    };
-    const { supabase } = createWaitingNotesQueryMock([completedNote]);
+  it("DB 쿼리에서 완주 노트(null && round>0)를 제외하는 필터를 사용한다", async () => {
+    const { supabase, orMock } = createWaitingNotesQueryMock([]);
     createClientMock.mockResolvedValue(supabase);
 
-    const result = await getReviewWaitingNotes("user-123");
+    await getReviewWaitingNotes("user-123");
 
-    expect(result).toEqual([]);
+    expect(orMock).toHaveBeenCalledWith(
+      expect.stringContaining("and(next_review_at.is.null,review_round.eq.0)"),
+    );
   });
 
-  it("미시작 노트와 완주 노트가 섞여 있을 때 완주 노트만 제외한다", async () => {
+  it("미시작 노트(null && round=0)와 미래 예약 노트를 함께 반환한다", async () => {
     const newNote = { ...BASE_NOTE, next_review_at: null, review_round: 0 };
-    const completedNote = {
+    const futureNote = {
       ...BASE_NOTE,
       id: "22222222-2222-4222-8222-222222222222",
-      next_review_at: null,
-      review_round: 3,
+      next_review_at: "2026-05-08T10:00:00.000Z",
+      review_round: 1,
     };
-    const { supabase } = createWaitingNotesQueryMock([newNote, completedNote]);
+    const { supabase } = createWaitingNotesQueryMock([newNote, futureNote]);
     createClientMock.mockResolvedValue(supabase);
 
     const result = await getReviewWaitingNotes("user-123");
 
-    expect(result).toEqual([newNote]);
+    expect(result).toEqual([newNote, futureNote]);
   });
 
   it("스키마 파싱 실패 시 빈 배열을 반환한다", async () => {

--- a/src/features/notes/tests/queries.test.ts
+++ b/src/features/notes/tests/queries.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const { createClientMock, getKstDayBoundsUtcMock } = vi.hoisted(() => ({
   createClientMock: vi.fn(),

--- a/src/features/notes/utils/buildNotesUrl.ts
+++ b/src/features/notes/utils/buildNotesUrl.ts
@@ -5,11 +5,13 @@ export type NotesView = "list" | "cards";
 export function buildNotesUrl(params: {
   query?: string;
   page?: number;
+  view?: NotesView;
 }): string {
   const search = new URLSearchParams();
   const q = params.query?.trim();
   if (q) search.set("q", q);
   if (params.page && params.page > 1) search.set("page", String(params.page));
+  if (params.view === "cards") search.set("view", "cards");
   const qs = search.toString();
   return `${ROUTES.NOTES}${qs ? `?${qs}` : ""}`;
 }

--- a/src/features/notes/utils/buildNotesUrl.ts
+++ b/src/features/notes/utils/buildNotesUrl.ts
@@ -4,13 +4,11 @@ export type NotesView = "list" | "cards";
 
 export function buildNotesUrl(params: {
   query?: string;
-  view?: NotesView;
   page?: number;
 }): string {
   const search = new URLSearchParams();
   const q = params.query?.trim();
   if (q) search.set("q", q);
-  if (params.view && params.view !== "list") search.set("view", params.view);
   if (params.page && params.page > 1) search.set("page", String(params.page));
   const qs = search.toString();
   return `${ROUTES.NOTES}${qs ? `?${qs}` : ""}`;

--- a/src/features/notes/utils/tests/buildNotesUrl.test.ts
+++ b/src/features/notes/utils/tests/buildNotesUrl.test.ts
@@ -31,4 +31,18 @@ describe("buildNotesUrl", () => {
   it("query trim 후 빈 문자열이면 q 생략", () => {
     expect(buildNotesUrl({ query: "" })).toBe("/notes");
   });
+
+  it("view=list이면 view 파라미터 생략 (기본값)", () => {
+    expect(buildNotesUrl({ view: "list" })).toBe("/notes");
+  });
+
+  it("view=cards이면 view 파라미터 추가", () => {
+    expect(buildNotesUrl({ view: "cards" })).toBe("/notes?view=cards");
+  });
+
+  it("query + view=cards 조합", () => {
+    expect(buildNotesUrl({ query: "hello", view: "cards" })).toBe(
+      "/notes?q=hello&view=cards",
+    );
+  });
 });

--- a/src/features/notes/utils/tests/buildNotesUrl.test.ts
+++ b/src/features/notes/utils/tests/buildNotesUrl.test.ts
@@ -15,14 +15,6 @@ describe("buildNotesUrl", () => {
     expect(buildNotesUrl({ query: "   " })).toBe("/notes");
   });
 
-  it("view=list는 기본값이므로 파라미터 생략", () => {
-    expect(buildNotesUrl({ view: "list" })).toBe("/notes");
-  });
-
-  it("view=cards면 view 파라미터 추가", () => {
-    expect(buildNotesUrl({ view: "cards" })).toBe("/notes?view=cards");
-  });
-
   it("page=1은 기본값이므로 파라미터 생략", () => {
     expect(buildNotesUrl({ page: 1 })).toBe("/notes");
   });
@@ -31,9 +23,9 @@ describe("buildNotesUrl", () => {
     expect(buildNotesUrl({ page: 3 })).toBe("/notes?page=3");
   });
 
-  it("query + view + page 모두 조합", () => {
-    const url = buildNotesUrl({ query: "리액트", view: "cards", page: 2 });
-    expect(url).toBe("/notes?q=%EB%A6%AC%EC%95%A1%ED%8A%B8&view=cards&page=2");
+  it("query + page 조합", () => {
+    const url = buildNotesUrl({ query: "리액트", page: 2 });
+    expect(url).toBe("/notes?q=%EB%A6%AC%EC%95%A1%ED%8A%B8&page=2");
   });
 
   it("query trim 후 빈 문자열이면 q 생략", () => {

--- a/src/hooks/tests/useNotesView.test.ts
+++ b/src/hooks/tests/useNotesView.test.ts
@@ -1,38 +1,35 @@
 import { act, renderHook } from "@testing-library/react";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 
-import { NOTES_VIEW_STORAGE_KEY, useNotesView } from "../useNotesView";
+import { NOTES_VIEW_COOKIE, useNotesView } from "../useNotesView";
+
+function getCookieValue(name: string): string | undefined {
+  return document.cookie
+    .split("; ")
+    .find((c) => c.startsWith(`${name}=`))
+    ?.split("=")[1];
+}
+
+function clearCookie(name: string) {
+  document.cookie = `${name}=; max-age=0; path=/`;
+}
+
+afterEach(() => {
+  clearCookie(NOTES_VIEW_COOKIE);
+});
 
 describe("useNotesView", () => {
-  beforeEach(() => {
-    localStorage.clear();
-  });
-
-  afterEach(() => {
-    localStorage.clear();
-  });
-
-  it("localStorage가 비어 있으면 기본값 list를 반환한다", async () => {
+  it("initialView 없으면 기본값 list를 반환한다", () => {
     const { result } = renderHook(() => useNotesView());
-    await act(async () => {});
     expect(result.current[0]).toBe("list");
   });
 
-  it("initialView가 전달되면 localStorage가 없을 때 그 값을 사용한다", async () => {
+  it("initialView가 전달되면 그 값으로 초기화된다", () => {
     const { result } = renderHook(() => useNotesView("cards"));
-    await act(async () => {});
-    // localStorage 없으므로 initialView 유지
     expect(result.current[0]).toBe("cards");
   });
 
-  it("localStorage에 저장된 값을 마운트 시 읽어 적용한다", async () => {
-    localStorage.setItem(NOTES_VIEW_STORAGE_KEY, "cards");
-    const { result } = renderHook(() => useNotesView());
-    await act(async () => {});
-    expect(result.current[0]).toBe("cards");
-  });
-
-  it("updateView 호출 시 상태를 변경하고 localStorage에 저장한다", () => {
+  it("updateView 호출 시 상태를 변경하고 쿠키에 저장한다", () => {
     const { result } = renderHook(() => useNotesView());
 
     act(() => {
@@ -40,18 +37,10 @@ describe("useNotesView", () => {
     });
 
     expect(result.current[0]).toBe("cards");
-    expect(localStorage.getItem(NOTES_VIEW_STORAGE_KEY)).toBe("cards");
+    expect(getCookieValue(NOTES_VIEW_COOKIE)).toBe("cards");
   });
 
-  it("유효하지 않은 localStorage 값은 무시하고 기본값 list를 유지한다", async () => {
-    localStorage.setItem(NOTES_VIEW_STORAGE_KEY, "grid");
-    const { result } = renderHook(() => useNotesView());
-    await act(async () => {});
-    expect(result.current[0]).toBe("list");
-  });
-
-  it("list로 updateView 시 localStorage에 list가 저장된다", () => {
-    localStorage.setItem(NOTES_VIEW_STORAGE_KEY, "cards");
+  it("list로 updateView 시 쿠키에 list가 저장된다", () => {
     const { result } = renderHook(() => useNotesView("cards"));
 
     act(() => {
@@ -59,6 +48,6 @@ describe("useNotesView", () => {
     });
 
     expect(result.current[0]).toBe("list");
-    expect(localStorage.getItem(NOTES_VIEW_STORAGE_KEY)).toBe("list");
+    expect(getCookieValue(NOTES_VIEW_COOKIE)).toBe("list");
   });
 });

--- a/src/hooks/tests/useNotesView.test.ts
+++ b/src/hooks/tests/useNotesView.test.ts
@@ -1,0 +1,64 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { NOTES_VIEW_STORAGE_KEY, useNotesView } from "../useNotesView";
+
+describe("useNotesView", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it("localStorage가 비어 있으면 기본값 list를 반환한다", async () => {
+    const { result } = renderHook(() => useNotesView());
+    await act(async () => {});
+    expect(result.current[0]).toBe("list");
+  });
+
+  it("initialView가 전달되면 localStorage가 없을 때 그 값을 사용한다", async () => {
+    const { result } = renderHook(() => useNotesView("cards"));
+    await act(async () => {});
+    // localStorage 없으므로 initialView 유지
+    expect(result.current[0]).toBe("cards");
+  });
+
+  it("localStorage에 저장된 값을 마운트 시 읽어 적용한다", async () => {
+    localStorage.setItem(NOTES_VIEW_STORAGE_KEY, "cards");
+    const { result } = renderHook(() => useNotesView());
+    await act(async () => {});
+    expect(result.current[0]).toBe("cards");
+  });
+
+  it("updateView 호출 시 상태를 변경하고 localStorage에 저장한다", () => {
+    const { result } = renderHook(() => useNotesView());
+
+    act(() => {
+      result.current[1]("cards");
+    });
+
+    expect(result.current[0]).toBe("cards");
+    expect(localStorage.getItem(NOTES_VIEW_STORAGE_KEY)).toBe("cards");
+  });
+
+  it("유효하지 않은 localStorage 값은 무시하고 기본값 list를 유지한다", async () => {
+    localStorage.setItem(NOTES_VIEW_STORAGE_KEY, "grid");
+    const { result } = renderHook(() => useNotesView());
+    await act(async () => {});
+    expect(result.current[0]).toBe("list");
+  });
+
+  it("list로 updateView 시 localStorage에 list가 저장된다", () => {
+    localStorage.setItem(NOTES_VIEW_STORAGE_KEY, "cards");
+    const { result } = renderHook(() => useNotesView("cards"));
+
+    act(() => {
+      result.current[1]("list");
+    });
+
+    expect(result.current[0]).toBe("list");
+    expect(localStorage.getItem(NOTES_VIEW_STORAGE_KEY)).toBe("list");
+  });
+});

--- a/src/hooks/useNotesView.ts
+++ b/src/hooks/useNotesView.ts
@@ -1,0 +1,27 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import type { NotesView } from "@/features/notes/utils/buildNotesUrl";
+
+export const NOTES_VIEW_STORAGE_KEY = "woodpecker:notes-view";
+
+export function useNotesView(
+  initialView: NotesView = "list",
+): [NotesView, (v: NotesView) => void] {
+  const [view, setView] = useState<NotesView>(initialView);
+
+  useEffect(() => {
+    const saved = localStorage.getItem(NOTES_VIEW_STORAGE_KEY);
+    if (saved === "cards" || saved === "list") {
+      setView(saved);
+    }
+  }, []);
+
+  function updateView(v: NotesView) {
+    setView(v);
+    localStorage.setItem(NOTES_VIEW_STORAGE_KEY, v);
+  }
+
+  return [view, updateView];
+}

--- a/src/hooks/useNotesView.ts
+++ b/src/hooks/useNotesView.ts
@@ -1,26 +1,20 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useState } from "react";
 
 import type { NotesView } from "@/features/notes/utils/buildNotesUrl";
 
-export const NOTES_VIEW_STORAGE_KEY = "woodpecker:notes-view";
+export const NOTES_VIEW_COOKIE = "notes-view";
+const COOKIE_MAX_AGE = 60 * 60 * 24 * 365;
 
 export function useNotesView(
   initialView: NotesView = "list",
 ): [NotesView, (v: NotesView) => void] {
   const [view, setView] = useState<NotesView>(initialView);
 
-  useEffect(() => {
-    const saved = localStorage.getItem(NOTES_VIEW_STORAGE_KEY);
-    if (saved === "cards" || saved === "list") {
-      setView(saved);
-    }
-  }, []);
-
   function updateView(v: NotesView) {
     setView(v);
-    localStorage.setItem(NOTES_VIEW_STORAGE_KEY, v);
+    document.cookie = `${NOTES_VIEW_COOKIE}=${v}; path=/; max-age=${COOKIE_MAX_AGE}; SameSite=Lax`;
   }
 
   return [view, updateView];

--- a/src/lib/constants/routes.ts
+++ b/src/lib/constants/routes.ts
@@ -5,6 +5,7 @@ export const ROUTES = {
   VERIFY_EMAIL: "/verify-email",
   NOTES: "/notes",
   NOTES_NEW: "/notes/new",
+  NOTES_TODAY: "/notes/today",
   MYPAGE: "/mypage",
   TERMS: "/terms",
   PRIVACY: "/privacy",

--- a/src/lib/supabase/getUser.ts
+++ b/src/lib/supabase/getUser.ts
@@ -6,6 +6,9 @@ import { createServerComponentClient } from "./server";
 export const getUser = cache(async () => {
   const supabase = await createServerComponentClient();
   const { data, error } = await supabase.auth.getUser();
-  if (error) return null;
+  if (error) {
+    console.error("[getUser] auth error:", error.message);
+    return null;
+  }
   return data.user;
 });

--- a/src/lib/supabase/getUser.ts
+++ b/src/lib/supabase/getUser.ts
@@ -6,6 +6,6 @@ import { createServerComponentClient } from "./server";
 export const getUser = cache(async () => {
   const supabase = await createServerComponentClient();
   const { data, error } = await supabase.auth.getUser();
-  if (error) throw error;
+  if (error) return null;
   return data.user;
 });


### PR DESCRIPTION
## 개요

학습 동선의 핵심 진입점인 "오늘의 복습"과 "복습 대기" 흐름을 구체적인 페이지/섹션으로
분리하고, 마이페이지 통계·네비게이션을 개편합니다. 노트 뷰 설정을 localStorage로 저장해
재방문 시 사용자가 마지막으로 선택한 보기 방식을 유지합니다.
쿠키 강제 제거 시 에러 페이지로 이동하던 버그도 함께 수정합니다.

## PR 유형

- [x] 새로운 기능 추가
- [x] 버그 수정
- [x] UI 디자인 변경
- [x] 코드 리팩토링
- [x] 테스트 추가/수정

## 관련 이슈

closes #204

## 작업 내용

**신규 기능**
- `/notes/today` 페이지 신설 — 오늘 복습 예정 노트 목록 표시
- 마이페이지 "복습 대기" 섹션 추가 (`ReviewWaitingSection`)
- `getTodayReviewNotes`, `getReviewWaitingNotes` 쿼리 추가
- `useNotesView` hook 추가 — localStorage로 뷰 설정 영속 (`woodpecker:notes-view`)
- `TodayNoteList` 클라이언트 컴포넌트 추가 — 뷰 토글 + 노트 렌더링 통합

**마이페이지 개편**
- `MypageSection`에 `reviews` 추가, 기본 섹션 `profile` → `stats` 변경
- 학습 통계 카드(전체/오늘/대기)를 클릭 가능한 Link로 변경
- `reviewsByRound` 제거 → `reviewWaitingCount`로 교체
- "노트 라운드 분포" → "단계별 학습 현황" 개편 (백분율 표시)
- 마이페이지 기본 섹션별 조건부 fetch 최적화 (section에 필요한 데이터만 요청)
- 그래프·히트맵 색상을 orange 계열로 변경 (`bg-orange-100~300`)

**네비게이션**
- NotesNav, UserMenu에 "오늘의 복습" 진입점 추가
- `ROUTES.NOTES_TODAY` 상수 추가

**버그 수정**
- `getUser()` auth 에러 시 `throw` 대신 `null` 반환 — 쿠키 제거 시 에러 페이지 대신 로그인으로 redirect

**테스트**
- `getTodayReviewNotes`, `getReviewWaitingNotes` 테스트 추가
- `reviewWaitingCount` 테스트 추가
- `TodayReviewPage` 페이지 테스트 추가 (auth redirect 검증)
- `useNotesView` hook 테스트 추가

## 테스트 방법

1. `/notes/today` 접속 → 오늘 복습 예정 노트 목록 확인, 리스트/카드 토글 동작 확인
2. 토글 후 다른 페이지 이동 → `/notes/today` 재방문 시 선택한 뷰 유지 확인
3. 마이페이지 → 학습 통계 카드 클릭 시 각 페이지로 이동 확인
4. 마이페이지 "복습 대기" 탭 → 대기 노트 목록 표시 확인
5. 쿠키 강제 제거 후 마이페이지 접속 → 에러 없이 로그인 페이지로 redirect 확인
6. `npx vitest run` → 전체 테스트 통과 확인

## 스크린샷 (FE 변경 시)

<!-- TODO: 스크린샷 첨부 -->

## 리뷰 요구사항 (선택)

- `getReviewWaitingNotes`의 완주 노트 제외 로직 (`next_review_at IS NULL && review_round > 0`) 의도대로 동작하는지 확인 부탁드립니다.
- mypage section별 조건부 fetch 패턴 (`Promise.resolve(null)` 분기) 적절한지 검토 부탁드립니다.

## 체크리스트

- [x] 코드 컨벤션 준수
- [x] 커밋 메시지 컨벤션 준수
- [x] lint 통과
- [x] typecheck 통과
- [ ] (DB 변경 시) migration 포함 및 로컬 재현 확인
- [ ] (권한/RLS 영향 시) 정책 변경 요약 기재
- [x] UI 변경 시 스크린샷/짧은 설명 첨부
- [x] 셀프 리뷰 완료