### PR TITLE
Feat/207 note UI ux improve

### DIFF
--- a/src/app/(main)/notes/[noteId]/page.test.tsx
+++ b/src/app/(main)/notes/[noteId]/page.test.tsx
@@ -152,7 +152,7 @@ describe("NoteDetailPage", () => {
     expect(getNoteByIdMock).toHaveBeenCalledWith("note-123", "user-123");
     const titleHeading = screen.getByRole("heading", { name: "Test note" });
     expect(titleHeading).toBeInTheDocument();
-    expect(titleHeading).toHaveClass("break-words", "break-keep");
+    expect(titleHeading).toHaveClass("wrap-break-word", "break-keep");
     expect(screen.getByTestId("note-viewer")).toHaveTextContent("note body");
     expect(screen.getByTestId("notification-time-picker")).toHaveTextContent(
       "note-123:21:30:00",

--- a/src/app/(main)/notes/[noteId]/page.tsx
+++ b/src/app/(main)/notes/[noteId]/page.tsx
@@ -5,6 +5,7 @@ import { notFound, redirect } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { DeleteNoteDialog } from "@/features/notes/components/DeleteNoteDialog";
 import { NoteViewer } from "@/features/notes/components/NoteViewer";
+import { ScrollToTopOnMount } from "@/features/notes/components/ScrollToTopOnMount";
 import { getNoteById } from "@/features/notes/queries";
 import { NotificationTimePicker } from "@/features/notifications/components/NotificationTimePicker";
 import { hasCompletedReviewForNoteToday } from "@/features/review/queries";
@@ -78,6 +79,7 @@ export default async function NoteDetailPage({
 
   return (
     <div className="mx-auto w-full max-w-4xl px-6 py-10 md:px-12">
+      <ScrollToTopOnMount />
       <header className="border-b border-border/60 pb-6">
         <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
           <span className="rounded-full bg-muted px-2 py-1 font-medium text-foreground">
@@ -89,7 +91,7 @@ export default async function NoteDetailPage({
             </span>
           )}
         </div>
-        <h1 className="mt-4 break-words break-keep text-3xl font-bold text-foreground">
+        <h1 className="mt-4 wrap-break-word break-keep text-3xl font-bold text-foreground">
           {note.title}
         </h1>
         <div className="mt-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">

--- a/src/features/editor/components/TipTapEditor.tsx
+++ b/src/features/editor/components/TipTapEditor.tsx
@@ -19,6 +19,7 @@ type TipTapEditorProps = {
   className?: string;
   "aria-label"?: string;
   onEditorReady?: (editor: Editor) => void;
+  onArrowUpAtStart?: () => void;
   extensions?: AnyExtension[];
 };
 
@@ -31,6 +32,7 @@ export function TipTapEditor({
   className,
   "aria-label": ariaLabel,
   onEditorReady,
+  onArrowUpAtStart,
   extensions,
 }: TipTapEditorProps) {
   const onEditorReadyRef = useRef(onEditorReady);
@@ -64,6 +66,42 @@ export function TipTapEditor({
       el.removeAttribute("aria-label");
     }
   }, [editor, ariaLabel]);
+
+  const onArrowUpAtStartRef = useRef(onArrowUpAtStart);
+  onArrowUpAtStartRef.current = onArrowUpAtStart;
+
+  useEffect(() => {
+    if (!editor) return;
+    if (!onArrowUpAtStart) return;
+
+    const el = editor.view.dom;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "ArrowUp") return;
+      if (event.shiftKey || event.altKey || event.metaKey || event.ctrlKey)
+        return;
+
+      const { selection, doc } = editor.state;
+      if (!selection.empty) return;
+
+      const $from = selection.$from;
+      // 첫 textblock의 첫 위치인지 — 문서의 첫 번째 자식과 동일하고 그 안의 offset이 0.
+      const isAtFirstBlockStart =
+        $from.parentOffset === 0 && $from.before(1) === 0 && doc.firstChild
+          ? $from.node(1) === doc.firstChild
+          : false;
+
+      if (!isAtFirstBlockStart) return;
+
+      event.preventDefault();
+      onArrowUpAtStartRef.current?.();
+    };
+
+    el.addEventListener("keydown", handleKeyDown);
+    return () => {
+      el.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [editor, onArrowUpAtStart]);
 
   return (
     <div

--- a/src/features/notes/components/NoteForm.tsx
+++ b/src/features/notes/components/NoteForm.tsx
@@ -85,7 +85,7 @@ export function NoteForm() {
           value={title}
           onChange={(e) => setTitle(e.target.value)}
           onKeyDown={handleTitleKeyDown}
-          className="w-full border-none bg-transparent text-4xl font-bold text-foreground placeholder:text-muted-foreground/30 focus:outline-none"
+          className="w-full border-none bg-transparent text-4xl font-bold leading-tight text-foreground placeholder:text-muted-foreground/30 focus:outline-none"
         />
         {fieldErrors?.title && (
           <p role="alert" className="mt-2 text-xs text-destructive">

--- a/src/features/notes/components/NoteForm.tsx
+++ b/src/features/notes/components/NoteForm.tsx
@@ -85,7 +85,7 @@ export function NoteForm() {
           value={title}
           onChange={(e) => setTitle(e.target.value)}
           onKeyDown={handleTitleKeyDown}
-          className="w-full border-none bg-transparent text-4xl font-bold leading-tight text-foreground placeholder:text-muted-foreground/30 focus:outline-none"
+          className="w-full border-none bg-transparent text-4xl font-bold leading-snug text-foreground placeholder:text-muted-foreground/30 focus:outline-none"
         />
         {fieldErrors?.title && (
           <p role="alert" className="mt-2 text-xs text-destructive">

--- a/src/features/notes/components/NoteForm.tsx
+++ b/src/features/notes/components/NoteForm.tsx
@@ -1,7 +1,8 @@
 "use client";
 
+import type { Editor } from "@tiptap/react";
 import { useRouter } from "next/navigation";
-import { useActionState, useEffect, useState } from "react";
+import { useActionState, useEffect, useRef, useState } from "react";
 
 import { Button } from "@/components/ui/button";
 import { TipTapEditor } from "@/features/editor/components/TipTapEditor";
@@ -18,6 +19,8 @@ export function NoteForm() {
   const [title, setTitle] = useState("");
   const [content, setContent] = useState("");
   const [createdNoteId, setCreatedNoteId] = useState<string | null>(null);
+  const titleInputRef = useRef<HTMLInputElement>(null);
+  const editorRef = useRef<Editor | null>(null);
 
   const fieldErrors =
     state?.error && typeof state.error === "object" ? state.error : null;
@@ -39,34 +42,41 @@ export function NoteForm() {
     router.push(getNoteDetailRoute(createdNoteId));
   }, [createdNoteId, router]);
 
+  const focusContentStart = () => {
+    editorRef.current?.commands.focus("start");
+  };
+
+  const handleTitleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.nativeEvent.isComposing) return;
+    if (event.key === "Enter" || event.key === "ArrowDown") {
+      event.preventDefault();
+      focusContentStart();
+    }
+  };
+
+  const handleArrowUpFromContent = () => {
+    const input = titleInputRef.current;
+    if (!input) return;
+    input.focus();
+    const end = input.value.length;
+    input.setSelectionRange(end, end);
+    window.scrollTo({ top: 0, behavior: "smooth" });
+  };
+
   return (
     <form
       action={formAction}
       className="mx-auto flex w-full max-w-4xl flex-col"
     >
-      <div className="flex items-center justify-end gap-2 px-12 py-4">
-        <Button
-          type="submit"
-          size="sm"
-          disabled={isPending || content.length > CONTENT_MAX_LENGTH}
-          title={
-            content.length > CONTENT_MAX_LENGTH
-              ? "내용이 최대 글자수를 초과했습니다"
-              : undefined
-          }
-        >
-          {isPending ? "저장 중..." : "저장"}
-        </Button>
-      </div>
-
       {generalError && (
-        <p role="alert" className="px-12 text-xs text-destructive">
+        <p role="alert" className="px-12 pt-4 text-xs text-destructive">
           {generalError}
         </p>
       )}
 
       <div className="px-12 pt-8 pb-6">
         <input
+          ref={titleInputRef}
           id="title"
           name="title"
           aria-label="제목"
@@ -74,6 +84,7 @@ export function NoteForm() {
           maxLength={100}
           value={title}
           onChange={(e) => setTitle(e.target.value)}
+          onKeyDown={handleTitleKeyDown}
           className="w-full border-none bg-transparent text-4xl font-bold text-foreground placeholder:text-muted-foreground/30 focus:outline-none"
         />
         {fieldErrors?.title && (
@@ -97,10 +108,14 @@ export function NoteForm() {
         placeholder="내용을 입력하세요..."
         autoFocus
         aria-label="내용"
+        onEditorReady={(editor) => {
+          editorRef.current = editor;
+        }}
+        onArrowUpAtStart={handleArrowUpFromContent}
         className="flex-1 rounded-none border-none focus-within:ring-0 focus-within:border-none [&_.tiptap]:min-h-[70vh] [&_.tiptap]:px-12! [&_.tiptap]:py-6!"
       />
 
-      <div className="flex justify-end px-12 py-2">
+      <div className="flex items-center justify-end gap-3 px-12 py-2">
         <span
           aria-live="polite"
           className={`text-xs tabular-nums ${
@@ -114,6 +129,18 @@ export function NoteForm() {
           {content.length.toLocaleString()} /{" "}
           {CONTENT_MAX_LENGTH.toLocaleString()}
         </span>
+        <Button
+          type="submit"
+          size="sm"
+          disabled={isPending || content.length > CONTENT_MAX_LENGTH}
+          title={
+            content.length > CONTENT_MAX_LENGTH
+              ? "내용이 최대 글자수를 초과했습니다"
+              : undefined
+          }
+        >
+          {isPending ? "저장 중..." : "저장"}
+        </Button>
       </div>
     </form>
   );

--- a/src/features/notes/components/ScrollToTopOnMount.tsx
+++ b/src/features/notes/components/ScrollToTopOnMount.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import { useEffect } from "react";
+
+export function ScrollToTopOnMount() {
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, []);
+
+  return null;
+}


### PR DESCRIPTION
## 개요

노트 작성/상세에서 누적된 5가지 UX 불편함을 한 번에 정리. 제목 input의 의도치 않은 즉시 저장, 키보드만으로 제목↔본문 이동 불가, 긴 본문 작성 후 저장 버튼까지 다시 스크롤해야 하는 문제, 상세 진입 시 스크롤 위치 잔존, 굵은 한글 제목에서 디센더(g·y 등)가 살짝 잘리는 문제를 해결.

## PR 유형

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [x] UI 디자인 변경
- [ ] 코드 리팩토링
- [ ] 테스트 추가/수정
- [ ] 문서 수정
- [ ] 빌드/패키지 설정 변경

## 관련 이슈

closes #207

## 작업 내용

- 제목 input에서 `Enter` / `ArrowDown` → 본문(TipTap) 시작 위치로 포커스 이동, 즉시 submit 방지 (IME 조합 중에는 무시)
- 본문 첫 textblock 첫 위치에서 `ArrowUp` → 제목 input으로 포커스 + `window.scrollTo({ top: 0 })`로 페이지 최상단 스크롤. 그 외 위치의 `ArrowUp`은 기본 동작(본문 내 줄 이동) 유지
- [TipTapEditor](src/features/editor/components/TipTapEditor.tsx)에 `onArrowUpAtStart` prop 추가 — selection이 doc의 첫 textblock 첫 칸일 때만 호출되도록 가드
- 저장 버튼을 폼 상단에서 제거하고, 하단 글자수 카운터 옆으로 이동(우측 정렬, 카운터→버튼 순). 긴 본문 작성 후 위로 스크롤하지 않아도 저장 가능
- 노트 상세 페이지에 [ScrollToTopOnMount](src/features/notes/components/ScrollToTopOnMount.tsx) 클라이언트 컴포넌트 마운트 — 목록의 스크롤 위치가 상세로 새어 들어오는 케이스 차단
- 제목 input에 `leading-snug` 추가 — `text-4xl font-bold` 기본 line-height(≈1.11)에서 굵은 한글/영문 디센더가 input 박스 아래로 잘리는 문제 해결

## 테스트 방법

`pnpm dev`(또는 `npm run dev`) 후:

1. `/notes/new` 진입
   - 제목 입력 중 `Enter` → submit 안 되고 본문 시작으로 포커스 이동
   - 제목에서 `↓` → 본문 시작
   - 본문 첫 줄에서 `↑` → 제목 포커스 + 페이지 최상단 스크롤
   - 본문 두 번째 줄 이상에서 `↑` → 본문 내 줄 이동(기존 동작 유지)
   - 제목에 `#LangChain 정리`처럼 디센더가 있는 문자열 붙여넣기 → `g` 잘림 없음
   - 본문을 길게 작성 후 우측 하단 저장 버튼 클릭 → 정상 저장 → 상세 페이지로 라우팅
2. `/notes` 목록을 아래로 스크롤한 상태에서 노트 카드 클릭 → 상세가 항상 최상단에서 시작
3. `npm run lint`, `npm run type-check` 통과

## 스크린샷 (FE 변경 시)

<img width="2880" height="1524" alt="image" src="https://github.com/user-attachments/assets/5ecca885-d47d-41dd-acd4-7eb957576575" />


## 체크리스트

- [x] 코드 컨벤션 준수
- [x] 커밋 메시지 컨벤션 준수
- [x] lint 통과
- [x] typecheck 통과
- [ ] (DB 변경 시) migration 포함 및 로컬 재현 확인 — 해당 없음
- [ ] (권한/RLS 영향 시) 정책 변경 요약 기재 — 해당 없음
- [x] UI 변경 시 스크린샷/짧은 설명 첨부
- [x] 셀프 리뷰 완료
