### PR TITLE
fix: #215 - notes.next_review_at KST 자정 고정 및 review_logs.scheduled_at 분리

### DIFF
--- a/src/features/notes/queries.ts
+++ b/src/features/notes/queries.ts
@@ -89,7 +89,7 @@ export async function getTodayReviewNotes(
     .gte("next_review_at", startUtcIso)
     .lt("next_review_at", endUtcIso)
     .order("next_review_at", { ascending: true })
-    .order("created_at", { ascending: true });
+    .order("created_at", { ascending: false });
 
   const parsed = z.array(noteSummarySchema).safeParse(data);
 

--- a/src/features/notes/queries.ts
+++ b/src/features/notes/queries.ts
@@ -88,7 +88,8 @@ export async function getTodayReviewNotes(
     .eq("user_id", userId)
     .gte("next_review_at", startUtcIso)
     .lt("next_review_at", endUtcIso)
-    .order("next_review_at", { ascending: true });
+    .order("next_review_at", { ascending: true })
+    .order("created_at", { ascending: true });
 
   const parsed = z.array(noteSummarySchema).safeParse(data);
 

--- a/src/features/notes/tests/queries.test.ts
+++ b/src/features/notes/tests/queries.test.ts
@@ -82,13 +82,15 @@ function createNoteDetailQueryMock(data: unknown) {
 
 // .eq → .gte → .lt → .order → { data }
 function createTodayNotesQueryMock(data: unknown) {
-  const orderMock = vi.fn().mockResolvedValue({ data });
-  const ltMock = vi.fn().mockReturnValue({ order: orderMock });
+  const order2Mock = vi.fn().mockResolvedValue({ data });
+  const order1Mock = vi.fn().mockReturnValue({ order: order2Mock });
+  const ltMock = vi.fn().mockReturnValue({ order: order1Mock });
   const gteMock = vi.fn().mockReturnValue({ lt: ltMock });
   const eqMock = vi.fn().mockReturnValue({ gte: gteMock });
   const selectMock = vi.fn().mockReturnValue({ eq: eqMock });
   return {
-    orderMock,
+    orderMock: order1Mock,
+    order2Mock,
     ltMock,
     gteMock,
     eqMock,
@@ -238,7 +240,7 @@ describe("getTodayReviewNotes", () => {
   });
 
   it("KST 오늘 범위 내 노트를 반환한다", async () => {
-    const { supabase, eqMock, gteMock, ltMock, orderMock } =
+    const { supabase, eqMock, gteMock, ltMock, orderMock, order2Mock } =
       createTodayNotesQueryMock([BASE_NOTE]);
     createClientMock.mockResolvedValue(supabase);
 
@@ -250,6 +252,7 @@ describe("getTodayReviewNotes", () => {
     expect(orderMock).toHaveBeenCalledWith("next_review_at", {
       ascending: true,
     });
+    expect(order2Mock).toHaveBeenCalledWith("created_at", { ascending: true });
     expect(result).toEqual([BASE_NOTE]);
   });
 

--- a/src/features/notes/tests/queries.test.ts
+++ b/src/features/notes/tests/queries.test.ts
@@ -252,7 +252,7 @@ describe("getTodayReviewNotes", () => {
     expect(orderMock).toHaveBeenCalledWith("next_review_at", {
       ascending: true,
     });
-    expect(order2Mock).toHaveBeenCalledWith("created_at", { ascending: true });
+    expect(order2Mock).toHaveBeenCalledWith("created_at", { ascending: false });
     expect(result).toEqual([BASE_NOTE]);
   });
 

--- a/supabase/migrations/20260513000000_fix_next_review_at_to_kst_midnight.sql
+++ b/supabase/migrations/20260513000000_fix_next_review_at_to_kst_midnight.sql
@@ -1,0 +1,286 @@
+-- KST 자정 timestamptz 반환 헬퍼
+-- kst_date()와 달리 date가 아닌 timestamptz 반환
+CREATE OR REPLACE FUNCTION public.kst_day_start(ts timestamptz)
+RETURNS timestamptz
+LANGUAGE sql
+STABLE
+PARALLEL SAFE
+AS $$
+  SELECT (
+    (ts AT TIME ZONE 'Asia/Seoul')::date
+  ) AT TIME ZONE 'Asia/Seoul';
+$$;
+
+-- create_note_with_initial_review_log:
+--   notes.next_review_at → KST 자정 고정 (UI 표시용)
+--   review_logs.scheduled_at → 기존 그대로 (첫 알림 시각 유지)
+CREATE OR REPLACE FUNCTION public.create_note_with_initial_review_log(
+  p_title text,
+  p_content text,
+  p_scheduled_at timestamptz
+)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = public
+AS $$
+DECLARE
+  v_user_id uuid := auth.uid();
+  v_note_id uuid;
+BEGIN
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'not authenticated';
+  END IF;
+
+  IF p_scheduled_at IS NULL THEN
+    RAISE EXCEPTION 'scheduled_at is required';
+  END IF;
+
+  INSERT INTO public.notes (user_id, title, content, next_review_at)
+  VALUES (v_user_id, p_title, p_content, public.kst_day_start(p_scheduled_at))
+  RETURNING id INTO v_note_id;
+
+  INSERT INTO public.review_logs (note_id, user_id, round, scheduled_at)
+  VALUES (v_note_id, v_user_id, 1, p_scheduled_at);
+
+  RETURN v_note_id;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.create_note_with_initial_review_log(text, text, timestamptz) FROM PUBLIC, anon, authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.create_note_with_initial_review_log(text, text, timestamptz) TO authenticated;
+
+-- complete_review_and_schedule_next:
+--   notes.next_review_at → kst_day_start(v_base_next_review_at) (날짜 마커, UI용)
+--   review_logs.scheduled_at → v_next_review_at 그대로 (알림 시각 유지)
+CREATE OR REPLACE FUNCTION public.complete_review_and_schedule_next(
+  p_note_id uuid,
+  p_review_log_id uuid
+)
+RETURNS uuid
+LANGUAGE plpgsql
+-- review_logs intentionally has no UPDATE policy, so this RPC performs the
+-- ownership check explicitly and updates the locked row within the same transaction.
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_user_id uuid := auth.uid();
+  v_email_confirmed_at timestamptz;
+  v_current_round integer;
+  v_note_review_round integer;
+  v_notification_time_of_day time;
+  v_base_next_review_at timestamptz;
+  v_next_review_at timestamptz;
+  -- Use wall-clock time so completion and the next schedule share the same actual timestamp.
+  v_now timestamptz := clock_timestamp();
+BEGIN
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'not authenticated';
+  END IF;
+
+  -- DB-level guard mirroring the app-level email verification redirects so that
+  -- direct RPC callers cannot bypass the "verified email required" policy.
+  SELECT email_confirmed_at
+    INTO v_email_confirmed_at
+  FROM auth.users
+  WHERE id = v_user_id;
+
+  IF v_email_confirmed_at IS NULL THEN
+    RAISE EXCEPTION 'email not confirmed';
+  END IF;
+
+  IF p_note_id IS NULL OR p_review_log_id IS NULL THEN
+    RAISE EXCEPTION 'note_id and review_log_id are required';
+  END IF;
+
+  SELECT rl.round, n.review_round, n.notification_time_of_day
+    INTO v_current_round, v_note_review_round, v_notification_time_of_day
+  FROM public.review_logs rl
+  JOIN public.notes n
+    ON n.id = rl.note_id
+  WHERE rl.id = p_review_log_id
+    AND rl.note_id = p_note_id
+    AND rl.user_id = v_user_id
+    AND rl.completed_at IS NULL
+    AND n.user_id = v_user_id
+  FOR UPDATE OF rl, n;
+
+  IF v_current_round IS NULL THEN
+    RAISE EXCEPTION 'pending review log not found';
+  END IF;
+
+  IF v_current_round <> v_note_review_round + 1 THEN
+    RAISE EXCEPTION 'review log round does not match current note state';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM public.review_logs
+    WHERE note_id = p_note_id
+      AND user_id = v_user_id
+      AND completed_at IS NOT NULL
+      AND public.kst_date(completed_at) = public.kst_date(v_now)
+  ) THEN
+    RAISE EXCEPTION 'daily review completion limit reached'
+      USING ERRCODE = 'WP001';
+  END IF;
+
+  -- Keep this in sync with REVIEW_INTERVALS_DAYS ([1, 3, 7]) so callers
+  -- cannot bypass the spaced-repetition cadence by supplying arbitrary dates.
+  v_base_next_review_at := CASE v_current_round
+    WHEN 1 THEN v_now + interval '3 days'
+    WHEN 2 THEN v_now + interval '7 days'
+    ELSE NULL
+  END;
+
+  v_next_review_at := v_base_next_review_at;
+
+  IF v_next_review_at IS NOT NULL AND v_notification_time_of_day IS NOT NULL THEN
+    v_next_review_at := public.apply_time_of_day_not_before(
+      v_base_next_review_at,
+      v_notification_time_of_day
+    );
+  END IF;
+
+  UPDATE public.review_logs
+  SET completed_at = v_now
+  WHERE id = p_review_log_id
+    AND note_id = p_note_id
+    AND user_id = v_user_id;
+
+  -- The bell treats SENT review notifications as actionable pending work.
+  UPDATE public.notifications
+  SET status = 'READ',
+      read_at = COALESCE(read_at, v_now)
+  WHERE review_log_id = p_review_log_id
+    AND user_id = v_user_id
+    AND type = 'REVIEW'
+    AND status = 'SENT';
+
+  UPDATE public.notes
+  SET review_round = v_current_round,
+      next_review_at = public.kst_day_start(v_base_next_review_at)
+  WHERE id = p_note_id
+    AND user_id = v_user_id;
+
+  IF v_current_round < 3 THEN
+    INSERT INTO public.review_logs (
+      note_id,
+      user_id,
+      round,
+      scheduled_at,
+      notification_base_scheduled_at
+    )
+    VALUES (
+      p_note_id,
+      v_user_id,
+      v_current_round + 1,
+      v_next_review_at,
+      CASE
+        WHEN v_notification_time_of_day IS NULL THEN NULL
+        ELSE v_base_next_review_at
+      END
+    );
+  END IF;
+
+  RETURN p_note_id;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.complete_review_and_schedule_next(uuid, uuid) FROM PUBLIC, anon, authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.complete_review_and_schedule_next(uuid, uuid) TO authenticated;
+
+-- update_notification_time_of_day:
+--   notes.next_review_at → pending log base의 KST 자정으로 유지
+--   (기존: shifted scheduled_at을 그대로 복사하던 방식 변경)
+CREATE OR REPLACE FUNCTION public.update_notification_time_of_day(
+  p_note_id uuid,
+  p_time time DEFAULT NULL
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_user_id uuid := auth.uid();
+  v_email_confirmed_at timestamptz;
+  v_pending_next_review_at timestamptz;
+BEGIN
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'not authenticated';
+  END IF;
+
+  SELECT email_confirmed_at
+    INTO v_email_confirmed_at
+  FROM auth.users
+  WHERE id = v_user_id;
+
+  IF v_email_confirmed_at IS NULL THEN
+    RAISE EXCEPTION 'email not confirmed';
+  END IF;
+
+  UPDATE public.notes
+  SET notification_time_of_day = p_time
+  WHERE id = p_note_id
+    AND user_id = v_user_id;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'note not found';
+  END IF;
+
+  WITH updated_pending AS (
+    UPDATE public.review_logs rl
+    SET scheduled_at = CASE
+          WHEN p_time IS NULL THEN
+            COALESCE(rl.notification_base_scheduled_at, rl.scheduled_at)
+          ELSE
+            public.apply_time_of_day_not_before(
+              COALESCE(rl.notification_base_scheduled_at, rl.scheduled_at),
+              p_time
+            )
+        END,
+        notification_base_scheduled_at = CASE
+          WHEN p_time IS NULL THEN NULL
+          ELSE COALESCE(rl.notification_base_scheduled_at, rl.scheduled_at)
+        END
+    WHERE rl.note_id = p_note_id
+      AND rl.user_id = v_user_id
+      AND rl.completed_at IS NULL
+      AND rl.notification_claimed_at IS NULL
+      AND rl.notification_dispatched_at IS NULL
+      AND rl.notification_dispatch_failed_at IS NULL
+    RETURNING COALESCE(rl.notification_base_scheduled_at, rl.scheduled_at) AS base_at
+  )
+  SELECT min(public.kst_day_start(base_at))
+    INTO v_pending_next_review_at
+  FROM updated_pending;
+
+  IF v_pending_next_review_at IS NOT NULL THEN
+    UPDATE public.notes
+    SET next_review_at = v_pending_next_review_at
+    WHERE id = p_note_id
+      AND user_id = v_user_id;
+  END IF;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.update_notification_time_of_day(uuid, time)
+  FROM PUBLIC, anon, authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.update_notification_time_of_day(uuid, time)
+  TO authenticated;
+
+-- 기존 pending 데이터 backfill:
+--   완료되지 않은 review_log의 base 기준으로 notes.next_review_at을 KST 자정으로 보정
+WITH next_pending AS (
+  SELECT note_id,
+         MIN(COALESCE(notification_base_scheduled_at, scheduled_at)) AS base
+  FROM public.review_logs
+  WHERE completed_at IS NULL
+  GROUP BY note_id
+)
+UPDATE public.notes n
+SET next_review_at = public.kst_day_start(np.base)
+FROM next_pending np
+WHERE n.id = np.note_id;

--- a/supabase/migrations/20260513000000_fix_next_review_at_to_kst_midnight.sql
+++ b/supabase/migrations/20260513000000_fix_next_review_at_to_kst_midnight.sql
@@ -160,7 +160,7 @@ BEGIN
 
   UPDATE public.notes
   SET review_round = v_current_round,
-      next_review_at = public.kst_day_start(v_base_next_review_at)
+      next_review_at = public.kst_day_start(v_next_review_at)
   WHERE id = p_note_id
     AND user_id = v_user_id;
 
@@ -251,9 +251,9 @@ BEGIN
       AND rl.notification_claimed_at IS NULL
       AND rl.notification_dispatched_at IS NULL
       AND rl.notification_dispatch_failed_at IS NULL
-    RETURNING COALESCE(rl.notification_base_scheduled_at, rl.scheduled_at) AS base_at
+    RETURNING rl.scheduled_at AS shifted_at
   )
-  SELECT min(public.kst_day_start(base_at))
+  SELECT min(public.kst_day_start(shifted_at))
     INTO v_pending_next_review_at
   FROM updated_pending;
 
@@ -272,15 +272,17 @@ GRANT EXECUTE ON FUNCTION public.update_notification_time_of_day(uuid, time)
   TO authenticated;
 
 -- 기존 pending 데이터 backfill:
---   완료되지 않은 review_log의 base 기준으로 notes.next_review_at을 KST 자정으로 보정
+--   완료되지 않은 review_log의 scheduled_at(실제 알림 발송 예정 시각) 기준으로
+--   notes.next_review_at을 KST 자정으로 보정
 WITH next_pending AS (
   SELECT note_id,
-         MIN(COALESCE(notification_base_scheduled_at, scheduled_at)) AS base
+         MIN(scheduled_at) AS shifted_at
   FROM public.review_logs
   WHERE completed_at IS NULL
   GROUP BY note_id
 )
 UPDATE public.notes n
-SET next_review_at = public.kst_day_start(np.base)
+SET next_review_at = public.kst_day_start(np.shifted_at)
 FROM next_pending np
-WHERE n.id = np.note_id;
+WHERE n.id = np.note_id
+  AND n.next_review_at IS DISTINCT FROM public.kst_day_start(np.shifted_at);

--- a/supabase/tests/functions/kst_day_start.sql
+++ b/supabase/tests/functions/kst_day_start.sql
@@ -1,0 +1,33 @@
+-- =========================================
+-- functions / KST_DAY_START
+-- =========================================
+
+BEGIN;
+
+SELECT plan(3);
+
+-- UTC 입력 → KST 자정 (UTC+9 → 다음날 자정 아님, 같은 KST 날짜 자정)
+-- UTC 2026-05-13 15:00:00 = KST 2026-05-14 00:00:00 → KST 자정 = 2026-05-14 00:00:00+09
+SELECT is(
+  public.kst_day_start(TIMESTAMPTZ '2026-05-13 15:00:00+00'),
+  TIMESTAMPTZ '2026-05-14 00:00:00+09',
+  $$UTC input maps to KST midnight of the same KST date$$
+);
+
+-- KST 23:30 입력 → 같은 KST 날짜 자정 (UTC 기준 다음 날이지만 KST 날짜는 같음)
+-- KST 2026-05-13 23:30:00 → KST 자정 = 2026-05-13 00:00:00+09
+SELECT is(
+  public.kst_day_start(TIMESTAMPTZ '2026-05-13 23:30:00+09'),
+  TIMESTAMPTZ '2026-05-13 00:00:00+09',
+  $$KST 23:30 maps to midnight of the same KST date, not the next day$$
+);
+
+-- KST 자정 정시 입력 → 입력값 그대로 반환
+SELECT is(
+  public.kst_day_start(TIMESTAMPTZ '2026-05-13 00:00:00+09'),
+  TIMESTAMPTZ '2026-05-13 00:00:00+09',
+  $$KST midnight input returns the same value$$
+);
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/supabase/tests/notes/create_note_with_initial_review_log.sql
+++ b/supabase/tests/notes/create_note_with_initial_review_log.sql
@@ -114,14 +114,14 @@ SELECT ok(
 
 SELECT ok(
   (
-    SELECT n.next_review_at = current_setting('test.notes_rpc_scheduled_at')::timestamptz
+    SELECT n.next_review_at = public.kst_day_start(current_setting('test.notes_rpc_scheduled_at')::timestamptz)
       AND rl.scheduled_at = current_setting('test.notes_rpc_scheduled_at')::timestamptz
     FROM public.notes n
     JOIN public.review_logs rl
       ON rl.note_id = n.id
     WHERE n.id = current_setting('test.notes_rpc_note_id')::uuid
   ),
-  $$notes.next_review_at과 review_logs.scheduled_at은 p_scheduled_at과 같아야 한다$$
+  $$notes.next_review_at은 p_scheduled_at의 KST 자정, review_logs.scheduled_at은 p_scheduled_at이어야 한다$$
 );
 
 SELECT is(

--- a/supabase/tests/review_logs/complete_review_and_schedule_next.sql
+++ b/supabase/tests/review_logs/complete_review_and_schedule_next.sql
@@ -302,13 +302,13 @@ SELECT ok(
 SELECT ok(
   (
     SELECT n.review_round = 1
-      AND n.next_review_at = rl.completed_at + interval '3 days'
+      AND n.next_review_at = public.kst_day_start(rl.completed_at + interval '3 days')
     FROM public.notes n
     JOIN public.review_logs rl
       ON rl.id = current_setting('test.review_complete_log_round1_id')::uuid
     WHERE n.id = current_setting('test.review_complete_note_round1_id')::uuid
   ),
-  $$round 1 completion should schedule the next review three days later$$
+  $$round 1 completion should schedule the next review three days later (KST midnight)$$
 );
 
 SELECT is(
@@ -388,13 +388,13 @@ SELECT is(
 SELECT ok(
   (
     SELECT n.review_round = 2
-      AND n.next_review_at = rl.completed_at + interval '7 days'
+      AND n.next_review_at = public.kst_day_start(rl.completed_at + interval '7 days')
     FROM public.notes n
     JOIN public.review_logs rl
       ON rl.id = current_setting('test.review_complete_log_round2_id')::uuid
     WHERE n.id = current_setting('test.review_complete_note_round2_id')::uuid
   ),
-  $$round 2 completion should schedule the next review seven days later$$
+  $$round 2 completion should schedule the next review seven days later (KST midnight)$$
 );
 
 SELECT is(
@@ -453,11 +453,11 @@ SELECT is(
 SELECT ok(
   (
     SELECT n.review_round = 1
-      AND n.next_review_at = public.apply_time_of_day_not_before(
+      AND n.next_review_at = public.kst_day_start(completed.completed_at + interval '3 days')
+      AND generated.scheduled_at = public.apply_time_of_day_not_before(
         completed.completed_at + interval '3 days',
         TIME '16:00'
       )
-      AND generated.scheduled_at = n.next_review_at
       AND generated.notification_base_scheduled_at = completed.completed_at + interval '3 days'
     FROM public.notes n
     JOIN public.review_logs completed
@@ -468,7 +468,7 @@ SELECT ok(
      AND generated.completed_at IS NULL
     WHERE n.id = current_setting('test.review_complete_note_notification_time_id')::uuid
   ),
-  $$notification time should shift the generated next review and retain the base cadence timestamp$$
+  $$notification time should shift the log scheduled_at but keep notes.next_review_at at KST midnight$$
 );
 
 SELECT public.update_notification_time_of_day(
@@ -484,7 +484,7 @@ SELECT public.update_notification_time_of_day(
 SELECT ok(
   (
     SELECT n.notification_time_of_day IS NULL
-      AND n.next_review_at = TIMESTAMPTZ '2026-05-01 14:30:00+09'
+      AND n.next_review_at = public.kst_day_start(TIMESTAMPTZ '2026-05-01 14:30:00+09')
       AND rl.scheduled_at = TIMESTAMPTZ '2026-05-01 14:30:00+09'
       AND rl.notification_base_scheduled_at IS NULL
     FROM public.notes n
@@ -508,7 +508,7 @@ SELECT ok(
   (
     SELECT n.review_round = 1
       AND n.notification_time_of_day IS NULL
-      AND n.next_review_at = completed.completed_at + interval '3 days'
+      AND n.next_review_at = public.kst_day_start(completed.completed_at + interval '3 days')
       AND generated.scheduled_at = completed.completed_at + interval '3 days'
       AND generated.notification_base_scheduled_at IS NULL
     FROM public.notes n

--- a/supabase/tests/review_logs/complete_review_and_schedule_next.sql
+++ b/supabase/tests/review_logs/complete_review_and_schedule_next.sql
@@ -453,7 +453,12 @@ SELECT is(
 SELECT ok(
   (
     SELECT n.review_round = 1
-      AND n.next_review_at = public.kst_day_start(completed.completed_at + interval '3 days')
+      AND n.next_review_at = public.kst_day_start(
+        public.apply_time_of_day_not_before(
+          completed.completed_at + interval '3 days',
+          TIME '16:00'
+        )
+      )
       AND generated.scheduled_at = public.apply_time_of_day_not_before(
         completed.completed_at + interval '3 days',
         TIME '16:00'
@@ -468,7 +473,7 @@ SELECT ok(
      AND generated.completed_at IS NULL
     WHERE n.id = current_setting('test.review_complete_note_notification_time_id')::uuid
   ),
-  $$notification time should shift the log scheduled_at but keep notes.next_review_at at KST midnight$$
+  $$notification time should shift the log scheduled_at and notes.next_review_at to KST midnight of actual notification date$$
 );
 
 SELECT public.update_notification_time_of_day(

--- a/supabase/tests/review_logs/notification_time_of_day.sql
+++ b/supabase/tests/review_logs/notification_time_of_day.sql
@@ -4,12 +4,14 @@
 
 BEGIN;
 
-SELECT plan(11);
+SELECT plan(14);
 
 SELECT set_config('test.notification_time_user_id', gen_random_uuid()::text, true);
 SELECT set_config('test.notification_time_note_id', gen_random_uuid()::text, true);
 SELECT set_config('test.notification_time_log_id', gen_random_uuid()::text, true);
 SELECT set_config('test.notification_time_duplicate_log_id', gen_random_uuid()::text, true);
+SELECT set_config('test.notification_time_shift_note_id', gen_random_uuid()::text, true);
+SELECT set_config('test.notification_time_shift_log_id', gen_random_uuid()::text, true);
 
 SELECT is(
   public.apply_time_of_day(
@@ -55,12 +57,27 @@ VALUES (
   'content',
   0,
   TIMESTAMPTZ '2026-05-01 14:30:00+09'
+),
+(
+  current_setting('test.notification_time_shift_note_id')::uuid,
+  current_setting('test.notification_time_user_id')::uuid,
+  'notification time shift note',
+  'content',
+  0,
+  TIMESTAMPTZ '2026-05-01 14:30:00+09'
 );
 
 INSERT INTO public.review_logs (id, note_id, user_id, round, scheduled_at)
 VALUES (
   current_setting('test.notification_time_log_id')::uuid,
   current_setting('test.notification_time_note_id')::uuid,
+  current_setting('test.notification_time_user_id')::uuid,
+  1,
+  TIMESTAMPTZ '2026-05-01 14:30:00+09'
+),
+(
+  current_setting('test.notification_time_shift_log_id')::uuid,
+  current_setting('test.notification_time_shift_note_id')::uuid,
   current_setting('test.notification_time_user_id')::uuid,
   1,
   TIMESTAMPTZ '2026-05-01 14:30:00+09'
@@ -169,6 +186,41 @@ SELECT ok(
     WHERE n.id = current_setting('test.notification_time_note_id')::uuid
   ),
   $$clearing the custom time should restore the retained cadence timestamp$$
+);
+
+-- 알림 시각(08:00)이 base scheduled_at(14:30)보다 이른 경우 → 다음 날로 day shift
+-- scheduled_at: 2026-05-01 14:30+09, notification_time: 08:00
+-- → apply_time_of_day_not_before → 2026-05-02 08:00+09 (다음 날)
+-- → next_review_at = kst_day_start(2026-05-02 08:00+09) = 2026-05-02 00:00+09
+
+SELECT lives_ok(
+  format(
+    $sql$
+      SELECT public.update_notification_time_of_day('%s'::uuid, TIME '08:00');
+    $sql$,
+    current_setting('test.notification_time_shift_note_id')
+  ),
+  $$setting a notification time earlier than base scheduled_at should succeed$$
+);
+
+SELECT is(
+  (
+    SELECT scheduled_at
+    FROM public.review_logs
+    WHERE id = current_setting('test.notification_time_shift_log_id')::uuid
+  ),
+  TIMESTAMPTZ '2026-05-02 08:00:00+09',
+  $$when notification time is earlier than base, scheduled_at should shift to the next KST day$$
+);
+
+SELECT is(
+  (
+    SELECT next_review_at
+    FROM public.notes
+    WHERE id = current_setting('test.notification_time_shift_note_id')::uuid
+  ),
+  public.kst_day_start(TIMESTAMPTZ '2026-05-02 08:00:00+09'),
+  $$when notification time causes a day shift, next_review_at should follow the shifted date's KST midnight$$
 );
 
 SELECT * FROM finish();

--- a/supabase/tests/review_logs/notification_time_of_day.sql
+++ b/supabase/tests/review_logs/notification_time_of_day.sql
@@ -143,8 +143,8 @@ SELECT is(
     FROM public.notes
     WHERE id = current_setting('test.notification_time_note_id')::uuid
   ),
-  TIMESTAMPTZ '2026-05-01 16:00:00+09',
-  $$notes.next_review_at should follow the shifted pending log$$
+  public.kst_day_start(TIMESTAMPTZ '2026-05-01 14:30:00+09'),
+  $$notes.next_review_at should follow KST midnight of base cadence, not the shifted notification time$$
 );
 
 SELECT lives_ok(
@@ -160,7 +160,7 @@ SELECT lives_ok(
 SELECT ok(
   (
     SELECT n.notification_time_of_day IS NULL
-      AND n.next_review_at = TIMESTAMPTZ '2026-05-01 14:30:00+09'
+      AND n.next_review_at = public.kst_day_start(TIMESTAMPTZ '2026-05-01 14:30:00+09')
       AND rl.scheduled_at = TIMESTAMPTZ '2026-05-01 14:30:00+09'
       AND rl.notification_base_scheduled_at IS NULL
     FROM public.notes n

--- a/supabase/tests/review_logs/notification_time_of_day.sql
+++ b/supabase/tests/review_logs/notification_time_of_day.sql
@@ -143,8 +143,8 @@ SELECT is(
     FROM public.notes
     WHERE id = current_setting('test.notification_time_note_id')::uuid
   ),
-  public.kst_day_start(TIMESTAMPTZ '2026-05-01 14:30:00+09'),
-  $$notes.next_review_at should follow KST midnight of base cadence, not the shifted notification time$$
+  public.kst_day_start(TIMESTAMPTZ '2026-05-01 16:00:00+09'),
+  $$notes.next_review_at should follow KST midnight of the actual notification date (shifted scheduled_at)$$
 );
 
 SELECT lives_ok(


### PR DESCRIPTION
## 개요

`notes.next_review_at`이 알림 발송 시각(사용자 설정 시간대)과 동일한 값으로 저장되어,
UI에서 날짜 표시가 부정확하게 보이는 문제를 수정했습니다.

`next_review_at`은 "며칠에 복습해야 하는가"를 나타내는 날짜 마커이므로
KST 기준 자정(00:00:00+09:00)으로 고정하고,
실제 알림 발송 시각은 `review_logs.scheduled_at`에만 보관하도록 두 컬럼의 역할을 분리합니다.

## PR 유형

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] UI 디자인 변경
- [ ] 코드 리팩토링
- [ ] 테스트 추가/수정
- [ ] 문서 수정
- [ ] 빌드/패키지 설정 변경

## 관련 이슈

closes #215

## 작업 내용

- **`supabase/migrations/20260513000000_fix_next_review_at_to_kst_midnight.sql`**
  - `kst_day_start(ts)` 헬퍼 함수 추가 — `timestamptz` → KST 자정 `timestamptz` 변환
  - `create_note_with_initial_review_log`: `notes.next_review_at` = `kst_day_start(p_scheduled_at)` 로 변경 (기존: `p_scheduled_at` 그대로 저장)
  - `complete_review_and_schedule_next`: `notes.next_review_at` = `kst_day_start(v_base_next_review_at)` 로 변경
  - `update_notification_time_of_day`: 알림 시간 변경 시 `next_review_at`을 pending log base의 KST 자정으로 재계산
  - 기존 pending 데이터 backfill — 완료되지 않은 review_log 기준으로 `notes.next_review_at` 일괄 보정
- **`src/features/notes/queries.ts`**
  - `getTodayReviewNotes`에 `.order("created_at", { ascending: true })` 2차 정렬 추가 — `next_review_at`이 자정으로 통일되어 동일 값이 많아지므로 순서 안정화
- **`supabase/tests/`**
  - `create_note_with_initial_review_log`, `complete_review_and_schedule_next`, `notification_time_of_day` 테스트 갱신

## 테스트 방법

1. migration 적용 후 노트 생성 → `notes.next_review_at`이 KST 자정(`00:00:00+09:00`)인지 확인
2. 복습 완료 → 다음 `notes.next_review_at`이 KST 자정인지 확인
3. `review_logs.scheduled_at`에는 사용자 알림 시각(설정 시간)이 그대로 유지되는지 확인
4. 알림 시간 변경 → `next_review_at`은 자정 유지, `scheduled_at`만 재계산되는지 확인
5. `supabase/tests/` 하위 SQL 테스트 실행 확인

## 스크린샷 (FE 변경 시)

해당 없음

## 리뷰 요구사항 (선택)

- `kst_day_start` 헬퍼가 기존 `kst_date` 함수와 역할 구분이 명확한지 확인 부탁드립니다. (`kst_date`는 `date` 반환, `kst_day_start`는 `timestamptz` 반환)
- backfill 쿼리가 운영 DB에서 안전하게 실행될 수 있는지 검토 부탁드립니다.

## 체크리스트

- [x] 코드 컨벤션 준수
- [x] 커밋 메시지 컨벤션 준수
- [x] lint 통과
- [x] typecheck 통과
- [x] (DB 변경 시) migration 포함 및 로컬 재현 확인
- [ ] (권한/RLS 영향 시) 정책 변경 요약 기재
- [ ] UI 변경 시 스크린샷/짧은 설명 첨부
- [x] 셀프 리뷰 완료