### PR TITLE
fix: #244 - mypage 이메일 미인증 redirect에 purpose=signup 추가

### DIFF
--- a/src/app/(main)/mypage/page.test.tsx
+++ b/src/app/(main)/mypage/page.test.tsx
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { ROUTES } from "@/lib/constants/routes";
+
 const REDIRECT_ERROR = new Error("NEXT_REDIRECT");
 
 const {
@@ -67,6 +69,18 @@ describe("MyPage", () => {
     });
     getUserMock.mockResolvedValue(mockUser);
     getProfileMock.mockResolvedValue(mockProfile);
+  });
+
+  it("이메일 미인증 사용자는 RESEND_EMAIL?purpose=signup으로 redirect된다", async () => {
+    getUserMock.mockResolvedValue({ ...mockUser, email_confirmed_at: null });
+
+    await expect(MyPage({ searchParams: Promise.resolve({}) })).rejects.toBe(
+      REDIRECT_ERROR,
+    );
+
+    expect(redirectMock).toHaveBeenCalledWith(
+      `${ROUTES.RESEND_EMAIL}?purpose=signup`,
+    );
   });
 
   it("DB 조회 오류가 발생하면 빈 상태로 대체하지 않고 error boundary로 전파한다", async () => {

--- a/src/app/(main)/mypage/page.tsx
+++ b/src/app/(main)/mypage/page.tsx
@@ -62,7 +62,8 @@ export default async function MyPage({ searchParams }: Props) {
 
   const [user, profile] = await Promise.all([getUser(), getProfile()]);
   if (!user || !profile) redirect(ROUTES.LOGIN);
-  if (user.email_confirmed_at == null) redirect(ROUTES.RESEND_EMAIL);
+  if (user.email_confirmed_at == null)
+    redirect(`${ROUTES.RESEND_EMAIL}?purpose=signup`);
 
   // 활성 section에서만 fetch
   let stats: Awaited<ReturnType<typeof getLearningStats>> | null = null;


### PR DESCRIPTION
## 개요

마이페이지에서 이메일 미인증 상태로 접근 시 `/resend-email`로 redirect할 때
`purpose=signup` 쿼리 파라미터가 누락되어 있던 버그를 수정합니다.
`purpose` 값이 없으면 resend-email 페이지에서 이메일 재발송 목적을 구분하지 못해
잘못된 안내가 표시될 수 있었습니다.

## PR 유형

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] UI 디자인 변경
- [ ] 코드 리팩토링
- [ ] 테스트 추가/수정
- [ ] 문서 수정
- [ ] 빌드/패키지 설정 변경

## 관련 이슈

closes #244

## 작업 내용

- `src/app/(main)/mypage/page.tsx`: 이메일 미인증 redirect URL에 `?purpose=signup` 추가
- `src/app/(main)/mypage/page.test.tsx`: redirect URL에 purpose 파라미터 포함 여부 검증 테스트 추가

## 테스트 방법

1. 이메일 미인증 상태의 계정으로 로그인
2. `/mypage` 접근
3. `/resend-email?purpose=signup&email=...` 형태로 redirect 되는지 확인

## 스크린샷 (FE 변경 시)

(해당 없음 — redirect 로직만 변경)

## 리뷰 요구사항 (선택)

(없음)

## 체크리스트

- [x] 코드 컨벤션 준수
- [x] 커밋 메시지 컨벤션 준수
- [x] lint 통과
- [x] typecheck 통과
- [ ] (DB 변경 시) migration 포함 및 로컬 재현 확인
- [ ] (권한/RLS 영향 시) 정책 변경 요약 기재
- [ ] UI 변경 시 스크린샷/짧은 설명 첨부
- [x] 셀프 리뷰 완료