### PR TITLE
fix: #226-vercel과 로컬 시간 출력이 다른 오류 수정

### DIFF
--- a/src/lib/utils/formatDate.ts
+++ b/src/lib/utils/formatDate.ts
@@ -4,6 +4,7 @@ export function formatDate(date: Date | string, locale = "ko-KR"): string {
     year: "numeric",
     month: "long",
     day: "numeric",
+    timeZone: "Asia/Seoul",
   });
 }
 
@@ -15,6 +16,7 @@ export function formatDateTime(date: Date | string, locale = "ko-KR"): string {
     day: "numeric",
     hour: "2-digit",
     minute: "2-digit",
+    timeZone: "Asia/Seoul",
   });
 }
 

--- a/src/lib/utils/tests/formatDate.test.ts
+++ b/src/lib/utils/tests/formatDate.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { formatDate, formatRelativeDate } from "../formatDate";
+import { formatDate, formatDateTime, formatRelativeDate } from "../formatDate";
 
 describe("formatDate", () => {
   it("Date 객체를 한국어 날짜 문자열로 변환한다", () => {
@@ -14,6 +14,15 @@ describe("formatDate", () => {
   it("ISO 문자열을 받아도 동작한다", () => {
     const result = formatDate("2024-01-15");
     expect(result).toContain("2024");
+  });
+});
+
+describe("formatDateTime", () => {
+  it("formats UTC instants in KST regardless of server timezone", () => {
+    const result = formatDateTime("2026-01-01T00:00:00.000Z", "en-US");
+
+    expect(result).toContain("January 1, 2026");
+    expect(result).toContain("09:00 AM");
   });
 });
 


### PR DESCRIPTION
## 개요

`formatDate` / `formatDateTime`이 `toLocaleString` 호출 시 `timeZone`을 지정하지 않아
실행 환경의 시스템 타임존을 따라가던 문제를 수정했습니다.
Vercel(UTC)에서 노트 상세의 시각이 KST 대비 9시간 빠르게 표시되던 환경 간 불일치를 해결합니다.

## PR 유형

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] UI 디자인 변경
- [ ] 코드 리팩토링
- [ ] 테스트 추가/수정
- [ ] 문서 수정
- [ ] 빌드/패키지 설정 변경

## 관련 이슈

closes #226 

## 작업 내용

- `src/lib/utils/formatDate.ts`의 `formatDate`, `formatDateTime`에 `timeZone: "Asia/Seoul"` 명시
- 두 함수는 Server Component에서도 호출되므로(예: 노트 상세 페이지의 "다음 예정") 서버 런타임 타임존이 결과에 박혀 내려가던 구조를 환경 무관하게 KST로 고정
- 동일 파일의 `formatDateKST`가 이미 같은 패턴을 사용 중이라 옵션을 통일

## 테스트 방법

1. Vercel preview 배포 확인 후 노트 상세 페이지 진입
2. 헤더 "다음 예정: …" 시각이 KST 기준으로 표시되는지 확인 (수정 전: UTC, 9시간 빠름)
3. 로컬 `pnpm dev`에서도 동일하게 KST로 표시되는지 확인 (회귀 없음)
4. `pnpm test src/lib/utils/tests/formatDate.test.ts` 통과 확인

## 스크린샷 (FE 변경 시)


## 리뷰 요구사항 (선택)


## 체크리스트

- [x] 코드 컨벤션 준수
- [x] 커밋 메시지 컨벤션 준수
- [x] lint 통과
- [x] typecheck 통과
- [ ] (DB 변경 시) migration 포함 및 로컬 재현 확인 — 해당 없음
- [ ] (권한/RLS 영향 시) 정책 변경 요약 기재 — 해당 없음
- [ ] UI 변경 시 스크린샷/짧은 설명 첨부 — 시각 표기 변경, 본문에 설명
- [x] 셀프 리뷰 완료
