### PR TITLE
Refactor/214 delete the bell list along with the notes

### DIFF
--- a/src/features/notifications/components/NotificationList.tsx
+++ b/src/features/notifications/components/NotificationList.tsx
@@ -63,9 +63,7 @@ export function NotificationList({
     <ul className="max-h-96 overflow-y-auto" aria-label="알림 목록">
       {items.map((item) => {
         const description = getNotificationDescription(item);
-        const reviewHref = item.note_id
-          ? getNoteReviewRoute(item.note_id)
-          : null;
+        const reviewHref = getNoteReviewRoute(item.note_id);
         const content = (
           <div className="min-w-0">
             <div className="flex items-center gap-2">
@@ -90,19 +88,15 @@ export function NotificationList({
             key={item.id}
             className="flex items-start gap-2 border-t border-border/60 px-4 py-3 transition-colors hover:bg-muted/40"
           >
-            {reviewHref ? (
-              <Link
-                href={reviewHref}
-                className="min-w-0 flex-1"
-                onClick={() => {
-                  onItemNavigate?.();
-                }}
-              >
-                {content}
-              </Link>
-            ) : (
-              <div className="min-w-0 flex-1">{content}</div>
-            )}
+            <Link
+              href={reviewHref}
+              className="min-w-0 flex-1"
+              onClick={() => {
+                onItemNavigate?.();
+              }}
+            >
+              {content}
+            </Link>
           </li>
         );
       })}

--- a/src/features/notifications/schema.ts
+++ b/src/features/notifications/schema.ts
@@ -20,7 +20,7 @@ export const notificationListItemSchema = z.object({
   status: notificationStatusSchema,
   sent_at: z.string(),
   read_at: z.string().nullable(),
-  note_id: notificationUuidSchema.nullable(),
+  note_id: notificationUuidSchema,
   review_log_id: notificationUuidSchema.nullable(),
   noteTitle: z.string().nullable(),
 });

--- a/src/features/notifications/tests/queries.test.ts
+++ b/src/features/notifications/tests/queries.test.ts
@@ -233,6 +233,26 @@ describe("notification queries", () => {
         status: "SENT",
         sent_at: "2026-04-27T01:00:00.000Z",
         read_at: null,
+        note_id: "33333333-3333-4333-8333-333333333333",
+        review_log_id: null,
+        note: null,
+      },
+    ]);
+    createServerComponentClientMock.mockResolvedValue(supabase);
+
+    await expect(getNotificationList()).rejects.toThrow();
+  });
+
+  it("throws when a review notification list row has no note id", async () => {
+    const { supabase } = createNotificationListMock([
+      {
+        id: "22222222-2222-4222-8222-222222222222",
+        title: "Review due",
+        body: null,
+        type: "REVIEW",
+        status: "SENT",
+        sent_at: "2026-04-27T01:00:00.000Z",
+        read_at: null,
         note_id: null,
         review_log_id: null,
         note: null,

--- a/src/features/notifications/tests/schema.test.ts
+++ b/src/features/notifications/tests/schema.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import { NOTIFICATION_STATUS } from "@/lib/constants/notifications";
 
 import {
+  notificationListItemSchema,
   notificationStatusSchema,
   notificationTimeSchema,
   pushSubscriptionSchema,
@@ -18,6 +19,33 @@ describe("notificationStatusSchema", () => {
 
   it("rejects the removed skipped status", () => {
     expect(notificationStatusSchema.safeParse("SKIPPED").success).toBe(false);
+  });
+});
+
+describe("notificationListItemSchema", () => {
+  const baseNotification = {
+    id: "11111111-1111-4111-8111-111111111111",
+    title: "Review due",
+    body: null,
+    type: "REVIEW",
+    status: NOTIFICATION_STATUS.SENT,
+    sent_at: "2026-04-27T01:00:00.000Z",
+    read_at: null,
+    note_id: "22222222-2222-4222-8222-222222222222",
+    review_log_id: null,
+    noteTitle: "Interval note",
+  };
+
+  it("requires a note id for review notification list items", () => {
+    expect(notificationListItemSchema.safeParse(baseNotification).success).toBe(
+      true,
+    );
+    expect(
+      notificationListItemSchema.safeParse({
+        ...baseNotification,
+        note_id: null,
+      }).success,
+    ).toBe(false);
   });
 });
 

--- a/supabase/migrations/20260513000000_delete_notifications_for_deleted_notes.sql
+++ b/supabase/migrations/20260513000000_delete_notifications_for_deleted_notes.sql
@@ -1,0 +1,40 @@
+BEGIN;
+
+-- Orphan REVIEW notifications cannot navigate to a note or be completed, so remove them before enforcing note ownership.
+DO $$
+DECLARE
+  v_deleted_count integer;
+BEGIN
+  DELETE FROM public.notifications
+  WHERE type = 'REVIEW'
+    AND note_id IS NULL;
+
+  GET DIAGNOSTICS v_deleted_count = ROW_COUNT;
+  RAISE NOTICE 'Deleted % orphan REVIEW notifications before enforcing note_id constraints.', v_deleted_count;
+END $$;
+
+ALTER TABLE public.notifications
+  DROP CONSTRAINT IF EXISTS notifications_note_id_fkey;
+
+ALTER TABLE public.notifications
+  ADD CONSTRAINT notifications_note_id_fkey
+  FOREIGN KEY (note_id)
+  REFERENCES public.notes(id)
+  ON DELETE CASCADE
+  NOT VALID;
+
+ALTER TABLE public.notifications
+  VALIDATE CONSTRAINT notifications_note_id_fkey;
+
+ALTER TABLE public.notifications
+  DROP CONSTRAINT IF EXISTS notifications_review_note_id_not_null_check;
+
+ALTER TABLE public.notifications
+  ADD CONSTRAINT notifications_review_note_id_not_null_check
+  CHECK (type <> 'REVIEW' OR note_id IS NOT NULL)
+  NOT VALID;
+
+ALTER TABLE public.notifications
+  VALIDATE CONSTRAINT notifications_review_note_id_not_null_check;
+
+COMMIT;

--- a/supabase/tests/notifications/constraints_check.sql
+++ b/supabase/tests/notifications/constraints_check.sql
@@ -54,7 +54,7 @@ VALUES (
   current_setting('test.notifications_constraints_check_notification_seed_id')::uuid,
   current_setting('test.notifications_constraints_check_user_a_id')::uuid,
   NULL,
-  'REVIEW',
+  'ALERT',
   'seed title',
   'seed body',
   'SENT'
@@ -65,7 +65,7 @@ ON CONFLICT (id) DO NOTHING;
 -- status가 'SENT'이면 INSERT가 성공해야 한다
 SAVEPOINT notifications_status_insert_sent;
 INSERT INTO public.notifications (id, user_id, type, title, status)
-VALUES (gen_random_uuid(), current_setting('test.notifications_constraints_check_user_a_id')::uuid, 'REVIEW', 'sent ok', 'SENT');
+VALUES (gen_random_uuid(), current_setting('test.notifications_constraints_check_user_a_id')::uuid, 'ALERT', 'sent ok', 'SENT');
 
 SELECT is(
   (SELECT count(*) FROM public.notifications WHERE title = 'sent ok'),
@@ -77,7 +77,7 @@ ROLLBACK TO SAVEPOINT notifications_status_insert_sent;
 -- status가 'READ'이면 INSERT가 성공해야 한다
 SAVEPOINT notifications_status_insert_read;
 INSERT INTO public.notifications (id, user_id, type, title, status)
-VALUES (gen_random_uuid(), current_setting('test.notifications_constraints_check_user_a_id')::uuid, 'REVIEW', 'read ok', 'READ');
+VALUES (gen_random_uuid(), current_setting('test.notifications_constraints_check_user_a_id')::uuid, 'ALERT', 'read ok', 'READ');
 
 SELECT is(
   (SELECT count(*) FROM public.notifications WHERE title = 'read ok'),
@@ -90,7 +90,7 @@ ROLLBACK TO SAVEPOINT notifications_status_insert_read;
 SELECT throws_ok(
   $sql$
     INSERT INTO public.notifications (id, user_id, type, title, status)
-    VALUES (gen_random_uuid(), current_setting('test.notifications_constraints_check_user_a_id')::uuid, 'REVIEW', 'skipped blocked', 'SKIPPED');
+    VALUES (gen_random_uuid(), current_setting('test.notifications_constraints_check_user_a_id')::uuid, 'ALERT', 'skipped blocked', 'SKIPPED');
   $sql$,
   '23514',
   'new row for relation "notifications" violates check constraint "notifications_status_check"',
@@ -143,7 +143,7 @@ SELECT throws_ok(
 SELECT throws_ok(
   $sql$
     INSERT INTO public.notifications (id, user_id, type, title, status)
-    VALUES (gen_random_uuid(), current_setting('test.notifications_constraints_check_user_a_id')::uuid, 'REVIEW', 'invalid status', 'FAILED');
+    VALUES (gen_random_uuid(), current_setting('test.notifications_constraints_check_user_a_id')::uuid, 'ALERT', 'invalid status', 'FAILED');
   $sql$,
   '23514',
   'new row for relation "notifications" violates check constraint "notifications_status_check"',
@@ -154,7 +154,7 @@ SELECT throws_ok(
 SELECT throws_ok(
   $sql$
     INSERT INTO public.notifications (id, user_id, type, title, status)
-    VALUES (gen_random_uuid(), current_setting('test.notifications_constraints_check_user_a_id')::uuid, 'REVIEW', 'lowercase status', 'sent');
+    VALUES (gen_random_uuid(), current_setting('test.notifications_constraints_check_user_a_id')::uuid, 'ALERT', 'lowercase status', 'sent');
   $sql$,
   '23514',
   'new row for relation "notifications" violates check constraint "notifications_status_check"',
@@ -165,7 +165,7 @@ SELECT throws_ok(
 SELECT throws_ok(
   $sql$
     INSERT INTO public.notifications (id, user_id, type, title, status)
-    VALUES (gen_random_uuid(), current_setting('test.notifications_constraints_check_user_a_id')::uuid, 'REVIEW', 'spaced status', ' SENT');
+    VALUES (gen_random_uuid(), current_setting('test.notifications_constraints_check_user_a_id')::uuid, 'ALERT', 'spaced status', ' SENT');
   $sql$,
   '23514',
   'new row for relation "notifications" violates check constraint "notifications_status_check"',
@@ -176,7 +176,7 @@ SELECT throws_ok(
 SELECT throws_ok(
   $sql$
     INSERT INTO public.notifications (id, user_id, type, title, status)
-    VALUES (gen_random_uuid(), current_setting('test.notifications_constraints_check_user_a_id')::uuid, 'REVIEW', 'empty status', '');
+    VALUES (gen_random_uuid(), current_setting('test.notifications_constraints_check_user_a_id')::uuid, 'ALERT', 'empty status', '');
   $sql$,
   '23514',
   'new row for relation "notifications" violates check constraint "notifications_status_check"',
@@ -291,7 +291,7 @@ ROLLBACK TO SAVEPOINT notifications_status_invalid_update_transition;
 -- 정확히 'SENT'는 허용값 경계로서 성공해야 한다
 SAVEPOINT notifications_status_boundary_sent;
 INSERT INTO public.notifications (id, user_id, type, title, status)
-VALUES (gen_random_uuid(), current_setting('test.notifications_constraints_check_user_a_id')::uuid, 'REVIEW', 'boundary sent', 'SENT');
+VALUES (gen_random_uuid(), current_setting('test.notifications_constraints_check_user_a_id')::uuid, 'ALERT', 'boundary sent', 'SENT');
 
 SELECT is(
   (SELECT count(*) FROM public.notifications WHERE title = 'boundary sent'),
@@ -303,7 +303,7 @@ ROLLBACK TO SAVEPOINT notifications_status_boundary_sent;
 -- 정확히 'READ'는 허용값 경계로서 성공해야 한다
 SAVEPOINT notifications_status_boundary_read;
 INSERT INTO public.notifications (id, user_id, type, title, status)
-VALUES (gen_random_uuid(), current_setting('test.notifications_constraints_check_user_a_id')::uuid, 'REVIEW', 'boundary read', 'READ');
+VALUES (gen_random_uuid(), current_setting('test.notifications_constraints_check_user_a_id')::uuid, 'ALERT', 'boundary read', 'READ');
 
 SELECT is(
   (SELECT count(*) FROM public.notifications WHERE title = 'boundary read'),
@@ -316,7 +316,7 @@ ROLLBACK TO SAVEPOINT notifications_status_boundary_read;
 SELECT throws_ok(
   $sql$
     INSERT INTO public.notifications (id, user_id, type, title, status)
-    VALUES (gen_random_uuid(), current_setting('test.notifications_constraints_check_user_a_id')::uuid, 'REVIEW', 'boundary skipped', 'SKIPPED');
+    VALUES (gen_random_uuid(), current_setting('test.notifications_constraints_check_user_a_id')::uuid, 'ALERT', 'boundary skipped', 'SKIPPED');
   $sql$,
   '23514',
   'new row for relation "notifications" violates check constraint "notifications_status_check"',

--- a/supabase/tests/notifications/constraints_default.sql
+++ b/supabase/tests/notifications/constraints_default.sql
@@ -55,7 +55,7 @@ INSERT INTO public.notifications (
 VALUES (
   current_setting('test.notifications_constraints_default_notification_seed_id')::uuid,
   current_setting('test.notifications_constraints_default_user_a_id')::uuid,
-  'REVIEW',
+  'ALERT',
   'seed title',
   'SENT',
   now()
@@ -74,7 +74,7 @@ INSERT INTO public.notifications (
 )
 VALUES (
   current_setting('test.notifications_constraints_default_user_a_id')::uuid,
-  'REVIEW',
+  'ALERT',
   'default id',
   'SENT',
   now()
@@ -98,7 +98,7 @@ INSERT INTO public.notifications (
 VALUES (
   current_setting('test.notifications_constraints_default_status_id')::uuid,
   current_setting('test.notifications_constraints_default_user_a_id')::uuid,
-  'REVIEW',
+  'ALERT',
   'default status',
   now()
 );
@@ -123,7 +123,7 @@ INSERT INTO public.notifications (
 VALUES (
   current_setting('test.notifications_constraints_default_sent_at_id')::uuid,
   current_setting('test.notifications_constraints_default_user_a_id')::uuid,
-  'REVIEW',
+  'ALERT',
   'default sent_at',
   'SENT'
 );
@@ -147,7 +147,7 @@ ROLLBACK TO SAVEPOINT notifications_default_sent_at;
 SELECT throws_ok(
   $sql$
     INSERT INTO public.notifications (id, user_id, type, title, status, sent_at)
-    VALUES (NULL, current_setting('test.notifications_constraints_default_user_a_id')::uuid, 'REVIEW', 'null id', 'SENT', now());
+    VALUES (NULL, current_setting('test.notifications_constraints_default_user_a_id')::uuid, 'ALERT', 'null id', 'SENT', now());
   $sql$,
   '23502',
   'null value in column "id" of relation "notifications" violates not-null constraint',
@@ -158,7 +158,7 @@ SELECT throws_ok(
 SELECT throws_ok(
   $sql$
     INSERT INTO public.notifications (id, user_id, type, title, status, sent_at)
-    VALUES (gen_random_uuid(), current_setting('test.notifications_constraints_default_user_a_id')::uuid, 'REVIEW', 'null status', NULL, now());
+    VALUES (gen_random_uuid(), current_setting('test.notifications_constraints_default_user_a_id')::uuid, 'ALERT', 'null status', NULL, now());
   $sql$,
   '23502',
   'null value in column "status" of relation "notifications" violates not-null constraint',
@@ -169,7 +169,7 @@ SELECT throws_ok(
 SELECT throws_ok(
   $sql$
     INSERT INTO public.notifications (id, user_id, type, title, status, sent_at)
-    VALUES (gen_random_uuid(), current_setting('test.notifications_constraints_default_user_a_id')::uuid, 'REVIEW', 'null sent_at', 'SENT', NULL);
+    VALUES (gen_random_uuid(), current_setting('test.notifications_constraints_default_user_a_id')::uuid, 'ALERT', 'null sent_at', 'SENT', NULL);
   $sql$,
   '23502',
   'null value in column "sent_at" of relation "notifications" violates not-null constraint',
@@ -188,7 +188,7 @@ DO $$
 BEGIN
   BEGIN
     INSERT INTO public.notifications (id, user_id, type, title, status, sent_at)
-    VALUES (NULL, current_setting('test.notifications_constraints_default_user_a_id')::uuid, 'REVIEW', 'transition null id', 'SENT', now());
+    VALUES (NULL, current_setting('test.notifications_constraints_default_user_a_id')::uuid, 'ALERT', 'transition null id', 'SENT', now());
   EXCEPTION
     WHEN not_null_violation THEN
       NULL;

--- a/supabase/tests/notifications/constraints_not_null.sql
+++ b/supabase/tests/notifications/constraints_not_null.sql
@@ -77,7 +77,7 @@ VALUES (
   current_setting('test.notifications_constraints_not_null_notification_seed_id')::uuid,
   current_setting('test.notifications_constraints_not_null_user_a_id')::uuid,
   NULL,
-  'REVIEW',
+  'ALERT',
   'seed title',
   'seed body',
   'SENT',
@@ -126,7 +126,7 @@ INSERT INTO public.notifications (
 VALUES (
   current_setting('test.notifications_constraints_not_null_read_at_null_id')::uuid,
   current_setting('test.notifications_constraints_not_null_user_a_id')::uuid,
-  'REVIEW',
+  'ALERT',
   'read_at null',
   'SENT',
   now(),
@@ -229,7 +229,7 @@ INSERT INTO public.notifications (
 VALUES (
   current_setting('test.notifications_constraints_not_null_notification_insert_explicit_id')::uuid,
   current_setting('test.notifications_constraints_not_null_user_a_id')::uuid,
-  'REVIEW',
+  'ALERT',
   'explicit id',
   'SENT',
   now()
@@ -247,7 +247,7 @@ ROLLBACK TO SAVEPOINT notifications_not_null_insert_explicit_id;
 SELECT throws_ok(
   $sql$
     INSERT INTO public.notifications (id, user_id, type, title, status, sent_at)
-    VALUES (NULL, current_setting('test.notifications_constraints_not_null_user_a_id')::uuid, 'REVIEW', 'null id', 'SENT', now());
+    VALUES (NULL, current_setting('test.notifications_constraints_not_null_user_a_id')::uuid, 'ALERT', 'null id', 'SENT', now());
   $sql$,
   '23502',
   'null value in column "id" of relation "notifications" violates not-null constraint',
@@ -258,7 +258,7 @@ SELECT throws_ok(
 SELECT throws_ok(
   $sql$
     INSERT INTO public.notifications (id, user_id, type, title, status, sent_at)
-    VALUES (gen_random_uuid(), NULL, 'REVIEW', 'null user', 'SENT', now());
+    VALUES (gen_random_uuid(), NULL, 'ALERT', 'null user', 'SENT', now());
   $sql$,
   '23502',
   'null value in column "user_id" of relation "notifications" violates not-null constraint',
@@ -280,7 +280,7 @@ SELECT throws_ok(
 SELECT throws_ok(
   $sql$
     INSERT INTO public.notifications (id, user_id, type, title, status, sent_at)
-    VALUES (gen_random_uuid(), current_setting('test.notifications_constraints_not_null_user_a_id')::uuid, 'REVIEW', NULL, 'SENT', now());
+    VALUES (gen_random_uuid(), current_setting('test.notifications_constraints_not_null_user_a_id')::uuid, 'ALERT', NULL, 'SENT', now());
   $sql$,
   '23502',
   'null value in column "title" of relation "notifications" violates not-null constraint',
@@ -291,7 +291,7 @@ SELECT throws_ok(
 SELECT throws_ok(
   $sql$
     INSERT INTO public.notifications (id, user_id, type, title, status, sent_at)
-    VALUES (gen_random_uuid(), current_setting('test.notifications_constraints_not_null_user_a_id')::uuid, 'REVIEW', 'null status', NULL, now());
+    VALUES (gen_random_uuid(), current_setting('test.notifications_constraints_not_null_user_a_id')::uuid, 'ALERT', 'null status', NULL, now());
   $sql$,
   '23502',
   'null value in column "status" of relation "notifications" violates not-null constraint',
@@ -302,7 +302,7 @@ SELECT throws_ok(
 SELECT throws_ok(
   $sql$
     INSERT INTO public.notifications (id, user_id, type, title, status, sent_at)
-    VALUES (gen_random_uuid(), current_setting('test.notifications_constraints_not_null_user_a_id')::uuid, 'REVIEW', 'null sent_at', 'SENT', NULL);
+    VALUES (gen_random_uuid(), current_setting('test.notifications_constraints_not_null_user_a_id')::uuid, 'ALERT', 'null sent_at', 'SENT', NULL);
   $sql$,
   '23502',
   'null value in column "sent_at" of relation "notifications" violates not-null constraint',
@@ -439,7 +439,7 @@ INSERT INTO public.notifications (
 VALUES (
   gen_random_uuid(),
   current_setting('test.notifications_constraints_not_null_user_a_id')::uuid,
-  'REVIEW',
+  'ALERT',
   'T',
   'SENT',
   now()
@@ -465,7 +465,7 @@ INSERT INTO public.notifications (
 VALUES (
   gen_random_uuid(),
   current_setting('test.notifications_constraints_not_null_user_a_id')::uuid,
-  'REVIEW',
+  'ALERT',
   'boundary status',
   'SENT',
   now()
@@ -491,7 +491,7 @@ INSERT INTO public.notifications (
 VALUES (
   gen_random_uuid(),
   current_setting('test.notifications_constraints_not_null_user_a_id')::uuid,
-  'REVIEW',
+  'ALERT',
   'boundary sent_at',
   'READ',
   now()
@@ -516,7 +516,7 @@ INSERT INTO public.notifications (
 VALUES (
   gen_random_uuid(),
   current_setting('test.notifications_constraints_not_null_user_a_id')::uuid,
-  'REVIEW',
+  'ALERT',
   'boundary user',
   'READ',
   now()
@@ -542,7 +542,7 @@ INSERT INTO public.notifications (
 VALUES (
   gen_random_uuid(),
   current_setting('test.notifications_constraints_not_null_user_a_id')::uuid,
-  'REVIEW',
+  'ALERT',
   'boundary id',
   'READ',
   now()
@@ -559,7 +559,7 @@ ROLLBACK TO SAVEPOINT notifications_not_null_boundary_id;
 SELECT throws_ok(
   $sql$
     INSERT INTO public.notifications (id, user_id, type, title, status, sent_at)
-    VALUES (NULL, current_setting('test.notifications_constraints_not_null_user_a_id')::uuid, 'REVIEW', 'default null', NULL, NULL);
+    VALUES (NULL, current_setting('test.notifications_constraints_not_null_user_a_id')::uuid, 'ALERT', 'default null', NULL, NULL);
   $sql$,
   '23502',
   'null value in column "id" of relation "notifications" violates not-null constraint',
@@ -595,7 +595,7 @@ SELECT results_eq(
   ),
   format(
     $sql$
-      SELECT '%s'::text, 'REVIEW'::text, 'seed title'::text, 'SENT'::text,
+      SELECT '%s'::text, 'ALERT'::text, 'seed title'::text, 'SENT'::text,
              sent_at::text
       FROM public.notifications
       WHERE id = '%s'::uuid

--- a/supabase/tests/notifications/fk_note.sql
+++ b/supabase/tests/notifications/fk_note.sql
@@ -5,7 +5,6 @@
 
 BEGIN;
 
--- TODO: fix plan count after schema is finalized
 SELECT plan(16);
 
 -- 테스트용 UUID 준비
@@ -173,41 +172,33 @@ SELECT is(
 );
 ROLLBACK TO SAVEPOINT notifications_note_fk_insert_ok;
 
--- note_id = NULL인 notifications INSERT는 허용되어야 한다.
-SAVEPOINT notifications_note_fk_insert_null_ok;
-INSERT INTO public.notifications (
-  id,
-  user_id,
-  note_id,
-  type,
-  title
-)
-VALUES (
-  current_setting('test.notifications_fk_note_insert_note_null_id')::uuid,
-  current_setting('test.notifications_fk_note_user_a_id')::uuid,
+-- REVIEW notifications는 note_id 없이 생성될 수 없어야 한다.
+SELECT throws_ok(
+  format(
+    $sql$
+      INSERT INTO public.notifications (id, user_id, note_id, type, title)
+      VALUES ('%s'::uuid, '%s'::uuid, NULL, 'REVIEW', 'null review note');
+    $sql$,
+    current_setting('test.notifications_fk_note_insert_note_null_id'),
+    current_setting('test.notifications_fk_note_user_a_id')
+  ),
+  '23514',
   NULL,
-  'REVIEW',
-  'null ok'
+  $$REVIEW notifications는 note_id 없이 생성될 수 없어야 한다.$$
 );
 
-SELECT is(
-  (SELECT count(*) FROM public.notifications WHERE id = current_setting('test.notifications_fk_note_insert_note_null_id')::uuid),
-  1::bigint,
-  $$note_id = NULL인 notifications INSERT는 허용되어야 한다.$$
-);
-ROLLBACK TO SAVEPOINT notifications_note_fk_insert_null_ok;
-
--- 부모 note_a 삭제 시 이를 참조하던 notifications 행 자체는 유지되어야 하며 note_id만 NULL로 변경되어야 한다.
-SAVEPOINT notifications_note_fk_delete_set_null;
+-- 부모 note_a 삭제 시 이를 참조하던 notifications 행도 함께 삭제되어야 한다.
+SAVEPOINT notifications_note_fk_delete_cascade;
 DELETE FROM public.notes
 WHERE id = current_setting('test.notifications_fk_note_note_a_id')::uuid;
 
 SELECT ok(
-  (
-    (SELECT count(*) FROM public.notifications WHERE id = current_setting('test.notifications_fk_note_a1_id')::uuid) = 1
-    AND (SELECT note_id FROM public.notifications WHERE id = current_setting('test.notifications_fk_note_a1_id')::uuid) IS NULL
+  NOT EXISTS (
+    SELECT 1
+    FROM public.notifications
+    WHERE id = current_setting('test.notifications_fk_note_a1_id')::uuid
   ),
-  $$부모 note_a 삭제 시 이를 참조하던 notifications 행 자체는 유지되어야 하며 note_id만 NULL로 변경되어야 한다.$$
+  $$부모 note_a 삭제 시 이를 참조하던 notifications 행도 함께 삭제되어야 한다.$$
 );
 
 -- 삭제되지 않은 다른 note를 참조하던 notifications는 그대로 유지되어야 한다.
@@ -219,7 +210,7 @@ SELECT ok(
   ),
   $$삭제되지 않은 다른 note를 참조하던 notifications는 그대로 유지되어야 한다.$$
 );
-ROLLBACK TO SAVEPOINT notifications_note_fk_delete_set_null;
+ROLLBACK TO SAVEPOINT notifications_note_fk_delete_cascade;
 
 -- [예외 조건]
 -- 존재하지 않는 public.notes.id를 note_id로 참조하는 notifications INSERT/UPDATE는 허용되지 않아야 한다.
@@ -303,29 +294,20 @@ SELECT is(
 ROLLBACK TO SAVEPOINT notifications_note_fk_update_valid;
 
 -- [경계 조건]
--- note_id = NULL인 최소 형태 notifications INSERT는 허용되어야 한다.
-SAVEPOINT notifications_note_fk_min_insert;
-INSERT INTO public.notifications (
-  id,
-  user_id,
-  note_id,
-  type,
-  title
-)
-VALUES (
-  current_setting('test.notifications_fk_note_insert_note_min_id')::uuid,
-  current_setting('test.notifications_fk_note_user_a_id')::uuid,
+-- REVIEW notifications는 최소 형태에서도 note_id를 생략할 수 없어야 한다.
+SELECT throws_ok(
+  format(
+    $sql$
+      INSERT INTO public.notifications (id, user_id, note_id, type, title)
+      VALUES ('%s'::uuid, '%s'::uuid, NULL, 'REVIEW', 'min note null');
+    $sql$,
+    current_setting('test.notifications_fk_note_insert_note_min_id'),
+    current_setting('test.notifications_fk_note_user_a_id')
+  ),
+  '23514',
   NULL,
-  'REVIEW',
-  'min note null'
+  $$REVIEW notifications는 최소 형태에서도 note_id를 생략할 수 없어야 한다.$$
 );
-
-SELECT is(
-  (SELECT count(*) FROM public.notifications WHERE id = current_setting('test.notifications_fk_note_insert_note_min_id')::uuid),
-  1::bigint,
-  $$note_id = NULL인 최소 형태 notifications INSERT는 허용되어야 한다.$$
-);
-ROLLBACK TO SAVEPOINT notifications_note_fk_min_insert;
 
 -- 유효한 note_id를 포함한 최대 형태 notifications INSERT는 허용되어야 한다.
 SAVEPOINT notifications_note_fk_max_insert;
@@ -375,27 +357,34 @@ SELECT throws_ok(
   $$존재하지 않는 임의 UUID를 note_id로 사용하는 경우는 차단되어야 한다.$$
 );
 
--- 한 note를 여러 notifications가 참조하더라도 부모 note 삭제 시 관련 모든 notifications의 note_id는 NULL로 전환되어야 한다.
+-- 한 note를 여러 notifications가 참조하더라도 부모 note 삭제 시 관련 모든 notifications 행이 함께 삭제되어야 한다.
 SAVEPOINT notifications_note_fk_delete_many;
 DELETE FROM public.notes
 WHERE id = current_setting('test.notifications_fk_note_note_a_id')::uuid;
 
 SELECT ok(
-  (
-    (SELECT count(*) FROM public.notifications WHERE id IN (
+  NOT EXISTS (
+    SELECT 1
+    FROM public.notifications
+    WHERE id IN (
       current_setting('test.notifications_fk_note_a1_id')::uuid,
       current_setting('test.notifications_fk_note_a2_id')::uuid
-    ) AND note_id IS NULL) = 2
+    )
   ),
-  $$한 note를 여러 notifications가 참조하더라도 부모 note 삭제 시 관련 모든 notifications의 note_id는 NULL로 전환되어야 한다.$$
+  $$한 note를 여러 notifications가 참조하더라도 부모 note 삭제 시 관련 모든 notifications 행이 함께 삭제되어야 한다.$$
 );
 ROLLBACK TO SAVEPOINT notifications_note_fk_delete_many;
 
--- 부모 note 삭제 직후에도 해당 notifications 행 수는 유지되어야 하며, 참조값만 바뀌어야 한다.
+-- 부모 note 삭제 직후에는 해당 note를 참조하던 notifications 행 수만큼 전체 행 수가 줄어야 한다.
 SAVEPOINT notifications_note_fk_delete_row_count;
 SELECT set_config(
   'test.notifications_fk_note_before_total',
   (SELECT count(*) FROM public.notifications)::text,
+  true
+);
+SELECT set_config(
+  'test.notifications_fk_note_before_note_a_for_count',
+  (SELECT count(*) FROM public.notifications WHERE note_id = current_setting('test.notifications_fk_note_note_a_id')::uuid)::text,
   true
 );
 
@@ -404,11 +393,12 @@ WHERE id = current_setting('test.notifications_fk_note_note_a_id')::uuid;
 
 SELECT ok(
   (
-    (SELECT count(*) FROM public.notifications) = current_setting('test.notifications_fk_note_before_total')::bigint
-    AND (SELECT count(*) FROM public.notifications WHERE id = current_setting('test.notifications_fk_note_a1_id')::uuid
-      AND note_id IS NULL) = 1
+    (SELECT count(*) FROM public.notifications)
+      = current_setting('test.notifications_fk_note_before_total')::bigint
+        - current_setting('test.notifications_fk_note_before_note_a_for_count')::bigint
+    AND (SELECT count(*) FROM public.notifications WHERE id = current_setting('test.notifications_fk_note_a1_id')::uuid) = 0
   ),
-  $$부모 note 삭제 직후에도 해당 notifications 행 수는 유지되어야 하며, 참조값만 바뀌어야 한다.$$
+  $$부모 note 삭제 직후에는 해당 note를 참조하던 notifications 행 수만큼 전체 행 수가 줄어야 한다.$$
 );
 ROLLBACK TO SAVEPOINT notifications_note_fk_delete_row_count;
 
@@ -424,13 +414,8 @@ SELECT ok(
   $$테스트 종료 시점에 존재하는 모든 notifications의 note_id는 NULL이거나 존재하는 public.notes.id만 참조해야 한다.$$
 );
 
--- 부모 note 삭제 전후를 비교했을 때, 해당 note를 참조하던 notifications는 행 수를 유지한 채 note_id만 NULL로 전환되어야 하며, 다른 note를 참조하던 notifications는 영향을 받지 않아야 한다.
+-- 부모 note 삭제 전후를 비교했을 때, 해당 note를 참조하던 notifications는 삭제되며 다른 note를 참조하던 notifications는 영향을 받지 않아야 한다.
 SAVEPOINT notifications_note_fk_transition;
-SELECT set_config(
-  'test.notifications_fk_note_before_note_a',
-  (SELECT count(*) FROM public.notifications WHERE note_id = current_setting('test.notifications_fk_note_note_a_id')::uuid)::text,
-  true
-);
 SELECT set_config(
   'test.notifications_fk_note_before_note_b',
   (SELECT count(*) FROM public.notifications WHERE note_id = current_setting('test.notifications_fk_note_note_b_id')::uuid)::text,
@@ -443,13 +428,12 @@ WHERE id = current_setting('test.notifications_fk_note_note_a_id')::uuid;
 SELECT ok(
   (
     (SELECT count(*) FROM public.notifications WHERE note_id = current_setting('test.notifications_fk_note_note_a_id')::uuid) = 0
-    AND (SELECT count(*) FROM public.notifications WHERE note_id IS NULL) >= current_setting('test.notifications_fk_note_before_note_a')::bigint
     AND (SELECT count(*) FROM public.notifications WHERE note_id = current_setting('test.notifications_fk_note_note_b_id')::uuid)
       = current_setting('test.notifications_fk_note_before_note_b')::bigint
   ),
-  $$부모 note 삭제 전후를 비교했을 때, 해당 note를 참조하던 notifications는 행 수를 유지한 채 note_id만 NULL로 전환되어야 하며, 다른 note를 참조하던 notifications는 영향을 받지 않아야 한다.$$
+  $$부모 note 삭제 전후를 비교했을 때, 해당 note를 참조하던 notifications는 삭제되며 다른 note를 참조하던 notifications는 영향을 받지 않아야 한다.$$
 );
-ROLLBACK TO SAVEPOINT notifications_note_fk_transition;
+RELEASE SAVEPOINT notifications_note_fk_transition;
 
 SELECT * FROM finish();
 ROLLBACK;

--- a/supabase/tests/notifications/fk_user.sql
+++ b/supabase/tests/notifications/fk_user.sql
@@ -146,7 +146,7 @@ VALUES
     current_setting('test.notifications_fk_user_notification_user_b_id')::uuid,
     current_setting('test.notifications_fk_user_user_b_id')::uuid,
     NULL,
-    'REVIEW',
+    'ALERT',
     'user b title',
     'user b body',
     'SENT'
@@ -169,7 +169,7 @@ VALUES (
   current_setting('test.notifications_fk_user_insert_ok_id')::uuid,
   current_setting('test.notifications_fk_user_user_a_id')::uuid,
   NULL,
-  'REVIEW',
+  'ALERT',
   'insert ok',
   'body',
   'SENT'
@@ -209,7 +209,7 @@ SELECT throws_ok(
   format(
     $sql$
       INSERT INTO public.notifications (id, user_id, type, title)
-      VALUES ('%s'::uuid, '%s'::uuid, 'REVIEW', 'invalid user');
+      VALUES ('%s'::uuid, '%s'::uuid, 'ALERT', 'invalid user');
     $sql$,
     gen_random_uuid(),
     current_setting('test.notifications_fk_user_invalid_user_id')
@@ -243,7 +243,7 @@ SELECT throws_ok(
   format(
     $sql$
       INSERT INTO public.notifications (id, user_id, type, title)
-      VALUES ('%s'::uuid, '%s'::uuid, 'REVIEW', 'deleted parent');
+      VALUES ('%s'::uuid, '%s'::uuid, 'ALERT', 'deleted parent');
     $sql$,
     gen_random_uuid(),
     current_setting('test.notifications_fk_user_user_a_id')
@@ -294,7 +294,7 @@ INSERT INTO public.notifications (
 VALUES (
   current_setting('test.notifications_fk_user_insert_min_id')::uuid,
   current_setting('test.notifications_fk_user_user_a_id')::uuid,
-  'REVIEW',
+  'ALERT',
   'min title'
 );
 
@@ -342,7 +342,7 @@ SELECT throws_ok(
   format(
     $sql$
       INSERT INTO public.notifications (id, user_id, type, title)
-      VALUES ('%s'::uuid, '%s'::uuid, 'REVIEW', 'invalid uuid');
+      VALUES ('%s'::uuid, '%s'::uuid, 'ALERT', 'invalid uuid');
     $sql$,
     gen_random_uuid(),
     current_setting('test.notifications_fk_user_invalid_user_id')
@@ -420,7 +420,7 @@ SELECT ok(
   ),
   $$부모 user_a 삭제 전후를 비교했을 때, 해당 user를 참조하던 notifications는 삭제되어야 하고, 다른 user(예: user_b)의 notifications는 영향을 받지 않아야 한다.$$
 );
-ROLLBACK TO SAVEPOINT notifications_user_fk_transition;
+RELEASE SAVEPOINT notifications_user_fk_transition;
 
 SELECT * FROM finish();
 ROLLBACK;

--- a/supabase/tests/notifications/mark_notification_as_read.sql
+++ b/supabase/tests/notifications/mark_notification_as_read.sql
@@ -40,7 +40,7 @@ VALUES
   (
     current_setting('test.mark_read_notification_a_id')::uuid,
     current_setting('test.mark_read_user_a_id')::uuid,
-    'REVIEW',
+    'ALERT',
     'a title',
     'a body',
     'SENT'
@@ -48,7 +48,7 @@ VALUES
   (
     current_setting('test.mark_read_notification_b_id')::uuid,
     current_setting('test.mark_read_user_b_id')::uuid,
-    'REVIEW',
+    'ALERT',
     'b title',
     'b body',
     'SENT'
@@ -56,7 +56,7 @@ VALUES
   (
     current_setting('test.mark_read_notification_unverified_id')::uuid,
     current_setting('test.mark_read_unverified_user_id')::uuid,
-    'REVIEW',
+    'ALERT',
     'unverified title',
     'unverified body',
     'SENT'

--- a/supabase/tests/notifications/rls.sql
+++ b/supabase/tests/notifications/rls.sql
@@ -90,7 +90,7 @@ VALUES
   (
     current_setting('test.notifications_rls_a1_id')::uuid,
     current_setting('test.notifications_rls_user_a_id')::uuid,
-    'REVIEW',
+    'ALERT',
     'a1 title',
     'a1 body',
     'SENT'
@@ -106,7 +106,7 @@ VALUES
   (
     current_setting('test.notifications_rls_b1_id')::uuid,
     current_setting('test.notifications_rls_user_b_id')::uuid,
-    'REVIEW',
+    'ALERT',
     'b1 title',
     'b1 body',
     'SENT'
@@ -268,7 +268,7 @@ INSERT INTO public.notifications (
 VALUES (
   current_setting('test.notifications_rls_single_id')::uuid,
   current_setting('test.notifications_rls_user_a_id')::uuid,
-  'REVIEW',
+  'ALERT',
   'single title',
   'single body',
   'SENT'
@@ -345,7 +345,7 @@ SELECT throws_ok(
   format(
     $sql$
       INSERT INTO public.notifications (id, user_id, type, title)
-      VALUES ('%s'::uuid, '%s'::uuid, 'REVIEW', 'min title');
+      VALUES ('%s'::uuid, '%s'::uuid, 'ALERT', 'min title');
     $sql$,
     current_setting('test.notifications_rls_insert_min_id'),
     current_setting('test.notifications_rls_user_a_id')
@@ -445,7 +445,7 @@ SELECT set_config(
 DO $$
 BEGIN
   INSERT INTO public.notifications (id, user_id, type, title)
-  VALUES (gen_random_uuid(), current_setting('test.notifications_rls_user_a_id')::uuid, 'REVIEW', 'blocked');
+  VALUES (gen_random_uuid(), current_setting('test.notifications_rls_user_a_id')::uuid, 'ALERT', 'blocked');
 EXCEPTION
   WHEN others THEN
     NULL;
@@ -502,7 +502,7 @@ BEGIN
   VALUES (
     current_setting('test.notifications_rls_insert_transition_id')::uuid,
     current_setting('test.notifications_rls_user_a_id')::uuid,
-    'REVIEW',
+    'ALERT',
     'transition blocked'
   );
 EXCEPTION


### PR DESCRIPTION
## 개요

복습 알림(REVIEW)이 가리키는 노트가 삭제되면 알림도 함께 사라지도록 FK 정책을 `ON DELETE CASCADE`로 바꾸고, REVIEW 타입은 `note_id`가 반드시 존재하도록 CHECK 제약을 추가했습니다. 이에 맞춰 클라이언트 스키마/UI의 nullable 분기를 제거했습니다.

## PR 유형

- [x] 버그 수정
- [x] 코드 리팩토링
- [x] 테스트 추가/수정
- [ ] 새로운 기능 추가
- [ ] UI 디자인 변경
- [ ] 문서 수정
- [ ] 빌드/패키지 설정 변경

## 관련 이슈

closes #214 

## 작업 내용

- **마이그레이션** ([20260513000000_delete_notifications_for_deleted_notes.sql](supabase/migrations/20260513000000_delete_notifications_for_deleted_notes.sql))
  - 제약 강화 전 `type='REVIEW' AND note_id IS NULL`인 고아 행 선제 삭제
  - `notifications_note_id_fkey`를 `ON DELETE CASCADE`로 재생성 (`NOT VALID` → `VALIDATE`)
  - `notifications_review_note_id_not_null_check` CHECK 제약 추가 (`type <> 'REVIEW' OR note_id IS NOT NULL`)
- **스키마/쿼리**
  - [schema.ts](src/features/notifications/schema.ts): `notificationListItemSchema.note_id`에서 `.nullable()` 제거 — REVIEW 리스트 행에 note_id가 없으면 parse 실패
- **UI**
  - [NotificationList.tsx](src/features/notifications/components/NotificationList.tsx): `note_id` 분기/`<div>` fallback 제거, 항상 `<Link>`로 복습 라우트 진입
- **테스트**
  - 단위 테스트: REVIEW 리스트 행의 `note_id=null` 케이스에서 throw / parse 실패 확인 ([queries.test.ts](src/features/notifications/tests/queries.test.ts), [schema.test.ts](src/features/notifications/tests/schema.test.ts))
  - pgTAP: [fk_note.sql](supabase/tests/notifications/fk_note.sql)을 SET NULL 시나리오 → CASCADE/CHECK 시나리오로 갱신, 남은 savepoint 정리
  - `note_id=NULL`로 seed하던 다른 pgTAP 케이스(`constraints_*`, `fk_user`, `mark_notification_as_read`, `rls`)는 새 CHECK에 걸리지 않도록 type을 `REVIEW` → `ALERT`로 교체

## 테스트 방법

1. `supabase db reset` (또는 마이그레이션 적용) 후 마이그레이션 로그에서 `Deleted N orphan REVIEW notifications` NOTICE 확인
2. pgTAP: `supabase test db` 로 `notifications/` 디렉터리 전체 통과 확인
3. `pnpm test src/features/notifications` 통과 확인
4. 수동 검증
   - 복습 알림이 있는 노트를 삭제 → 알림 종 목록에서 해당 항목이 사라지는지 확인
   - 알림 종에서 REVIEW 알림 클릭 → 복습 라우트로 정상 이동
   - REVIEW 타입으로 `note_id=NULL` INSERT 시도 → 23514 CHECK violation 발생 확인

## 스크린샷 (FE 변경 시)

UI 동작은 동일(분기 제거로 단순화). 별도 스크린샷 없음.

## 리뷰 요구사항 (선택)

- 마이그레이션의 고아 행 선삭제 + `NOT VALID` → `VALIDATE` 순서가 무중단 적용에 적합한지
- `REVIEW`/`ALERT` 외 향후 타입 추가 시 CHECK 제약 확장 방향

## 체크리스트

- [x] 코드 컨벤션 준수
- [x] 커밋 메시지 컨벤션 준수
- [ ] lint 통과
- [ ] typecheck 통과
- [x] (DB 변경 시) migration 포함 및 로컬 재현 확인
- [x] (권한/RLS 영향 시) 정책 변경 요약 기재 — RLS 변경 없음, FK/CHECK 변경만 기재
- [ ] UI 변경 시 스크린샷/짧은 설명 첨부 — 동작 동일, 분기 제거 설명으로 갈음
- [x] 셀프 리뷰 완료
