### PR TITLE
feat: #256 - 사용자 피드백 테이블 및 스토리지 버킷 마이그레이션 추가

### DIFF
--- a/supabase/migrations/20260723000000_create_feedback_table.sql
+++ b/supabase/migrations/20260723000000_create_feedback_table.sql
@@ -3,7 +3,7 @@
 -- 관리자 조회/상태 변경은 createAdminClient(RLS 우회)로 처리하므로
 -- 여기서는 사용자 본인 insert/select 정책만 정의한다.
 
-CREATE TABLE IF NOT EXISTS "public"."feedback" (
+CREATE TABLE IF NOT EXISTS "public"."feedbacks" (
     "id" "uuid" DEFAULT "gen_random_uuid"() NOT NULL,
     "user_id" "uuid" NOT NULL,
     "note_id" "uuid",
@@ -14,41 +14,41 @@ CREATE TABLE IF NOT EXISTS "public"."feedback" (
     "status" character varying(20) DEFAULT 'OPEN'::character varying NOT NULL,
     "created_at" timestamp with time zone DEFAULT "now"() NOT NULL,
     "updated_at" timestamp with time zone DEFAULT "now"() NOT NULL,
-    CONSTRAINT "feedback_category_check" CHECK ((("category")::"text" = ANY ((ARRAY['BUG'::character varying, 'FEATURE'::character varying, 'ETC'::character varying])::"text"[]))),
-    CONSTRAINT "feedback_status_check" CHECK ((("status")::"text" = ANY ((ARRAY['OPEN'::character varying, 'RESOLVED'::character varying])::"text"[])))
+    CONSTRAINT "feedbacks_category_check" CHECK ((("category")::"text" = ANY ((ARRAY['BUG'::character varying, 'FEATURE'::character varying, 'ETC'::character varying])::"text"[]))),
+    CONSTRAINT "feedbacks_status_check" CHECK ((("status")::"text" = ANY ((ARRAY['OPEN'::character varying, 'RESOLVED'::character varying])::"text"[])))
 );
 
 
-ALTER TABLE "public"."feedback" OWNER TO "postgres";
+ALTER TABLE "public"."feedbacks" OWNER TO "postgres";
 
 
-ALTER TABLE ONLY "public"."feedback"
-    ADD CONSTRAINT "feedback_pkey" PRIMARY KEY ("id");
+ALTER TABLE ONLY "public"."feedbacks"
+    ADD CONSTRAINT "feedbacks_pkey" PRIMARY KEY ("id");
 
 
-ALTER TABLE ONLY "public"."feedback"
-    ADD CONSTRAINT "feedback_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "auth"."users"("id") ON DELETE CASCADE;
+ALTER TABLE ONLY "public"."feedbacks"
+    ADD CONSTRAINT "feedbacks_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "auth"."users"("id") ON DELETE CASCADE;
 
 
-ALTER TABLE ONLY "public"."feedback"
-    ADD CONSTRAINT "feedback_note_id_fkey" FOREIGN KEY ("note_id") REFERENCES "public"."notes"("id") ON DELETE SET NULL;
+ALTER TABLE ONLY "public"."feedbacks"
+    ADD CONSTRAINT "feedbacks_note_id_fkey" FOREIGN KEY ("note_id") REFERENCES "public"."notes"("id") ON DELETE SET NULL;
 
 
-CREATE INDEX "feedback_user_id_idx" ON "public"."feedback" USING "btree" ("user_id");
+CREATE INDEX "feedbacks_user_id_idx" ON "public"."feedbacks" USING "btree" ("user_id");
 
 
-CREATE INDEX "feedback_status_created_at_idx" ON "public"."feedback" USING "btree" ("status", "created_at" DESC);
+CREATE INDEX "feedbacks_status_created_at_idx" ON "public"."feedbacks" USING "btree" ("status", "created_at" DESC);
 
 
-ALTER TABLE "public"."feedback" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."feedbacks" ENABLE ROW LEVEL SECURITY;
 
 
-CREATE POLICY "feedback_insert_own" ON "public"."feedback" FOR INSERT TO "authenticated" WITH CHECK (("auth"."uid"() = "user_id"));
+CREATE POLICY "feedbacks_insert_own" ON "public"."feedbacks" FOR INSERT TO "authenticated" WITH CHECK (("auth"."uid"() = "user_id"));
 
 
-CREATE POLICY "feedback_select_own" ON "public"."feedback" FOR SELECT TO "authenticated" USING (("auth"."uid"() = "user_id"));
+CREATE POLICY "feedbacks_select_own" ON "public"."feedbacks" FOR SELECT TO "authenticated" USING (("auth"."uid"() = "user_id"));
 
 
-GRANT ALL ON TABLE "public"."feedback" TO "anon";
-GRANT ALL ON TABLE "public"."feedback" TO "authenticated";
-GRANT ALL ON TABLE "public"."feedback" TO "service_role";
+GRANT ALL ON TABLE "public"."feedbacks" TO "anon";
+GRANT ALL ON TABLE "public"."feedbacks" TO "authenticated";
+GRANT ALL ON TABLE "public"."feedbacks" TO "service_role";

--- a/supabase/migrations/20260723000000_create_feedback_table.sql
+++ b/supabase/migrations/20260723000000_create_feedback_table.sql
@@ -1,0 +1,54 @@
+-- 사용자 피드백 제출 테이블
+-- 로그인 사용자가 의견/버그/개선요청을 남기면 저장한다.
+-- 관리자 조회/상태 변경은 createAdminClient(RLS 우회)로 처리하므로
+-- 여기서는 사용자 본인 insert/select 정책만 정의한다.
+
+CREATE TABLE IF NOT EXISTS "public"."feedback" (
+    "id" "uuid" DEFAULT "gen_random_uuid"() NOT NULL,
+    "user_id" "uuid" NOT NULL,
+    "note_id" "uuid",
+    "category" character varying(20) NOT NULL,
+    "title" character varying(100) NOT NULL,
+    "content" "text" NOT NULL,
+    "image_urls" "text"[] DEFAULT '{}'::"text"[] NOT NULL,
+    "status" character varying(20) DEFAULT 'OPEN'::character varying NOT NULL,
+    "created_at" timestamp with time zone DEFAULT "now"() NOT NULL,
+    "updated_at" timestamp with time zone DEFAULT "now"() NOT NULL,
+    CONSTRAINT "feedback_category_check" CHECK ((("category")::"text" = ANY ((ARRAY['BUG'::character varying, 'FEATURE'::character varying, 'ETC'::character varying])::"text"[]))),
+    CONSTRAINT "feedback_status_check" CHECK ((("status")::"text" = ANY ((ARRAY['OPEN'::character varying, 'RESOLVED'::character varying])::"text"[])))
+);
+
+
+ALTER TABLE "public"."feedback" OWNER TO "postgres";
+
+
+ALTER TABLE ONLY "public"."feedback"
+    ADD CONSTRAINT "feedback_pkey" PRIMARY KEY ("id");
+
+
+ALTER TABLE ONLY "public"."feedback"
+    ADD CONSTRAINT "feedback_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "auth"."users"("id") ON DELETE CASCADE;
+
+
+ALTER TABLE ONLY "public"."feedback"
+    ADD CONSTRAINT "feedback_note_id_fkey" FOREIGN KEY ("note_id") REFERENCES "public"."notes"("id") ON DELETE SET NULL;
+
+
+CREATE INDEX "feedback_user_id_idx" ON "public"."feedback" USING "btree" ("user_id");
+
+
+CREATE INDEX "feedback_status_created_at_idx" ON "public"."feedback" USING "btree" ("status", "created_at" DESC);
+
+
+ALTER TABLE "public"."feedback" ENABLE ROW LEVEL SECURITY;
+
+
+CREATE POLICY "feedback_insert_own" ON "public"."feedback" FOR INSERT TO "authenticated" WITH CHECK (("auth"."uid"() = "user_id"));
+
+
+CREATE POLICY "feedback_select_own" ON "public"."feedback" FOR SELECT TO "authenticated" USING (("auth"."uid"() = "user_id"));
+
+
+GRANT ALL ON TABLE "public"."feedback" TO "anon";
+GRANT ALL ON TABLE "public"."feedback" TO "authenticated";
+GRANT ALL ON TABLE "public"."feedback" TO "service_role";

--- a/supabase/migrations/20260723000001_create_feedback_bucket.sql
+++ b/supabase/migrations/20260723000001_create_feedback_bucket.sql
@@ -1,0 +1,57 @@
+-- feedback 첨부 이미지 버킷 (private)
+-- 버그 화면·개인정보가 담길 수 있으므로 public이 아닌 private로 둔다.
+--   조회는 서명 URL(createSignedUrl)로만 가능.
+-- 파일 경로 규칙: {auth.uid()}/{feedbackId 등}/파일명 → RLS는 첫 폴더가 본인 uid인지로 판별.
+INSERT INTO storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+VALUES (
+  'feedback',
+  'feedback',
+  false, -- private: URL만으로는 접근 불가, 서명 URL 필요
+  5242880, -- 5MB
+  ARRAY['image/jpeg', 'image/png', 'image/gif', 'image/webp']
+)
+ON CONFLICT (id) DO NOTHING;
+
+
+-- feedback bucket RLS policies
+--
+-- Design rules:
+-- - private 버킷이므로 본인 이미지 열람을 위한 SELECT 정책이 필요
+-- - INSERT/SELECT/UPDATE/DELETE 모두 본인 폴더({auth.uid()}/)로 제한
+-- - 관리자 조회는 service_role(adminClient)로 서명 URL을 만들어 RLS를 우회한다
+DROP POLICY IF EXISTS "feedback_authenticated_insert" ON storage.objects;
+DROP POLICY IF EXISTS "feedback_authenticated_select" ON storage.objects;
+DROP POLICY IF EXISTS "feedback_authenticated_update" ON storage.objects;
+DROP POLICY IF EXISTS "feedback_authenticated_delete" ON storage.objects;
+
+CREATE POLICY "feedback_authenticated_insert"
+  ON storage.objects FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    bucket_id = 'feedback'
+    AND (storage.foldername(name))[1] = auth.uid()::text
+  );
+
+CREATE POLICY "feedback_authenticated_select"
+  ON storage.objects FOR SELECT
+  TO authenticated
+  USING (
+    bucket_id = 'feedback'
+    AND (storage.foldername(name))[1] = auth.uid()::text
+  );
+
+CREATE POLICY "feedback_authenticated_update"
+  ON storage.objects FOR UPDATE
+  TO authenticated
+  USING (
+    bucket_id = 'feedback'
+    AND (storage.foldername(name))[1] = auth.uid()::text
+  );
+
+CREATE POLICY "feedback_authenticated_delete"
+  ON storage.objects FOR DELETE
+  TO authenticated
+  USING (
+    bucket_id = 'feedback'
+    AND (storage.foldername(name))[1] = auth.uid()::text
+  );

--- a/supabase/migrations/20260723000001_create_feedback_bucket.sql
+++ b/supabase/migrations/20260723000001_create_feedback_bucket.sql
@@ -1,11 +1,11 @@
--- feedback 첨부 이미지 버킷 (private)
+-- feedbacks 첨부 이미지 버킷 (private)
 -- 버그 화면·개인정보가 담길 수 있으므로 public이 아닌 private로 둔다.
 --   조회는 서명 URL(createSignedUrl)로만 가능.
 -- 파일 경로 규칙: {auth.uid()}/{feedbackId 등}/파일명 → RLS는 첫 폴더가 본인 uid인지로 판별.
 INSERT INTO storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
 VALUES (
-  'feedback',
-  'feedback',
+  'feedbacks',
+  'feedbacks',
   false, -- private: URL만으로는 접근 불가, 서명 URL 필요
   5242880, -- 5MB
   ARRAY['image/jpeg', 'image/png', 'image/gif', 'image/webp']
@@ -13,45 +13,45 @@ VALUES (
 ON CONFLICT (id) DO NOTHING;
 
 
--- feedback bucket RLS policies
+-- feedbacks bucket RLS policies
 --
 -- Design rules:
 -- - private 버킷이므로 본인 이미지 열람을 위한 SELECT 정책이 필요
 -- - INSERT/SELECT/UPDATE/DELETE 모두 본인 폴더({auth.uid()}/)로 제한
 -- - 관리자 조회는 service_role(adminClient)로 서명 URL을 만들어 RLS를 우회한다
-DROP POLICY IF EXISTS "feedback_authenticated_insert" ON storage.objects;
-DROP POLICY IF EXISTS "feedback_authenticated_select" ON storage.objects;
-DROP POLICY IF EXISTS "feedback_authenticated_update" ON storage.objects;
-DROP POLICY IF EXISTS "feedback_authenticated_delete" ON storage.objects;
+DROP POLICY IF EXISTS "feedbacks_authenticated_insert" ON storage.objects;
+DROP POLICY IF EXISTS "feedbacks_authenticated_select" ON storage.objects;
+DROP POLICY IF EXISTS "feedbacks_authenticated_update" ON storage.objects;
+DROP POLICY IF EXISTS "feedbacks_authenticated_delete" ON storage.objects;
 
-CREATE POLICY "feedback_authenticated_insert"
+CREATE POLICY "feedbacks_authenticated_insert"
   ON storage.objects FOR INSERT
   TO authenticated
   WITH CHECK (
-    bucket_id = 'feedback'
+    bucket_id = 'feedbacks'
     AND (storage.foldername(name))[1] = auth.uid()::text
   );
 
-CREATE POLICY "feedback_authenticated_select"
+CREATE POLICY "feedbacks_authenticated_select"
   ON storage.objects FOR SELECT
   TO authenticated
   USING (
-    bucket_id = 'feedback'
+    bucket_id = 'feedbacks'
     AND (storage.foldername(name))[1] = auth.uid()::text
   );
 
-CREATE POLICY "feedback_authenticated_update"
+CREATE POLICY "feedbacks_authenticated_update"
   ON storage.objects FOR UPDATE
   TO authenticated
   USING (
-    bucket_id = 'feedback'
+    bucket_id = 'feedbacks'
     AND (storage.foldername(name))[1] = auth.uid()::text
   );
 
-CREATE POLICY "feedback_authenticated_delete"
+CREATE POLICY "feedbacks_authenticated_delete"
   ON storage.objects FOR DELETE
   TO authenticated
   USING (
-    bucket_id = 'feedback'
+    bucket_id = 'feedbacks'
     AND (storage.foldername(name))[1] = auth.uid()::text
   );


### PR DESCRIPTION
## 개요

사용자 피드백 제출 기능(#256)의 기반이 되는 DB 스키마를 추가합니다.
피드백 본문(제목/카테고리/내용)을 저장할 `feedbacks` 테이블과, 첨부 이미지를
보관할 private 스토리지 버킷 `feedbacks`를 마이그레이션으로 정의했습니다.

## PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] UI 디자인 변경
- [ ] 코드 리팩토링
- [ ] 테스트 추가/수정
- [ ] 문서 수정
- [ ] 빌드/패키지 설정 변경

## 관련 이슈

closes #256

## 작업 내용

- `feedbacks` 테이블 추가 (`20260723000000_create_feedback_table.sql`)
  - 컬럼: `id`, `user_id`, `note_id`(nullable), `category`, `title`, `content`,
    `image_urls`(text[]), `status`, `created_at`, `updated_at`
  - FK: `user_id → auth.users`(ON DELETE CASCADE), `note_id → notes`(ON DELETE SET NULL)
  - CHECK: `category`(BUG/FEATURE/ETC), `status`(OPEN/RESOLVED)
  - 인덱스: `user_id`, `(status, created_at DESC)`
  - RLS: 본인 insert/select 정책 (관리자 조회/상태변경은 adminClient로 RLS 우회)
- private 스토리지 버킷 `feedbacks` 추가 (`20260723000001_create_feedback_bucket.sql`)
  - private(서명 URL 접근), 5MB 제한, 이미지 MIME만 허용
  - Storage RLS: 본인 폴더(`{uid}/`)에 대해 insert/select/update/delete
- 다른 테이블 컨벤션에 맞춰 테이블·버킷·제약·인덱스·정책명 모두 복수형(`feedbacks`)으로 통일

## 테스트 방법

1. 개발 Supabase 대시보드 SQL Editor에서 두 마이그레이션을 순서대로 실행
   (테이블 → 버킷)
2. Table Editor에 `feedbacks` 테이블, Storage에 `feedbacks`(private) 버킷 생성 확인
3. RLS 정책(본인 insert/select), CHECK 제약(category/status) 적용 확인

## 스크린샷 (FE 변경 시)

해당 없음 (DB 스키마만 변경)

## 리뷰 요구사항 (선택)

- `image_urls`를 `text[]`(다중 이미지)로 둔 설계, `status`/`updated_at`을 초기 스키마에
  포함(관리자 처리 대비)한 부분에 대한 의견
- 피드백 첨부 버킷을 avatars와 달리 private로 둔 방향 검토

## 체크리스트

- [x] 코드 컨벤션 준수
- [x] 커밋 메시지 컨벤션 준수
- [x] lint 통과
- [x] typecheck 통과
- [x] (DB 변경 시) migration 포함 및 로컬 재현 확인
- [x] (권한/RLS 영향 시) 정책 변경 요약 기재
- [ ] UI 변경 시 스크린샷/짧은 설명 첨부 <!-- 해당 없음 -->
- [x] 셀프 리뷰 완료
