### PR TITLE
chore: #250 - Vercel Cron을 cron-job.org로 이관

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,8 +1,1 @@
-{
-  "crons": [
-    {
-      "path": "/api/cron/dispatch-notifications",
-      "schedule": "*/5 * * * *"
-    }
-  ]
-}
+{}


### PR DESCRIPTION
## 개요

알림 발송 cron(`/api/cron/dispatch-notifications`)을 기존 Vercel Cron에서 cron-job.org로 이관한다. `vercel.json`의 `crons` 설정을 제거한다.

## PR 유형

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] UI 디자인 변경
- [ ] 코드 리팩토링
- [ ] 테스트 추가/수정
- [ ] 문서 수정
- [x] 빌드/패키지 설정 변경

## 관련 이슈

closes #250

## 작업 내용

- cron-job.org에 `/api/cron/dispatch-notifications` cronjob 등록 (5분 간격, `Authorization: Bearer $CRON_SECRET` 헤더)
- cron-job.org 실행 성공 확인 (200 OK)
- `vercel.json`에서 `crons` 설정 제거 (Vercel Cron과 이중 호출 방지)

## 테스트 방법

1. `curl -H "Authorization: Bearer $CRON_SECRET" https://woodpecker-blue.vercel.app/api/cron/dispatch-notifications` → 200 OK 확인
2. cron-job.org 대시보드에서 5분 간격 실행 이력 확인 (Successful, 200 OK)
3. `claim_due_review_logs` RPC가 `FOR UPDATE SKIP LOCKED` 기반이라 이관 과정 중 Vercel Cron과 cron-job.org가 동시에 호출되어도 중복 발송되지 않음을 확인

## 스크린샷 (FE 변경 시)
<img width="1591" height="717" alt="스크린샷 2026-07-21 142049" src="https://github.com/user-attachments/assets/4281be2e-50b6-4b35-8f9c-b254b26efd4c" />


## 리뷰 요구사항 (선택)

없음

## 체크리스트

- [x] 코드 컨벤션 준수
- [x] 커밋 메시지 컨벤션 준수
- [x] lint 통과
- [x] typecheck 통과
- [ ] (DB 변경 시) migration 포함 및 로컬 재현 확인
- [ ] (권한/RLS 영향 시) 정책 변경 요약 기재
- [ ] UI 변경 시 스크린샷/짧은 설명 첨부
- [x] 셀프 리뷰 완료
