### PR TITLE
fix: #245 - 페이지네이션 UX 개선

### DIFF
--- a/src/app/(main)/notes/page.tsx
+++ b/src/app/(main)/notes/page.tsx
@@ -6,6 +6,7 @@ import { Suspense } from "react";
 import { NotesToolbar } from "@/features/notes/components/NotesToolbar";
 import { NotesViewContainer } from "@/features/notes/components/NotesViewContainer";
 import { getNotes } from "@/features/notes/queries";
+import { buildNotesUrl } from "@/features/notes/utils/buildNotesUrl";
 import { NOTES_VIEW_COOKIE } from "@/hooks/useNotesView";
 import {
   NOTES_CARDS_PAGE_SIZE,
@@ -38,7 +39,8 @@ export default async function NotesPage({ searchParams }: NotesPageProps) {
   }
 
   const params = await searchParams;
-  const page = Math.max(1, Number(params.page) || 1);
+  const rawPage = Number(params.page);
+  const page = Number.isFinite(rawPage) ? Math.max(1, Math.floor(rawPage)) : 1;
   const query = params.q ?? "";
   const cookieStore = await cookies();
   const cookieView =
@@ -48,6 +50,11 @@ export default async function NotesPage({ searchParams }: NotesPageProps) {
     view === "cards" ? NOTES_CARDS_PAGE_SIZE : NOTES_LIST_PAGE_SIZE;
 
   const { notes, total } = await getNotes(user.id, page, query, pageSize);
+  const totalPages = Math.ceil(total / pageSize);
+
+  if (total > 0 && page > totalPages) {
+    redirect(buildNotesUrl({ page: totalPages, query, view }));
+  }
 
   return (
     <div className="mx-auto w-full max-w-5xl px-6 py-10 md:px-12">

--- a/src/app/(main)/notes/today/page.test.tsx
+++ b/src/app/(main)/notes/today/page.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { TODAY_PAGE_SIZE } from "@/lib/constants/notes";
 import { ROUTES } from "@/lib/constants/routes";
 
 const REDIRECT_ERROR = new Error("NEXT_REDIRECT");
@@ -33,6 +34,8 @@ vi.mock("next/navigation", () => ({
 }));
 
 import TodayReviewPage from "./page";
+
+const DEFAULT_SEARCH_PARAMS = { searchParams: Promise.resolve({}) };
 
 function createSupabaseMock(
   userId: string | null,
@@ -70,7 +73,9 @@ describe("TodayReviewPage", () => {
   it("미인증 사용자를 로그인 페이지로 redirect한다", async () => {
     createClientMock.mockResolvedValue(createSupabaseMock(null));
 
-    await expect(TodayReviewPage()).rejects.toBe(REDIRECT_ERROR);
+    await expect(TodayReviewPage(DEFAULT_SEARCH_PARAMS)).rejects.toBe(
+      REDIRECT_ERROR,
+    );
 
     expect(redirectMock).toHaveBeenCalledWith(ROUTES.LOGIN);
     expect(getTodayReviewNotesMock).not.toHaveBeenCalled();
@@ -83,7 +88,9 @@ describe("TodayReviewPage", () => {
         createSupabaseMock("user-123", emailConfirmedAt),
       );
 
-      await expect(TodayReviewPage()).rejects.toBe(REDIRECT_ERROR);
+      await expect(TodayReviewPage(DEFAULT_SEARCH_PARAMS)).rejects.toBe(
+        REDIRECT_ERROR,
+      );
 
       expect(redirectMock).toHaveBeenCalledWith(
         `${ROUTES.RESEND_EMAIL}?purpose=signup`,
@@ -94,11 +101,15 @@ describe("TodayReviewPage", () => {
 
   it("인증된 사용자에게 오늘의 복습 페이지를 렌더링한다", async () => {
     createClientMock.mockResolvedValue(createSupabaseMock("user-123"));
-    getTodayReviewNotesMock.mockResolvedValue([]);
+    getTodayReviewNotesMock.mockResolvedValue({ notes: [], total: 0 });
 
-    render(await TodayReviewPage());
+    render(await TodayReviewPage(DEFAULT_SEARCH_PARAMS));
 
-    expect(getTodayReviewNotesMock).toHaveBeenCalledWith("user-123");
+    expect(getTodayReviewNotesMock).toHaveBeenCalledWith(
+      "user-123",
+      1,
+      TODAY_PAGE_SIZE,
+    );
     expect(
       screen.getByRole("heading", { name: "오늘의 복습" }),
     ).toBeInTheDocument();
@@ -106,9 +117,9 @@ describe("TodayReviewPage", () => {
 
   it("복습할 노트가 없을 때 빈 상태 메시지를 표시한다", async () => {
     createClientMock.mockResolvedValue(createSupabaseMock("user-123"));
-    getTodayReviewNotesMock.mockResolvedValue([]);
+    getTodayReviewNotesMock.mockResolvedValue({ notes: [], total: 0 });
 
-    render(await TodayReviewPage());
+    render(await TodayReviewPage(DEFAULT_SEARCH_PARAMS));
 
     expect(
       screen.getByText("오늘 예정된 복습이 없습니다."),
@@ -120,6 +131,6 @@ describe("TodayReviewPage", () => {
     createClientMock.mockResolvedValue(createSupabaseMock("user-123"));
     getTodayReviewNotesMock.mockRejectedValue(dbError);
 
-    await expect(TodayReviewPage()).rejects.toBe(dbError);
+    await expect(TodayReviewPage(DEFAULT_SEARCH_PARAMS)).rejects.toBe(dbError);
   });
 });

--- a/src/app/(main)/notes/today/page.tsx
+++ b/src/app/(main)/notes/today/page.tsx
@@ -36,7 +36,8 @@ export default async function TodayReviewPage({
   }
 
   const params = await searchParams;
-  const page = Math.max(1, Number(params.page) || 1);
+  const rawPage = Number(params.page);
+  const page = Number.isFinite(rawPage) ? Math.max(1, Math.floor(rawPage)) : 1;
 
   const cookieStore = await cookies();
   const initialView =
@@ -48,6 +49,15 @@ export default async function TodayReviewPage({
     TODAY_PAGE_SIZE,
   );
   const totalPages = Math.ceil(total / TODAY_PAGE_SIZE);
+
+  if (total > 0 && page > totalPages) {
+    const lastPage = totalPages;
+    redirect(
+      lastPage === 1
+        ? ROUTES.NOTES_TODAY
+        : `${ROUTES.NOTES_TODAY}?page=${lastPage}`,
+    );
+  }
 
   return (
     <div className="mx-auto w-full max-w-5xl px-6 py-10 md:px-12">

--- a/src/app/(main)/notes/today/page.tsx
+++ b/src/app/(main)/notes/today/page.tsx
@@ -2,9 +2,11 @@ import type { Metadata } from "next";
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 
+import { NotesPagination } from "@/features/notes/components/NotesPagination";
 import { TodayNoteList } from "@/features/notes/components/TodayNoteList";
 import { getTodayReviewNotes } from "@/features/notes/queries";
 import { NOTES_VIEW_COOKIE } from "@/hooks/useNotesView";
+import { TODAY_PAGE_SIZE } from "@/lib/constants/notes";
 import { ROUTES } from "@/lib/constants/routes";
 import { createServerComponentClient } from "@/lib/supabase/server";
 
@@ -13,7 +15,13 @@ export const metadata: Metadata = {
   robots: { index: false, follow: false },
 };
 
-export default async function TodayReviewPage() {
+type TodayReviewPageProps = {
+  searchParams: Promise<{ page?: string }>;
+};
+
+export default async function TodayReviewPage({
+  searchParams,
+}: TodayReviewPageProps) {
   const supabase = await createServerComponentClient();
   const {
     data: { user },
@@ -27,11 +35,19 @@ export default async function TodayReviewPage() {
     redirect(`${ROUTES.RESEND_EMAIL}?purpose=signup`);
   }
 
+  const params = await searchParams;
+  const page = Math.max(1, Number(params.page) || 1);
+
   const cookieStore = await cookies();
   const initialView =
     cookieStore.get(NOTES_VIEW_COOKIE)?.value === "cards" ? "cards" : "list";
 
-  const notes = await getTodayReviewNotes(user.id);
+  const { notes, total } = await getTodayReviewNotes(
+    user.id,
+    page,
+    TODAY_PAGE_SIZE,
+  );
+  const totalPages = Math.ceil(total / TODAY_PAGE_SIZE);
 
   return (
     <div className="mx-auto w-full max-w-5xl px-6 py-10 md:px-12">
@@ -41,7 +57,14 @@ export default async function TodayReviewPage() {
           오늘 복습할 노트만 모았어요.
         </p>
       </div>
-      <TodayNoteList notes={notes} initialView={initialView} />
+      <TodayNoteList notes={notes} initialView={initialView} total={total} />
+      <NotesPagination
+        currentPage={page}
+        totalPages={totalPages}
+        buildUrl={(p) =>
+          p === 1 ? ROUTES.NOTES_TODAY : `${ROUTES.NOTES_TODAY}?page=${p}`
+        }
+      />
     </div>
   );
 }

--- a/src/features/notes/components/NotesPagination.tsx
+++ b/src/features/notes/components/NotesPagination.tsx
@@ -127,6 +127,7 @@ function PaginationLink({
   if (disabled) {
     return (
       <span
+        {...props}
         className={cn(base, "cursor-not-allowed text-muted-foreground/40")}
         aria-disabled="true"
       >

--- a/src/features/notes/components/NotesPagination.tsx
+++ b/src/features/notes/components/NotesPagination.tsx
@@ -2,16 +2,13 @@ import Link from "next/link";
 
 import { cn } from "@/lib/utils/cn";
 
-import { buildNotesUrl, type NotesView } from "../utils/buildNotesUrl";
-
 const ELLIPSIS = "..." as const;
 type PageItem = number | typeof ELLIPSIS;
 
 type NotesPaginationProps = {
   currentPage: number;
   totalPages: number;
-  query: string;
-  view: NotesView;
+  buildUrl: (page: number) => string;
 };
 
 function getPageNumbers(current: number, total: number): PageItem[] {
@@ -36,8 +33,7 @@ function getPageNumbers(current: number, total: number): PageItem[] {
 export function NotesPagination({
   currentPage,
   totalPages,
-  query,
-  view,
+  buildUrl,
 }: NotesPaginationProps) {
   if (totalPages <= 1) return null;
 
@@ -51,8 +47,17 @@ export function NotesPagination({
       className="flex items-center justify-center gap-1 pt-2"
     >
       <PaginationLink
-        href={buildNotesUrl({ page: currentPage - 1, query, view })}
+        href={buildUrl(1)}
         disabled={!hasPrev}
+        title="첫 페이지"
+        aria-label="첫 페이지"
+      >
+        «
+      </PaginationLink>
+      <PaginationLink
+        href={buildUrl(currentPage - 1)}
+        disabled={!hasPrev}
+        title="이전 페이지"
         aria-label="이전 페이지"
       >
         ←
@@ -69,7 +74,7 @@ export function NotesPagination({
         ) : (
           <PaginationLink
             key={page}
-            href={buildNotesUrl({ page, query, view })}
+            href={buildUrl(page)}
             active={page === currentPage}
             aria-label={`${page} 페이지`}
             aria-current={page === currentPage ? "page" : undefined}
@@ -80,11 +85,20 @@ export function NotesPagination({
       )}
 
       <PaginationLink
-        href={buildNotesUrl({ page: currentPage + 1, query, view })}
+        href={buildUrl(currentPage + 1)}
         disabled={!hasNext}
+        title="다음 페이지"
         aria-label="다음 페이지"
       >
         →
+      </PaginationLink>
+      <PaginationLink
+        href={buildUrl(totalPages)}
+        disabled={!hasNext}
+        title="마지막 페이지"
+        aria-label="마지막 페이지"
+      >
+        »
       </PaginationLink>
     </nav>
   );
@@ -95,6 +109,7 @@ type PaginationLinkProps = {
   children: React.ReactNode;
   active?: boolean;
   disabled?: boolean;
+  title?: string;
   "aria-label"?: string;
   "aria-current"?: "page" | undefined;
 };
@@ -120,14 +135,23 @@ function PaginationLink({
     );
   }
 
+  if (active) {
+    return (
+      <span
+        className={cn(base, "cursor-default bg-foreground text-background")}
+        {...props}
+      >
+        {children}
+      </span>
+    );
+  }
+
   return (
     <Link
       href={href}
       className={cn(
         base,
-        active
-          ? "bg-foreground text-background"
-          : "text-muted-foreground hover:bg-muted hover:text-foreground",
+        "text-muted-foreground hover:bg-muted hover:text-foreground",
       )}
       {...props}
     >

--- a/src/features/notes/components/NotesViewContainer.tsx
+++ b/src/features/notes/components/NotesViewContainer.tsx
@@ -1,5 +1,5 @@
 import type { NoteSummary } from "../queries";
-import type { NotesView } from "../utils/buildNotesUrl";
+import { buildNotesUrl, type NotesView } from "../utils/buildNotesUrl";
 import { NoteGridCard } from "./NoteGridCard";
 import { NoteListItem } from "./NoteListItem";
 import { NotesEmptyState } from "./NotesEmptyState";
@@ -55,8 +55,7 @@ export function NotesViewContainer({
       <NotesPagination
         currentPage={currentPage}
         totalPages={totalPages}
-        query={query}
-        view={view}
+        buildUrl={(page) => buildNotesUrl({ page, query, view })}
       />
     </div>
   );

--- a/src/features/notes/components/TodayNoteList.tsx
+++ b/src/features/notes/components/TodayNoteList.tsx
@@ -11,9 +11,14 @@ import { ViewToggle } from "./ViewToggle";
 type TodayNoteListProps = {
   notes: NoteSummary[];
   initialView: NotesView;
+  total: number;
 };
 
-export function TodayNoteList({ notes, initialView }: TodayNoteListProps) {
+export function TodayNoteList({
+  notes,
+  initialView,
+  total,
+}: TodayNoteListProps) {
   const [view, updateView] = useNotesView(initialView);
 
   if (notes.length === 0) {
@@ -27,7 +32,7 @@ export function TodayNoteList({ notes, initialView }: TodayNoteListProps) {
   return (
     <div className="space-y-4">
       <div className="flex items-center justify-between">
-        <p className="text-sm text-muted-foreground">총 {notes.length}개</p>
+        <p className="text-sm text-muted-foreground">총 {total}개</p>
         <ViewToggle view={view} onChange={updateView} />
       </div>
 

--- a/src/features/notes/queries.ts
+++ b/src/features/notes/queries.ts
@@ -83,20 +83,26 @@ export async function getNotes(
 
 export async function getTodayReviewNotes(
   userId: string,
-): Promise<NoteSummary[]> {
+  page = 1,
+  pageSize = 9,
+): Promise<{ notes: NoteSummary[]; total: number }> {
   const supabase = await createServerComponentClient();
   const { startUtcIso, endUtcIso } = getKstDayBoundsUtc();
+  const from = (page - 1) * pageSize;
+  const to = from + pageSize - 1;
 
-  const { data, error } = await supabase
+  const { data, error, count } = await supabase
     .from("notes")
     .select(
       "id, title, content, next_review_at, review_round, created_at, updated_at",
+      { count: "exact" },
     )
     .eq("user_id", userId)
     .gte("next_review_at", startUtcIso)
     .lt("next_review_at", endUtcIso)
     .order("next_review_at", { ascending: true })
-    .order("created_at", { ascending: false });
+    .order("created_at", { ascending: false })
+    .range(from, to);
 
   if (error) throw error;
 
@@ -107,10 +113,10 @@ export async function getTodayReviewNotes(
       message: "[getTodayReviewNotes] noteSummarySchema 파싱 실패",
       error: parsed.error,
     });
-    return [];
+    return { notes: [], total: 0 };
   }
 
-  return parsed.data;
+  return { notes: parsed.data, total: count ?? 0 };
 }
 
 export async function getReviewWaitingNotes(

--- a/src/features/notes/tests/NotesPagination.test.tsx
+++ b/src/features/notes/tests/NotesPagination.test.tsx
@@ -1,0 +1,70 @@
+import "./setup";
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { NotesPagination } from "../components/NotesPagination";
+
+const buildUrl = (page: number) => `/notes?page=${page}`;
+
+describe("NotesPagination", () => {
+  it("totalPages가 1 이하면 렌더링하지 않는다", () => {
+    const { container } = render(
+      <NotesPagination currentPage={1} totalPages={1} buildUrl={buildUrl} />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("현재 페이지는 링크가 아닌 span으로 렌더링해 동일 URL 재요청을 막는다", () => {
+    render(
+      <NotesPagination currentPage={2} totalPages={5} buildUrl={buildUrl} />,
+    );
+
+    const current = screen.getByLabelText("2 페이지");
+    expect(current.tagName).toBe("SPAN");
+    expect(current).toHaveAttribute("aria-current", "page");
+  });
+
+  it("활성(이동 가능) 버튼은 title과 aria-label을 유지한다", () => {
+    render(
+      <NotesPagination currentPage={3} totalPages={5} buildUrl={buildUrl} />,
+    );
+
+    for (const label of [
+      "첫 페이지",
+      "이전 페이지",
+      "다음 페이지",
+      "마지막 페이지",
+    ]) {
+      const el = screen.getByLabelText(label);
+      expect(el).toHaveAttribute("title", label);
+    }
+  });
+
+  it("첫 페이지에서 비활성화된 «·← 버튼도 title과 aria-label을 유지한다", () => {
+    render(
+      <NotesPagination currentPage={1} totalPages={5} buildUrl={buildUrl} />,
+    );
+
+    for (const label of ["첫 페이지", "이전 페이지"]) {
+      const el = screen.getByLabelText(label);
+      expect(el.tagName).toBe("SPAN");
+      expect(el).toHaveAttribute("aria-disabled", "true");
+      expect(el).toHaveAttribute("title", label);
+    }
+  });
+
+  it("마지막 페이지에서 비활성화된 →·» 버튼도 title과 aria-label을 유지한다", () => {
+    render(
+      <NotesPagination currentPage={5} totalPages={5} buildUrl={buildUrl} />,
+    );
+
+    for (const label of ["다음 페이지", "마지막 페이지"]) {
+      const el = screen.getByLabelText(label);
+      expect(el.tagName).toBe("SPAN");
+      expect(el).toHaveAttribute("aria-disabled", "true");
+      expect(el).toHaveAttribute("title", label);
+    }
+  });
+});

--- a/src/features/notes/tests/queries.test.ts
+++ b/src/features/notes/tests/queries.test.ts
@@ -15,6 +15,8 @@ vi.mock("@/features/review/lib/kstDay", () => ({
 
 vi.mock("@/lib/logger", () => ({ logError: vi.fn() }));
 
+import { createSupabaseQueryMock } from "@/tests/supabaseQueryMock";
+
 import {
   getNoteById,
   getNotes,
@@ -33,127 +35,6 @@ const BASE_NOTE = {
   created_at: "2026-05-01T00:00:00.000Z",
   updated_at: "2026-05-06T00:00:00.000Z",
 };
-
-// ─── Mock 팩토리 ─────────────────────────────────────────────────────────────
-
-function createNotesQueryMock(data: unknown, count = 0, error: unknown = null) {
-  const rangeMock = vi.fn().mockResolvedValue({ data, count, error });
-  const orMock = vi.fn().mockReturnValue({ range: rangeMock });
-  const orderMock = vi.fn().mockReturnValue({ or: orMock, range: rangeMock });
-  const eqMock = vi.fn().mockReturnValue({ order: orderMock });
-  const selectMock = vi.fn().mockReturnValue({ eq: eqMock });
-
-  return {
-    rangeMock,
-    orMock,
-    orderMock,
-    eqMock,
-    selectMock,
-    supabase: {
-      from: vi.fn().mockReturnValue({ select: selectMock }),
-    },
-  };
-}
-
-function createNoteDetailQueryMock(
-  data: unknown,
-  pendingLog: { scheduled_at: string } | null = null,
-) {
-  const maybeSingleMock = vi.fn().mockResolvedValue({ data });
-  const userEqMock = vi.fn().mockReturnValue({
-    maybeSingle: maybeSingleMock,
-  });
-  const idEqMock = vi.fn().mockReturnValue({
-    eq: userEqMock,
-  });
-  const noteSelectMock = vi.fn().mockReturnValue({
-    eq: idEqMock,
-  });
-
-  const pendingMaybeSingleMock = vi
-    .fn()
-    .mockResolvedValue({ data: pendingLog });
-  const pendingLimitMock = vi.fn().mockReturnValue({
-    maybeSingle: pendingMaybeSingleMock,
-  });
-  const pendingOrderMock = vi.fn().mockReturnValue({
-    limit: pendingLimitMock,
-  });
-  const pendingIsMock = vi.fn().mockReturnValue({
-    order: pendingOrderMock,
-  });
-  const pendingUserEqMock = vi.fn().mockReturnValue({
-    is: pendingIsMock,
-  });
-  const pendingNoteEqMock = vi.fn().mockReturnValue({
-    eq: pendingUserEqMock,
-  });
-  const pendingSelectMock = vi.fn().mockReturnValue({
-    eq: pendingNoteEqMock,
-  });
-
-  const fromMock = vi
-    .fn()
-    .mockImplementation((table: string) =>
-      table === "review_logs"
-        ? { select: pendingSelectMock }
-        : { select: noteSelectMock },
-    );
-
-  return {
-    idEqMock,
-    maybeSingleMock,
-    selectMock: noteSelectMock,
-    userEqMock,
-    pendingSelectMock,
-    pendingNoteEqMock,
-    pendingUserEqMock,
-    pendingIsMock,
-    pendingOrderMock,
-    pendingLimitMock,
-    pendingMaybeSingleMock,
-    fromMock,
-    supabase: {
-      from: fromMock,
-    },
-  };
-}
-
-// .eq → .gte → .lt → .order → { data }
-function createTodayNotesQueryMock(data: unknown, error: unknown = null) {
-  const order2Mock = vi.fn().mockResolvedValue({ data, error });
-  const order1Mock = vi.fn().mockReturnValue({ order: order2Mock });
-  const ltMock = vi.fn().mockReturnValue({ order: order1Mock });
-  const gteMock = vi.fn().mockReturnValue({ lt: ltMock });
-  const eqMock = vi.fn().mockReturnValue({ gte: gteMock });
-  const selectMock = vi.fn().mockReturnValue({ eq: eqMock });
-  return {
-    orderMock: order1Mock,
-    order2Mock,
-    ltMock,
-    gteMock,
-    eqMock,
-    selectMock,
-    supabase: { from: vi.fn().mockReturnValue({ select: selectMock }) },
-  };
-}
-
-// .eq → .or → .order → .limit → { data }
-function createWaitingNotesQueryMock(data: unknown, error: unknown = null) {
-  const limitMock = vi.fn().mockResolvedValue({ data, error });
-  const orderMock = vi.fn().mockReturnValue({ limit: limitMock });
-  const orMock = vi.fn().mockReturnValue({ order: orderMock });
-  const eqMock = vi.fn().mockReturnValue({ or: orMock });
-  const selectMock = vi.fn().mockReturnValue({ eq: eqMock });
-  return {
-    limitMock,
-    orderMock,
-    orMock,
-    eqMock,
-    selectMock,
-    supabase: { from: vi.fn().mockReturnValue({ select: selectMock }) },
-  };
-}
 
 // ─── getNotes ────────────────────────────────────────────────────────────────
 
@@ -183,39 +64,49 @@ describe("getNotes", () => {
         updated_at: "2026-03-28T12:00:00.000Z",
       },
     ];
-    const { supabase, selectMock, eqMock, orderMock, rangeMock } =
-      createNotesQueryMock(notes, 2);
+    const { supabase, from, callsFor } = createSupabaseQueryMock({
+      notes: { data: notes, count: 2 },
+    });
 
     createClientMock.mockResolvedValue(supabase);
 
     const result = await getNotes("user-123");
 
-    expect(supabase.from).toHaveBeenCalledWith("notes");
-    expect(selectMock).toHaveBeenCalledWith(
-      "id, title, content, next_review_at, review_round, created_at, updated_at",
-      { count: "exact" },
-    );
-    expect(eqMock).toHaveBeenCalledWith("user_id", "user-123");
-    expect(orderMock).toHaveBeenCalledWith("updated_at", { ascending: false });
-    expect(rangeMock).toHaveBeenCalledWith(0, 4);
+    expect(from).toHaveBeenCalledWith("notes");
+    const calls = callsFor("notes");
+    expect(calls).toContainEqual([
+      "select",
+      [
+        "id, title, content, next_review_at, review_round, created_at, updated_at",
+        { count: "exact" },
+      ],
+    ]);
+    expect(calls).toContainEqual(["eq", ["user_id", "user-123"]]);
+    expect(calls).toContainEqual([
+      "order",
+      ["updated_at", { ascending: false }],
+    ]);
+    expect(calls).toContainEqual(["range", [0, 4]]);
     expect(result).toEqual({ notes, total: 2 });
   });
 
   it("returns an empty list when the query result does not match the schema", async () => {
-    const { supabase } = createNotesQueryMock(
-      [
-        {
-          id: "invalid-note-id",
-          title: "잘못된 노트",
-          content: "내용",
-          next_review_at: null,
-          review_round: 1,
-          created_at: "2026-03-29T00:00:00.000Z",
-          updated_at: "2026-03-29T12:00:00.000Z",
-        },
-      ],
-      1,
-    );
+    const { supabase } = createSupabaseQueryMock({
+      notes: {
+        data: [
+          {
+            id: "invalid-note-id",
+            title: "잘못된 노트",
+            content: "내용",
+            next_review_at: null,
+            review_round: 1,
+            created_at: "2026-03-29T00:00:00.000Z",
+            updated_at: "2026-03-29T12:00:00.000Z",
+          },
+        ],
+        count: 1,
+      },
+    });
 
     createClientMock.mockResolvedValue(supabase);
 
@@ -226,39 +117,31 @@ describe("getNotes", () => {
 
   it("DB 쿼리 에러 발생 시 throw한다", async () => {
     const dbError = new Error("DB connection failed");
-    const { supabase } = createNotesQueryMock(null, 0, dbError);
+    const { supabase } = createSupabaseQueryMock({
+      notes: { data: null, count: 0, error: dbError },
+    });
     createClientMock.mockResolvedValue(supabase);
 
     await expect(getNotes("user-123")).rejects.toThrow("DB connection failed");
   });
 
   it("returns note detail with notification time of day and pending scheduled_at", async () => {
-    const {
-      supabase,
-      selectMock,
-      idEqMock,
-      userEqMock,
-      maybeSingleMock,
-      pendingSelectMock,
-      pendingNoteEqMock,
-      pendingUserEqMock,
-      pendingIsMock,
-      pendingOrderMock,
-      pendingLimitMock,
-    } = createNoteDetailQueryMock(
-      {
-        id: "11111111-1111-4111-8111-111111111111",
-        title: "알림 시간 노트",
-        content: "note body",
-        next_review_at: "2026-03-30T09:00:00.000Z",
-        notification_time_of_day: "21:30:00",
-        review_round: 1,
-        created_at: "2026-03-29T00:00:00.000Z",
-        updated_at: "2026-03-29T01:00:00.000Z",
-        user_id: "22222222-2222-4222-8222-222222222222",
+    const { supabase, callsFor } = createSupabaseQueryMock({
+      notes: {
+        data: {
+          id: "11111111-1111-4111-8111-111111111111",
+          title: "알림 시간 노트",
+          content: "note body",
+          next_review_at: "2026-03-30T09:00:00.000Z",
+          notification_time_of_day: "21:30:00",
+          review_round: 1,
+          created_at: "2026-03-29T00:00:00.000Z",
+          updated_at: "2026-03-29T01:00:00.000Z",
+          user_id: "22222222-2222-4222-8222-222222222222",
+        },
       },
-      { scheduled_at: "2026-03-30T12:30:00.000Z" },
-    );
+      review_logs: { data: { scheduled_at: "2026-03-30T12:30:00.000Z" } },
+    });
 
     createClientMock.mockResolvedValue(supabase);
 
@@ -267,33 +150,39 @@ describe("getNotes", () => {
       "22222222-2222-4222-8222-222222222222",
     );
 
-    expect(selectMock).toHaveBeenCalledWith(
-      "id, title, content, next_review_at, notification_time_of_day, review_round, created_at, updated_at, user_id",
-    );
-    expect(idEqMock).toHaveBeenCalledWith(
-      "id",
-      "11111111-1111-4111-8111-111111111111",
-    );
-    expect(userEqMock).toHaveBeenCalledWith(
-      "user_id",
-      "22222222-2222-4222-8222-222222222222",
-    );
-    expect(maybeSingleMock).toHaveBeenCalledOnce();
+    const noteCalls = callsFor("notes");
+    expect(noteCalls).toContainEqual([
+      "select",
+      [
+        "id, title, content, next_review_at, notification_time_of_day, review_round, created_at, updated_at, user_id",
+      ],
+    ]);
+    expect(noteCalls).toContainEqual([
+      "eq",
+      ["id", "11111111-1111-4111-8111-111111111111"],
+    ]);
+    expect(noteCalls).toContainEqual([
+      "eq",
+      ["user_id", "22222222-2222-4222-8222-222222222222"],
+    ]);
+    expect(noteCalls).toContainEqual(["maybeSingle", []]);
 
-    expect(pendingSelectMock).toHaveBeenCalledWith("scheduled_at");
-    expect(pendingNoteEqMock).toHaveBeenCalledWith(
-      "note_id",
-      "11111111-1111-4111-8111-111111111111",
-    );
-    expect(pendingUserEqMock).toHaveBeenCalledWith(
-      "user_id",
-      "22222222-2222-4222-8222-222222222222",
-    );
-    expect(pendingIsMock).toHaveBeenCalledWith("completed_at", null);
-    expect(pendingOrderMock).toHaveBeenCalledWith("scheduled_at", {
-      ascending: true,
-    });
-    expect(pendingLimitMock).toHaveBeenCalledWith(1);
+    const logCalls = callsFor("review_logs");
+    expect(logCalls).toContainEqual(["select", ["scheduled_at"]]);
+    expect(logCalls).toContainEqual([
+      "eq",
+      ["note_id", "11111111-1111-4111-8111-111111111111"],
+    ]);
+    expect(logCalls).toContainEqual([
+      "eq",
+      ["user_id", "22222222-2222-4222-8222-222222222222"],
+    ]);
+    expect(logCalls).toContainEqual(["is", ["completed_at", null]]);
+    expect(logCalls).toContainEqual([
+      "order",
+      ["scheduled_at", { ascending: true }],
+    ]);
+    expect(logCalls).toContainEqual(["limit", [1]]);
 
     expect(result).toMatchObject({
       id: "11111111-1111-4111-8111-111111111111",
@@ -303,20 +192,22 @@ describe("getNotes", () => {
   });
 
   it("returns next_scheduled_at as null when no pending review_log exists", async () => {
-    const { supabase } = createNoteDetailQueryMock(
-      {
-        id: "11111111-1111-4111-8111-111111111111",
-        title: "완료된 노트",
-        content: "note body",
-        next_review_at: null,
-        notification_time_of_day: null,
-        review_round: 3,
-        created_at: "2026-03-29T00:00:00.000Z",
-        updated_at: "2026-03-29T01:00:00.000Z",
-        user_id: "22222222-2222-4222-8222-222222222222",
+    const { supabase } = createSupabaseQueryMock({
+      notes: {
+        data: {
+          id: "11111111-1111-4111-8111-111111111111",
+          title: "완료된 노트",
+          content: "note body",
+          next_review_at: null,
+          notification_time_of_day: null,
+          review_round: 3,
+          created_at: "2026-03-29T00:00:00.000Z",
+          updated_at: "2026-03-29T01:00:00.000Z",
+          user_id: "22222222-2222-4222-8222-222222222222",
+        },
       },
-      null,
-    );
+      review_logs: { data: null },
+    });
 
     createClientMock.mockResolvedValue(supabase);
 
@@ -344,36 +235,66 @@ describe("getTodayReviewNotes", () => {
   });
 
   it("KST 오늘 범위 내 노트를 반환한다", async () => {
-    const { supabase, eqMock, gteMock, ltMock, orderMock, order2Mock } =
-      createTodayNotesQueryMock([BASE_NOTE]);
+    const { supabase, callsFor } = createSupabaseQueryMock({
+      notes: { data: [BASE_NOTE], count: 1 },
+    });
     createClientMock.mockResolvedValue(supabase);
 
     const result = await getTodayReviewNotes("user-123");
 
-    expect(eqMock).toHaveBeenCalledWith("user_id", "user-123");
-    expect(gteMock).toHaveBeenCalledWith("next_review_at", KST_START);
-    expect(ltMock).toHaveBeenCalledWith("next_review_at", KST_END);
-    expect(orderMock).toHaveBeenCalledWith("next_review_at", {
-      ascending: true,
-    });
-    expect(order2Mock).toHaveBeenCalledWith("created_at", { ascending: false });
-    expect(result).toEqual([BASE_NOTE]);
+    const calls = callsFor("notes");
+    expect(calls).toContainEqual(["eq", ["user_id", "user-123"]]);
+    expect(calls).toContainEqual(["gte", ["next_review_at", KST_START]]);
+    expect(calls).toContainEqual(["lt", ["next_review_at", KST_END]]);
+    expect(calls).toContainEqual([
+      "order",
+      ["next_review_at", { ascending: true }],
+    ]);
+    expect(calls).toContainEqual([
+      "order",
+      ["created_at", { ascending: false }],
+    ]);
+    expect(result).toEqual({ notes: [BASE_NOTE], total: 1 });
   });
 
-  it("스키마 파싱 실패 시 빈 배열을 반환한다", async () => {
-    const { supabase } = createTodayNotesQueryMock([
-      { ...BASE_NOTE, id: "not-a-uuid" },
-    ]);
+  it("기본 page=1은 첫 페이지 range로 조회한다", async () => {
+    const { supabase, callsFor } = createSupabaseQueryMock({
+      notes: { data: [BASE_NOTE], count: 1 },
+    });
+    createClientMock.mockResolvedValue(supabase);
+
+    await getTodayReviewNotes("user-123");
+
+    expect(callsFor("notes")).toContainEqual(["range", [0, 8]]);
+  });
+
+  it("page/pageSize에 맞는 range로 조회한다", async () => {
+    const { supabase, callsFor } = createSupabaseQueryMock({
+      notes: { data: [], count: 20 },
+    });
+    createClientMock.mockResolvedValue(supabase);
+
+    await getTodayReviewNotes("user-123", 3, 9);
+
+    expect(callsFor("notes")).toContainEqual(["range", [18, 26]]);
+  });
+
+  it("스키마 파싱 실패 시 빈 결과를 반환한다", async () => {
+    const { supabase } = createSupabaseQueryMock({
+      notes: { data: [{ ...BASE_NOTE, id: "not-a-uuid" }], count: 1 },
+    });
     createClientMock.mockResolvedValue(supabase);
 
     const result = await getTodayReviewNotes("user-123");
 
-    expect(result).toEqual([]);
+    expect(result).toEqual({ notes: [], total: 0 });
   });
 
   it("DB 쿼리 에러 발생 시 throw한다", async () => {
     const dbError = new Error("DB connection failed");
-    const { supabase } = createTodayNotesQueryMock(null, dbError);
+    const { supabase } = createSupabaseQueryMock({
+      notes: { data: null, error: dbError },
+    });
     createClientMock.mockResolvedValue(supabase);
 
     await expect(getTodayReviewNotes("user-123")).rejects.toThrow(
@@ -381,13 +302,15 @@ describe("getTodayReviewNotes", () => {
     );
   });
 
-  it("DB가 빈 배열을 반환하면 빈 배열을 반환한다", async () => {
-    const { supabase } = createTodayNotesQueryMock([]);
+  it("DB가 빈 배열을 반환하면 빈 결과를 반환한다", async () => {
+    const { supabase } = createSupabaseQueryMock({
+      notes: { data: [], count: 0 },
+    });
     createClientMock.mockResolvedValue(supabase);
 
     const result = await getTodayReviewNotes("user-123");
 
-    expect(result).toEqual([]);
+    expect(result).toEqual({ notes: [], total: 0 });
   });
 });
 
@@ -410,7 +333,9 @@ describe("getReviewWaitingNotes", () => {
       next_review_at: "2026-05-08T10:00:00.000Z",
       review_round: 1,
     };
-    const { supabase } = createWaitingNotesQueryMock([futureNote]);
+    const { supabase } = createSupabaseQueryMock({
+      notes: { data: [futureNote] },
+    });
     createClientMock.mockResolvedValue(supabase);
 
     const result = await getReviewWaitingNotes("user-123");
@@ -424,7 +349,9 @@ describe("getReviewWaitingNotes", () => {
       next_review_at: null,
       review_round: 0,
     };
-    const { supabase } = createWaitingNotesQueryMock([newNote]);
+    const { supabase } = createSupabaseQueryMock({
+      notes: { data: [newNote] },
+    });
     createClientMock.mockResolvedValue(supabase);
 
     const result = await getReviewWaitingNotes("user-123");
@@ -433,14 +360,21 @@ describe("getReviewWaitingNotes", () => {
   });
 
   it("DB 쿼리에서 완주 노트(null && round>0)를 제외하는 필터를 사용한다", async () => {
-    const { supabase, orMock } = createWaitingNotesQueryMock([]);
+    const { supabase, callsFor } = createSupabaseQueryMock({
+      notes: { data: [] },
+    });
     createClientMock.mockResolvedValue(supabase);
 
     await getReviewWaitingNotes("user-123");
 
-    expect(orMock).toHaveBeenCalledWith(
-      expect.stringContaining("and(next_review_at.is.null,review_round.eq.0)"),
-    );
+    expect(callsFor("notes")).toContainEqual([
+      "or",
+      [
+        expect.stringContaining(
+          "and(next_review_at.is.null,review_round.eq.0)",
+        ),
+      ],
+    ]);
   });
 
   it("미시작 노트(null && round=0)와 미래 예약 노트를 함께 반환한다", async () => {
@@ -451,7 +385,9 @@ describe("getReviewWaitingNotes", () => {
       next_review_at: "2026-05-08T10:00:00.000Z",
       review_round: 1,
     };
-    const { supabase } = createWaitingNotesQueryMock([newNote, futureNote]);
+    const { supabase } = createSupabaseQueryMock({
+      notes: { data: [newNote, futureNote] },
+    });
     createClientMock.mockResolvedValue(supabase);
 
     const result = await getReviewWaitingNotes("user-123");
@@ -460,9 +396,9 @@ describe("getReviewWaitingNotes", () => {
   });
 
   it("스키마 파싱 실패 시 빈 배열을 반환한다", async () => {
-    const { supabase } = createWaitingNotesQueryMock([
-      { ...BASE_NOTE, id: "not-a-uuid" },
-    ]);
+    const { supabase } = createSupabaseQueryMock({
+      notes: { data: [{ ...BASE_NOTE, id: "not-a-uuid" }] },
+    });
     createClientMock.mockResolvedValue(supabase);
 
     const result = await getReviewWaitingNotes("user-123");
@@ -472,7 +408,9 @@ describe("getReviewWaitingNotes", () => {
 
   it("DB 쿼리 에러 발생 시 throw한다", async () => {
     const dbError = new Error("DB connection failed");
-    const { supabase } = createWaitingNotesQueryMock(null, dbError);
+    const { supabase } = createSupabaseQueryMock({
+      notes: { data: null, error: dbError },
+    });
     createClientMock.mockResolvedValue(supabase);
 
     await expect(getReviewWaitingNotes("user-123")).rejects.toThrow(

--- a/src/lib/constants/notes.ts
+++ b/src/lib/constants/notes.ts
@@ -1,2 +1,3 @@
 export const NOTES_LIST_PAGE_SIZE = 5;
 export const NOTES_CARDS_PAGE_SIZE = 9;
+export const TODAY_PAGE_SIZE = 9;

--- a/src/tests/supabaseQueryMock.ts
+++ b/src/tests/supabaseQueryMock.ts
@@ -1,0 +1,72 @@
+import { vi } from "vitest";
+
+type QueryResult = {
+  data?: unknown;
+  error?: unknown;
+  count?: number | null;
+};
+
+type ResolvedQueryResult = {
+  data: unknown;
+  error: unknown;
+  count: number | null;
+};
+
+export type RecordedCall = [method: string, args: unknown[]];
+
+type QueryBuilderMock = PromiseLike<ResolvedQueryResult> &
+  Record<string, (...args: unknown[]) => unknown>;
+
+// 체인 모양(메서드 순서·개수)에 의존하지 않는 쿼리 빌더 mock.
+// 모든 메서드 호출을 calls에 기록하고 자기 자신을 반환하며, await 시 result를 resolve한다.
+// 쿼리에 .range()·.limit() 등이 추가·제거돼도 mock이 깨지지 않도록
+// 테스트는 체인 순서 대신 "어떤 메서드가 어떤 인자로 호출됐는가"를 검증한다.
+function createQueryBuilderMock(result: QueryResult) {
+  const calls: RecordedCall[] = [];
+  const resolved: ResolvedQueryResult = {
+    data: null,
+    error: null,
+    count: null,
+    ...result,
+  };
+
+  const builder: QueryBuilderMock = new Proxy({} as QueryBuilderMock, {
+    get(_target, prop) {
+      if (typeof prop !== "string") return undefined;
+      if (prop === "then") {
+        return (
+          onFulfilled?: (value: ResolvedQueryResult) => unknown,
+          onRejected?: (reason: unknown) => unknown,
+        ) => Promise.resolve(resolved).then(onFulfilled, onRejected);
+      }
+      return (...args: unknown[]) => {
+        calls.push([prop, args]);
+        return builder;
+      };
+    },
+  });
+
+  return { builder, calls };
+}
+
+// 테이블별 결과를 지정해 supabase 클라이언트 mock을 생성한다.
+// 같은 테이블을 여러 번 조회하면 호출 기록이 하나의 calls 배열에 누적된다.
+export function createSupabaseQueryMock(
+  resultsByTable: Record<string, QueryResult>,
+) {
+  const builders = new Map(
+    Object.entries(resultsByTable).map(([table, result]) => [
+      table,
+      createQueryBuilderMock(result),
+    ]),
+  );
+
+  const from = vi.fn((table: string) => builders.get(table)?.builder);
+
+  return {
+    supabase: { from },
+    from,
+    callsFor: (table: string): RecordedCall[] =>
+      builders.get(table)?.calls ?? [],
+  };
+}


### PR DESCRIPTION
## 개요

`/notes` 페이지네이션의 UX 문제 4가지를 수정하고, 오늘의 복습(`/notes/today`)에 페이지네이션을 도입합니다. 추가로 쿼리 체인 변경 시마다 깨지던 테스트 mock을 체인 모양에 의존하지 않는 범용 mock으로 교체했습니다.

## PR 유형

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [x] UI 디자인 변경
- [ ] 코드 리팩토링
- [x] 테스트 추가/수정
- [ ] 문서 수정
- [ ] 빌드/패키지 설정 변경

## 관련 이슈

closes #245

## 작업 내용

**1. 현재 페이지 클릭 시 불필요한 재요청 제거** — `NotesPagination.tsx`
- 활성 페이지를 `<Link>` 대신 `<span>`으로 렌더링해 동일 URL 재요청 차단

**2. 이전/다음 버튼 호버 툴팁 추가** — `NotesPagination.tsx`
- `←`/`→` 버튼에 `title="이전 페이지"` / `title="다음 페이지"` 추가

**3. 첫/마지막 페이지 이동 버튼 추가** — `NotesPagination.tsx`
- `«`(첫 페이지) / `»`(마지막 페이지) 버튼 추가, `title`/`aria-label` 포함
- URL 생성을 `buildUrl` 콜백 prop으로 일반화해 `/notes`와 `/notes/today`에서 재사용

**4. 오늘의 복습 페이지네이션 도입** — `today/page.tsx`, `queries.ts`, `TodayNoteList.tsx`, `lib/constants/notes.ts`
- `getTodayReviewNotes`에 `page`/`pageSize` 파라미터 + `count: "exact"` + `.range()` 적용, 반환 타입 `{ notes, total }`로 변경
- `TODAY_PAGE_SIZE`(9) 상수 추가, `?page=` searchParam 처리

**5. page 파라미터 방어 처리** — `notes/page.tsx`, `today/page.tsx`
- page 파라미터 정수화 및 범위 밖(out-of-range) 페이지 접근 시 redirect

**6. 범용 Supabase 쿼리 mock 도입** — `src/tests/supabaseQueryMock.ts` (신규), `queries.test.ts`
- 기존 mock이 쿼리 체인 순서를 하드코딩해 `.range()` 추가만으로 4개 테스트가 깨지는 문제 발견
- 모든 메서드 호출을 기록하고 자기 자신을 반환하는 thenable Proxy 기반 mock으로 교체 — 체인 순서 대신 "어떤 메서드가 어떤 인자로 호출됐는가"를 검증
- 손수 만든 체인 mock 팩토리 4개 제거, 테스트 15 → 17개 (range 검증 2개 추가)

## 테스트 방법

1. `/notes`에서 페이지 2 이상 이동 후 현재 페이지 번호 클릭 → 네트워크 요청 없음 확인
2. `«` `←` `→` `»` 버튼 호버 → 툴팁 표시 확인, 첫/마지막 페이지 이동 확인
3. 복습할 노트가 10개 이상인 계정으로 `/notes/today` 접속 → 페이지네이션 표시 확인
4. `/notes/today?page=999` 접속 → 마지막 페이지로 redirect 확인
5. `npx vitest run` → 157 파일 / 1383 테스트 전체 통과

## 스크린샷 (FE 변경 시)

<!-- TODO: 스크린샷 첨부 -->

## 리뷰 요구사항 (선택)

- `src/tests/supabaseQueryMock.ts`의 Proxy 기반 mock 접근이 팀 컨벤션에 맞는지 봐주세요. 오타 메서드도 통과시키는 트레이드오프가 있지만, 프로덕션 코드는 type-check가 잡아줍니다.

## 체크리스트

- [x] 코드 컨벤션 준수
- [x] 커밋 메시지 컨벤션 준수
- [x] lint 통과
- [x] typecheck 통과
- [ ] (DB 변경 시) migration 포함 및 로컬 재현 확인 — 해당 없음
- [ ] (권한/RLS 영향 시) 정책 변경 요약 기재 — 해당 없음
- [ ] UI 변경 시 스크린샷/짧은 설명 첨부 — 스크린샷 첨부 필요
- [x] 셀프 리뷰 완료