### PR TITLE
fix: #235-다음 알림 시간 설정"으로 알림 시간을 바꿔도 화면의 "다음 예정: …" 텍스트가 새 시간으로 바뀌지 않는…

### DIFF
--- a/src/app/(main)/notes/[noteId]/page.test.tsx
+++ b/src/app/(main)/notes/[noteId]/page.test.tsx
@@ -133,14 +133,14 @@ describe("NoteDetailPage", () => {
     },
   );
 
-  it("renders a review entry point when the note is due for review", async () => {
+  it("renders a review entry point when the notification time has passed", async () => {
     createClientMock.mockResolvedValue(createSupabaseMock("user-123"));
     getNoteByIdMock.mockResolvedValue({
       id: "note-123",
       title: "Test note",
       content: "note body",
-      next_review_at: "2026-03-29T09:00:00.000Z",
-      next_scheduled_at: "2026-03-29T12:30:00.000Z",
+      next_review_at: "2026-03-29T00:00:00.000Z",
+      next_scheduled_at: "2026-03-29T09:00:00.000Z",
       notification_time_of_day: "21:30:00",
       review_round: 1,
       created_at: "2026-03-29T00:00:00.000Z",
@@ -158,7 +158,7 @@ describe("NoteDetailPage", () => {
     expect(titleHeading).toHaveClass("wrap-break-word", "break-keep");
     expect(screen.getByTestId("note-viewer")).toHaveTextContent("note body");
     expect(screen.getByTestId("notification-time-picker")).toHaveTextContent(
-      "note-123:21:30:00:2026-03-29T12:30:00.000Z",
+      "note-123:21:30:00:2026-03-29T09:00:00.000Z",
     );
     expect(
       screen.getByText("지금 백지 테스트를 진행할 수 있습니다."),
@@ -169,6 +169,38 @@ describe("NoteDetailPage", () => {
     expect(
       screen.getByRole("button", { name: "노트 삭제" }),
     ).toBeInTheDocument();
+  });
+
+  it("shows '다음 예정' (not 'due now') when notification time is still in the future today", async () => {
+    createClientMock.mockResolvedValue(createSupabaseMock("user-123"));
+    getNoteByIdMock.mockResolvedValue({
+      id: "note-123",
+      title: "Same-day, before notification",
+      content: "note body",
+      next_review_at: "2026-03-29T00:00:00.000Z",
+      next_scheduled_at: "2026-03-29T18:00:00.000Z",
+      notification_time_of_day: "03:00:00",
+      review_round: 1,
+      created_at: "2026-03-29T00:00:00.000Z",
+      updated_at: "2026-03-29T01:00:00.000Z",
+      user_id: "user-123",
+    });
+
+    render(
+      await NoteDetailPage({ params: Promise.resolve({ noteId: "note-123" }) }),
+    );
+
+    expect(
+      screen.getByText(
+        `다음 예정: ${formatDateTime("2026-03-29T18:00:00.000Z")}`,
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText("지금 백지 테스트를 진행할 수 있습니다."),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "백지 테스트 시작" }),
+    ).toHaveAttribute("href", getNoteReviewRoute("note-123"));
   });
 
   it("shows the next review schedule using the actual notification time", async () => {

--- a/src/app/(main)/notes/[noteId]/page.test.tsx
+++ b/src/app/(main)/notes/[noteId]/page.test.tsx
@@ -29,12 +29,14 @@ vi.mock("@/features/notifications/components/NotificationTimePicker", () => ({
   NotificationTimePicker: ({
     initialTime,
     noteId,
+    nextScheduledAt,
   }: {
     initialTime: string | null;
     noteId: string;
+    nextScheduledAt: string | null;
   }) => (
     <div data-testid="notification-time-picker">
-      {noteId}:{initialTime ?? "default"}
+      {noteId}:{initialTime ?? "default"}:{nextScheduledAt ?? "no-schedule"}
     </div>
   ),
 }));
@@ -138,6 +140,7 @@ describe("NoteDetailPage", () => {
       title: "Test note",
       content: "note body",
       next_review_at: "2026-03-29T09:00:00.000Z",
+      next_scheduled_at: "2026-03-29T12:30:00.000Z",
       notification_time_of_day: "21:30:00",
       review_round: 1,
       created_at: "2026-03-29T00:00:00.000Z",
@@ -155,7 +158,7 @@ describe("NoteDetailPage", () => {
     expect(titleHeading).toHaveClass("wrap-break-word", "break-keep");
     expect(screen.getByTestId("note-viewer")).toHaveTextContent("note body");
     expect(screen.getByTestId("notification-time-picker")).toHaveTextContent(
-      "note-123:21:30:00",
+      "note-123:21:30:00:2026-03-29T12:30:00.000Z",
     );
     expect(
       screen.getByText("지금 백지 테스트를 진행할 수 있습니다."),
@@ -168,14 +171,15 @@ describe("NoteDetailPage", () => {
     ).toBeInTheDocument();
   });
 
-  it("shows the next review schedule when the note is not due yet", async () => {
+  it("shows the next review schedule using the actual notification time", async () => {
     createClientMock.mockResolvedValue(createSupabaseMock("user-123"));
     getNoteByIdMock.mockResolvedValue({
       id: "note-123",
       title: "Future review note",
       content: "note body",
-      next_review_at: "2026-03-30T09:00:00.000Z",
-      notification_time_of_day: null,
+      next_review_at: "2026-03-30T15:00:00.000Z",
+      next_scheduled_at: "2026-03-30T01:00:00.000Z",
+      notification_time_of_day: "10:00:00",
       review_round: 1,
       created_at: "2026-03-29T00:00:00.000Z",
       updated_at: "2026-03-29T01:00:00.000Z",
@@ -188,7 +192,7 @@ describe("NoteDetailPage", () => {
 
     expect(
       screen.getByText(
-        `다음 예정: ${formatDateTime("2026-03-30T09:00:00.000Z")}`,
+        `다음 예정: ${formatDateTime("2026-03-30T01:00:00.000Z")}`,
       ),
     ).toBeInTheDocument();
     expect(
@@ -202,7 +206,8 @@ describe("NoteDetailPage", () => {
       id: "note-123",
       title: "Already done today",
       content: "note body",
-      next_review_at: "2026-03-30T09:00:00.000Z",
+      next_review_at: "2026-03-30T15:00:00.000Z",
+      next_scheduled_at: "2026-03-30T09:00:00.000Z",
       notification_time_of_day: null,
       review_round: 1,
       created_at: "2026-03-29T00:00:00.000Z",
@@ -234,6 +239,7 @@ describe("NoteDetailPage", () => {
       title: "Future review note",
       content: "note body",
       next_review_at: "2026-03-30T09:00:00.000Z",
+      next_scheduled_at: "2026-03-30T09:00:00.000Z",
       notification_time_of_day: null,
       review_round: 1,
       created_at: "2026-03-29T00:00:00.000Z",
@@ -260,6 +266,7 @@ describe("NoteDetailPage", () => {
       title: "Completed note",
       content: "note body",
       next_review_at: null,
+      next_scheduled_at: null,
       notification_time_of_day: null,
       review_round: 3,
       created_at: "2026-03-29T00:00:00.000Z",

--- a/src/app/(main)/notes/[noteId]/page.tsx
+++ b/src/app/(main)/notes/[noteId]/page.tsx
@@ -50,7 +50,8 @@ export default async function NoteDetailPage({
   const isReviewCompleted =
     note.review_round >= MAX_REVIEW_ROUND && nextReviewAt === null;
   const isReviewDue =
-    nextReviewAt !== null && new Date(nextReviewAt).getTime() <= Date.now();
+    nextScheduledAt !== null &&
+    new Date(nextScheduledAt).getTime() <= Date.now();
 
   // 1일 1회 제한 힌트. 일시적 조회 실패 시 fail-open(false) — 실제 차단은
   // DB 부분 unique 인덱스와 RPC가 보증하므로 페이지 표시를 막지 않는다.

--- a/src/app/(main)/notes/[noteId]/page.tsx
+++ b/src/app/(main)/notes/[noteId]/page.tsx
@@ -46,6 +46,7 @@ export default async function NoteDetailPage({
   }
 
   const nextReviewAt = note.next_review_at;
+  const nextScheduledAt = note.next_scheduled_at ?? nextReviewAt;
   const isReviewCompleted =
     note.review_round >= MAX_REVIEW_ROUND && nextReviewAt === null;
   const isReviewDue =
@@ -69,12 +70,12 @@ export default async function NoteDetailPage({
     !isReviewCompleted && nextReviewAt !== null && !alreadyCompletedToday;
   const reviewStatusMessage = isReviewCompleted
     ? "1-3-7 복습을 모두 마쳤습니다."
-    : nextReviewAt
+    : nextScheduledAt
       ? alreadyCompletedToday
-        ? `오늘 백지 테스트 완료. 다음 예정: ${formatDateTime(nextReviewAt)}`
+        ? `오늘 백지 테스트 완료. 다음 예정: ${formatDateTime(nextScheduledAt)}`
         : isReviewDue
           ? "지금 백지 테스트를 진행할 수 있습니다."
-          : `다음 예정: ${formatDateTime(nextReviewAt)}`
+          : `다음 예정: ${formatDateTime(nextScheduledAt)}`
       : "다음 복습 일정이 아직 준비되지 않았습니다.";
 
   return (
@@ -106,7 +107,7 @@ export default async function NoteDetailPage({
               <NotificationTimePicker
                 noteId={note.id}
                 initialTime={note.notification_time_of_day}
-                nextReviewAt={note.next_review_at}
+                nextScheduledAt={note.next_scheduled_at}
               />
             )}
             <DeleteNoteDialog noteId={note.id} noteTitle={note.title} />

--- a/src/features/notes/queries.ts
+++ b/src/features/notes/queries.ts
@@ -28,7 +28,12 @@ const noteSummarySchema = z.object({
   updated_at: z.string(),
 });
 
-export type NoteDetail = z.infer<typeof noteDetailSchema>;
+// next_scheduled_at는 notes 테이블 컬럼이 아니라 pending review_logs.scheduled_at에서
+// 파생된 실제 알림 발송 시각이다. notes.next_review_at은 KST 자정 마커이므로 시:분
+// 표시에는 사용할 수 없어 별도 필드로 합쳐 반환한다 (이슈 #215 설계 결정).
+export type NoteDetail = z.infer<typeof noteDetailSchema> & {
+  next_scheduled_at: string | null;
+};
 export type NoteSummary = z.infer<typeof noteSummarySchema>;
 
 export async function getNotes(
@@ -150,5 +155,23 @@ export async function getNoteById(
     .maybeSingle();
 
   const parsed = noteDetailSchema.safeParse(data);
-  return parsed.success ? parsed.data : null;
+  if (!parsed.success) return null;
+
+  const { data: pendingLog } = await supabase
+    .from("review_logs")
+    .select("scheduled_at")
+    .eq("note_id", noteId)
+    .eq("user_id", userId)
+    .is("completed_at", null)
+    .order("scheduled_at", { ascending: true })
+    .limit(1)
+    .maybeSingle();
+
+  return {
+    ...parsed.data,
+    next_scheduled_at:
+      typeof pendingLog?.scheduled_at === "string"
+        ? pendingLog.scheduled_at
+        : null,
+  };
 }

--- a/src/features/notes/tests/queries.test.ts
+++ b/src/features/notes/tests/queries.test.ts
@@ -55,7 +55,10 @@ function createNotesQueryMock(data: unknown, count = 0) {
   };
 }
 
-function createNoteDetailQueryMock(data: unknown) {
+function createNoteDetailQueryMock(
+  data: unknown,
+  pendingLog: { scheduled_at: string } | null = null,
+) {
   const maybeSingleMock = vi.fn().mockResolvedValue({ data });
   const userEqMock = vi.fn().mockReturnValue({
     maybeSingle: maybeSingleMock,
@@ -63,19 +66,55 @@ function createNoteDetailQueryMock(data: unknown) {
   const idEqMock = vi.fn().mockReturnValue({
     eq: userEqMock,
   });
-  const selectMock = vi.fn().mockReturnValue({
+  const noteSelectMock = vi.fn().mockReturnValue({
     eq: idEqMock,
   });
+
+  const pendingMaybeSingleMock = vi
+    .fn()
+    .mockResolvedValue({ data: pendingLog });
+  const pendingLimitMock = vi.fn().mockReturnValue({
+    maybeSingle: pendingMaybeSingleMock,
+  });
+  const pendingOrderMock = vi.fn().mockReturnValue({
+    limit: pendingLimitMock,
+  });
+  const pendingIsMock = vi.fn().mockReturnValue({
+    order: pendingOrderMock,
+  });
+  const pendingUserEqMock = vi.fn().mockReturnValue({
+    is: pendingIsMock,
+  });
+  const pendingNoteEqMock = vi.fn().mockReturnValue({
+    eq: pendingUserEqMock,
+  });
+  const pendingSelectMock = vi.fn().mockReturnValue({
+    eq: pendingNoteEqMock,
+  });
+
+  const fromMock = vi
+    .fn()
+    .mockImplementation((table: string) =>
+      table === "review_logs"
+        ? { select: pendingSelectMock }
+        : { select: noteSelectMock },
+    );
 
   return {
     idEqMock,
     maybeSingleMock,
-    selectMock,
+    selectMock: noteSelectMock,
     userEqMock,
+    pendingSelectMock,
+    pendingNoteEqMock,
+    pendingUserEqMock,
+    pendingIsMock,
+    pendingOrderMock,
+    pendingLimitMock,
+    pendingMaybeSingleMock,
+    fromMock,
     supabase: {
-      from: vi.fn().mockReturnValue({
-        select: selectMock,
-      }),
+      from: fromMock,
     },
   };
 }
@@ -185,9 +224,21 @@ describe("getNotes", () => {
     expect(result).toEqual({ notes: [], total: 1 });
   });
 
-  it("returns note detail with notification time of day", async () => {
-    const { supabase, selectMock, idEqMock, userEqMock, maybeSingleMock } =
-      createNoteDetailQueryMock({
+  it("returns note detail with notification time of day and pending scheduled_at", async () => {
+    const {
+      supabase,
+      selectMock,
+      idEqMock,
+      userEqMock,
+      maybeSingleMock,
+      pendingSelectMock,
+      pendingNoteEqMock,
+      pendingUserEqMock,
+      pendingIsMock,
+      pendingOrderMock,
+      pendingLimitMock,
+    } = createNoteDetailQueryMock(
+      {
         id: "11111111-1111-4111-8111-111111111111",
         title: "알림 시간 노트",
         content: "note body",
@@ -197,7 +248,9 @@ describe("getNotes", () => {
         created_at: "2026-03-29T00:00:00.000Z",
         updated_at: "2026-03-29T01:00:00.000Z",
         user_id: "22222222-2222-4222-8222-222222222222",
-      });
+      },
+      { scheduled_at: "2026-03-30T12:30:00.000Z" },
+    );
 
     createClientMock.mockResolvedValue(supabase);
 
@@ -218,10 +271,53 @@ describe("getNotes", () => {
       "22222222-2222-4222-8222-222222222222",
     );
     expect(maybeSingleMock).toHaveBeenCalledOnce();
+
+    expect(pendingSelectMock).toHaveBeenCalledWith("scheduled_at");
+    expect(pendingNoteEqMock).toHaveBeenCalledWith(
+      "note_id",
+      "11111111-1111-4111-8111-111111111111",
+    );
+    expect(pendingUserEqMock).toHaveBeenCalledWith(
+      "user_id",
+      "22222222-2222-4222-8222-222222222222",
+    );
+    expect(pendingIsMock).toHaveBeenCalledWith("completed_at", null);
+    expect(pendingOrderMock).toHaveBeenCalledWith("scheduled_at", {
+      ascending: true,
+    });
+    expect(pendingLimitMock).toHaveBeenCalledWith(1);
+
     expect(result).toMatchObject({
       id: "11111111-1111-4111-8111-111111111111",
       notification_time_of_day: "21:30:00",
+      next_scheduled_at: "2026-03-30T12:30:00.000Z",
     });
+  });
+
+  it("returns next_scheduled_at as null when no pending review_log exists", async () => {
+    const { supabase } = createNoteDetailQueryMock(
+      {
+        id: "11111111-1111-4111-8111-111111111111",
+        title: "완료된 노트",
+        content: "note body",
+        next_review_at: null,
+        notification_time_of_day: null,
+        review_round: 3,
+        created_at: "2026-03-29T00:00:00.000Z",
+        updated_at: "2026-03-29T01:00:00.000Z",
+        user_id: "22222222-2222-4222-8222-222222222222",
+      },
+      null,
+    );
+
+    createClientMock.mockResolvedValue(supabase);
+
+    const result = await getNoteById(
+      "11111111-1111-4111-8111-111111111111",
+      "22222222-2222-4222-8222-222222222222",
+    );
+
+    expect(result?.next_scheduled_at).toBeNull();
   });
 });
 

--- a/src/features/notifications/components/NotificationTimePicker.tsx
+++ b/src/features/notifications/components/NotificationTimePicker.tsx
@@ -41,7 +41,7 @@ import { notificationTimeSchema } from "../schema";
 type NotificationTimePickerProps = {
   noteId: string;
   initialTime: string | null;
-  nextReviewAt: string | null;
+  nextScheduledAt: string | null;
 };
 
 function getCurrentSettingLabel(time: string) {
@@ -51,7 +51,7 @@ function getCurrentSettingLabel(time: string) {
 export function NotificationTimePicker({
   noteId,
   initialTime,
-  nextReviewAt,
+  nextScheduledAt,
 }: NotificationTimePickerProps) {
   const inputBaseId = useId();
   const labelId = `${inputBaseId}-label`;
@@ -207,8 +207,8 @@ export function NotificationTimePicker({
             <DialogTitle>다음 알림 시간 설정</DialogTitle>
             <div className="mt-2 space-y-1 text-sm text-muted-foreground">
               <p>현재 설정: {getCurrentSettingLabel(savedTime)}</p>
-              {nextReviewAt && (
-                <p>다음 복습 예정 {formatDateTime(nextReviewAt)}</p>
+              {nextScheduledAt && (
+                <p>다음 복습 예정 {formatDateTime(nextScheduledAt)}</p>
               )}
             </div>
           </DialogHeader>

--- a/src/features/notifications/tests/NotificationTimePicker.test.tsx
+++ b/src/features/notifications/tests/NotificationTimePicker.test.tsx
@@ -34,7 +34,7 @@ describe("NotificationTimePicker", () => {
       <NotificationTimePicker
         noteId={NOTE_ID}
         initialTime="21:30:00"
-        nextReviewAt="2026-04-30T12:30:00.000Z"
+        nextScheduledAt="2026-04-30T12:30:00.000Z"
       />,
     );
 
@@ -65,7 +65,7 @@ describe("NotificationTimePicker", () => {
       <NotificationTimePicker
         noteId={NOTE_ID}
         initialTime={null}
-        nextReviewAt={null}
+        nextScheduledAt={null}
       />,
     );
 
@@ -103,7 +103,7 @@ describe("NotificationTimePicker", () => {
       <NotificationTimePicker
         noteId={NOTE_ID}
         initialTime={null}
-        nextReviewAt={null}
+        nextScheduledAt={null}
       />,
     );
 
@@ -139,7 +139,7 @@ describe("NotificationTimePicker", () => {
       <NotificationTimePicker
         noteId={NOTE_ID}
         initialTime={null}
-        nextReviewAt={null}
+        nextScheduledAt={null}
       />,
     );
 
@@ -179,7 +179,7 @@ describe("NotificationTimePicker", () => {
       <NotificationTimePicker
         noteId={NOTE_ID}
         initialTime="09:30:00"
-        nextReviewAt={null}
+        nextScheduledAt={null}
       />,
     );
 
@@ -187,7 +187,7 @@ describe("NotificationTimePicker", () => {
       <NotificationTimePicker
         noteId={NOTE_ID}
         initialTime="21:30:00"
-        nextReviewAt={null}
+        nextScheduledAt={null}
       />,
     );
 
@@ -214,7 +214,7 @@ describe("NotificationTimePicker", () => {
       <NotificationTimePicker
         noteId={NOTE_ID}
         initialTime={null}
-        nextReviewAt={null}
+        nextScheduledAt={null}
       />,
     );
 
@@ -248,7 +248,7 @@ describe("NotificationTimePicker", () => {
       <NotificationTimePicker
         noteId={NOTE_ID}
         initialTime="21:30:00"
-        nextReviewAt={null}
+        nextScheduledAt={null}
       />,
     );
 


### PR DESCRIPTION
## 개요

이슈 #215(PR #216) 이후 `notes.next_review_at`을 "KST 자정 마커"로 고정한 설계 변경이 노트 상세 페이지 UI에 반영되지 않아, 사용자가 알림 시간을 바꿔도 "다음 예정: …" 텍스트가 갱신되지 않던 문제를 수정합니다. 실제 알림 발송 시각이 들어 있는 `review_logs.scheduled_at`을 별도 필드로 노출해 표시에 사용합니다.

## PR 유형

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] UI 디자인 변경
- [ ] 코드 리팩토링
- [ ] 테스트 추가/수정
- [ ] 문서 수정
- [ ] 빌드/패키지 설정 변경

## 관련 이슈

closes #235 

## 작업 내용

- `getNoteById`에 pending `review_logs` 중 가장 이른 `scheduled_at`을 함께 조회해 `NoteDetail.next_scheduled_at`으로 반환.
- 노트 상세 페이지(`/notes/[noteId]/page.tsx`)의 "다음 예정: …" 표시를 `next_scheduled_at` 기준으로 변경. 단, `isReviewCompleted` / `isReviewDue` 게이트는 기존 동작 보존을 위해 `next_review_at`(날짜 마커)를 그대로 사용.
- `NotificationTimePicker` 다이얼로그의 "다음 복습 예정 …" 표시 prop을 `nextReviewAt` → `nextScheduledAt`으로 리네이밍 및 동일 값으로 교체.
- `getNoteById` / 노트 상세 페이지 / `NotificationTimePicker` 테스트 케이스 갱신 (pending log mock 추가, 새 prop 반영).
- `next_review_at`의 의미(KST 자정 마커)와 표시용 분리를 코드 주석으로 명시.
- `isReviewDue` 게이트를 `next_scheduled_at` 기준으로 전환 — "지금 백지 테스트 진행 가능" 안내가 실제 알림 발송 이후에만 표시되도록 함. (진입 자체는 정책에 따라 알림 당일 여부와 무관하게 가능하며, 1일 1회 제한은 `alreadyCompletedToday` + DB RPC 가드로 유지.)


DB 변경은 없습니다(이슈 #215, PR #231에서 추가된 RPC/마이그레이션을 그대로 사용).

## 테스트 방법

1. `npm run typecheck` — 통과.
2. `npx vitest run src/features/notes/tests/queries.test.ts "src/app/(main)/notes/[noteId]/page.test.tsx" src/features/notifications/tests/NotificationTimePicker.test.tsx` — 28 passed.
3. 로컬에서 임의의 노트 상세 진입 → "다음 알림 시간 설정" → 시간을 바꿔 저장 → 다이얼로그/페이지 헤더의 "다음 예정"이 새 시각으로 즉시 갱신되는지 확인.
4. 오전/오후 양쪽으로 변경해 보며 PR #231에서 고친 day-shift가 재발하지 않는지 함께 확인.
5. 기본 시간으로 되돌리기(`기본 시간` 버튼) 후 표시가 자연스럽게 갱신되는지 확인.

## 스크린샷 (FE 변경 시)

(전: "다음 예정: 2026년 5월 17일 오전 12:00" 고정 / 후: 설정한 시각 반영)

## 리뷰 요구사항 (선택)

- `next_review_at`(KST 자정 마커)과 `next_scheduled_at`(실제 알림 시각) 분리 방향이 이슈 #215 설계 의도와 일치하는지 확인 부탁드립니다.


## 체크리스트

- [x] 코드 컨벤션 준수
- [x] 커밋 메시지 컨벤션 준수
- [x] lint 통과
- [x] typecheck 통과
- [ ] (DB 변경 시) migration 포함 및 로컬 재현 확인 — 해당 없음
- [ ] (권한/RLS 영향 시) 정책 변경 요약 기재 — 해당 없음 (기존 review_logs SELECT 정책 그대로 사용)
- [x] UI 변경 시 스크린샷/짧은 설명 첨부
- [x] 셀프 리뷰 완료
