### PR TITLE
feat: #266 - 마이페이지 사용자 피드백 탭 구현 (재적용)

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,7 +1,7 @@
 ---
 name: "🚀 Feature Request"
 about: "새로운 기능 제안 및 구현 작업을 위한 템플릿입니다."
-title: "[Feat/auth] 00 기능 구현"
+title: "[Feat/도메인 라벨] 00 기능 구현"
 labels: "enhancement"
 assignees: ""
 ---

--- a/next.config.ts
+++ b/next.config.ts
@@ -7,24 +7,42 @@ const supabaseHostname =
     ? new URL(process.env.NEXT_PUBLIC_SUPABASE_URL).hostname
     : undefined);
 
-const supabaseImagePattern = process.env.NEXT_PUBLIC_SUPABASE_URL
+// Supabase Storage 이미지를 next/image로 표시하기 위한 허용 패턴입니다.
+// feedback/feedback_replies bucket은 private이므로 signed URL 경로도 함께 허용합니다.
+const supabaseImagePatterns = process.env.NEXT_PUBLIC_SUPABASE_URL
   ? (() => {
       const url = new URL(process.env.NEXT_PUBLIC_SUPABASE_URL!);
 
-      return {
-        protocol: url.protocol.replace(":", "") as "http" | "https",
-        hostname: url.hostname,
-        port: url.port,
-        pathname: "/storage/v1/object/public/**",
-      };
+      return [
+        {
+          protocol: url.protocol.replace(":", "") as "http" | "https",
+          hostname: url.hostname,
+          port: url.port,
+          pathname: "/storage/v1/object/public/**",
+        },
+        {
+          protocol: url.protocol.replace(":", "") as "http" | "https",
+          hostname: url.hostname,
+          port: url.port,
+          pathname: "/storage/v1/object/sign/**",
+        },
+      ];
     })()
   : supabaseHostname
-    ? {
-        protocol: "https" as const,
-        hostname: supabaseHostname,
-        port: "",
-        pathname: "/storage/v1/object/public/**",
-      }
+    ? [
+        {
+          protocol: "https" as const,
+          hostname: supabaseHostname,
+          port: "",
+          pathname: "/storage/v1/object/public/**",
+        },
+        {
+          protocol: "https" as const,
+          hostname: supabaseHostname,
+          port: "",
+          pathname: "/storage/v1/object/sign/**",
+        },
+      ]
     : undefined;
 
 export function shouldDisableSerwist() {
@@ -40,11 +58,12 @@ const nextConfig: NextConfig = {
   poweredByHeader: false,
   experimental: {
     serverActions: {
-      bodySizeLimit: "5mb",
+      // 관리자 답변은 5MB 이미지 여러 개를 FormData로 전달할 수 있어 기본 1MB보다 크게 둔다.
+      bodySizeLimit: "30mb",
     },
   },
   images: {
-    remotePatterns: [...(supabaseImagePattern ? [supabaseImagePattern] : [])],
+    remotePatterns: supabaseImagePatterns ?? [],
   },
   async headers() {
     const isProduction = process.env.NODE_ENV === "production";

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "lowlight": "^3.3.0",
         "lucide-react": "^0.577.0",
         "next": "^15.5.14",
-        "nodemailer": "^8.0.5",
+        "nodemailer": "^9.0.3",
         "radix-ui": "^1.4.3",
         "react": "19.1.0",
         "react-day-picker": "^10.0.1",
@@ -107,28 +107,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@antfu/ni": {
-      "version": "25.0.0",
-      "resolved": "https://registry.npmjs.org/@antfu/ni/-/ni-25.0.0.tgz",
-      "integrity": "sha512-9q/yCljni37pkMr4sPrI3G4jqdIk074+iukc5aFJl7kmDCCsiJrbZ6zKxnES1Gwg+i9RcDZwvktl23puGslmvA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansis": "^4.0.0",
-        "fzf": "^0.5.2",
-        "package-manager-detector": "^1.3.0",
-        "tinyexec": "^1.0.1"
-      },
-      "bin": {
-        "na": "bin/na.mjs",
-        "nci": "bin/nci.mjs",
-        "ni": "bin/ni.mjs",
-        "nlx": "bin/nlx.mjs",
-        "nr": "bin/nr.mjs",
-        "nun": "bin/nun.mjs",
-        "nup": "bin/nup.mjs"
-      }
-    },
     "node_modules/@asamuzakjp/css-color": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
@@ -144,13 +122,13 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -159,9 +137,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
-      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -169,21 +147,21 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-compilation-targets": "^7.28.6",
-        "@babel/helper-module-transforms": "^7.28.6",
-        "@babel/helpers": "^7.28.6",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/traverse": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
@@ -223,14 +201,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.29.1",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
-      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -253,14 +231,14 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
-      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.28.6",
-        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -322,9 +300,9 @@
       }
     },
     "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -346,29 +324,29 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
-      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
-      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.28.6",
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "@babel/traverse": "^7.28.6"
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -433,9 +411,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -443,9 +421,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -453,9 +431,9 @@
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -463,27 +441,27 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.6.tgz",
-      "integrity": "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
-      "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.0"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -592,33 +570,33 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/parser": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
-      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -626,14 +604,14 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1290,21 +1268,21 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
-      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
+        "@emnapi/wasi-threads": "1.2.2",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
-      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1312,9 +1290,9 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1505,9 +1483,9 @@
       "license": "MIT"
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.13",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.13.tgz",
-      "integrity": "sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==",
+      "version": "1.19.17",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.17.tgz",
+      "integrity": "sha512-dSneS5qhiauZWGDCeK4o695Xd9nUNjviSZCMQrj10eetr8Uln1ucn6bbphOM6UynAMMtNIzZNSpL9vnASJwrPQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2047,144 +2025,6 @@
         "url": "https://opencollective.com/libvips"
       }
     },
-    "node_modules/@inquirer/ansi": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-1.0.2.tgz",
-      "integrity": "sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@inquirer/confirm": {
-      "version": "5.1.21",
-      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.21.tgz",
-      "integrity": "sha512-KR8edRkIsUayMXV+o3Gv+q4jlhENF9nMYUZs9PA2HzrXeHI8M5uDag70U7RJn9yyiMZSbtF5/UexBtAVtZGSbQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/type": "^3.0.10"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@inquirer/core": {
-      "version": "10.3.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.3.2.tgz",
-      "integrity": "sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/ansi": "^1.0.2",
-        "@inquirer/figures": "^1.0.15",
-        "@inquirer/type": "^3.0.10",
-        "cli-width": "^4.1.0",
-        "mute-stream": "^2.0.0",
-        "signal-exit": "^4.1.0",
-        "wrap-ansi": "^6.2.0",
-        "yoctocolors-cjs": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@inquirer/core/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@inquirer/core/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@inquirer/core/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@inquirer/core/node_modules/wrap-ansi": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@inquirer/figures": {
-      "version": "1.0.15",
-      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.15.tgz",
-      "integrity": "sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@inquirer/type": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.10.tgz",
-      "integrity": "sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -2254,9 +2094,9 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.27.1",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.27.1.tgz",
-      "integrity": "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2318,24 +2158,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@mswjs/interceptors": {
-      "version": "0.41.3",
-      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.41.3.tgz",
-      "integrity": "sha512-cXu86tF4VQVfwz8W1SPbhoRyHJkti6mjH/XJIxp40jhO4j2k1m4KYrEykxqWPkFF3vrK4rgQppBh//AwyGSXPA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@open-draft/deferred-promise": "^2.2.0",
-        "@open-draft/logger": "^0.3.0",
-        "@open-draft/until": "^2.0.0",
-        "is-node-process": "^1.2.0",
-        "outvariant": "^1.4.3",
-        "strict-event-emitter": "^0.5.1"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
@@ -2350,9 +2172,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "15.5.18",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.18.tgz",
-      "integrity": "sha512-hAV85Ckd9QR6RvH04MEKwsfLTksvFpO47j9xwtoIuvuPnlwecpSi+uZTtm8HirVbtlI2Fnz//xpcSTjFdyJk+g==",
+      "version": "15.5.22",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.22.tgz",
+      "integrity": "sha512-O5BlKb3KtsHkvO0gjjV66PuJnAgCtIEIzwkt50HRAHsQkU1t77eksIXSZV84/WMtZJjWrnDUPKHVRi0D62nSAA==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -2366,9 +2188,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "15.5.18",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.18.tgz",
-      "integrity": "sha512-w0WvQf1n+txiwns/9pwIQteCJpZTbxzO2SE0FLcwuD4v0WEh1JPOjdyxWL21XwJsdpx8cFRjyzxzCS/siP7HcQ==",
+      "version": "15.5.22",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.22.tgz",
+      "integrity": "sha512-/VISwtffSg8+fVvBbXdglsvruCsdbBC4dG25iU6xascKVqfQKsj/OtjGnOEkIS7pX5GB9e9/r5QprpicsGL3gw==",
       "cpu": [
         "arm64"
       ],
@@ -2382,9 +2204,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "15.5.18",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.18.tgz",
-      "integrity": "sha512-znn71QmDuxm+BOaglihMZfvyySMnNljkVIY5Z2TCssBmm+WqL6c19VhtH5ktFkHa8EZ2bnTUpcNcmNSQsg67og==",
+      "version": "15.5.22",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.22.tgz",
+      "integrity": "sha512-NiA9ve8hbiuhG/Q17a2mZDRVxMTtg3rTOgjLnDaLlE+AEPAQlkkuKrfePEbeOrgYmX0U2KGX4EVEn09hXU5GlQ==",
       "cpu": [
         "x64"
       ],
@@ -2398,14 +2220,11 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "15.5.18",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.18.tgz",
-      "integrity": "sha512-yPPe5MNL+igZUa+OsqQJisqSfh6oarIuA1Q0BDxljGJhRQyZeP+WRHh7rs/jZUGMh5aY0YdIjXZG0VohkKkUdw==",
+      "version": "15.5.22",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.22.tgz",
+      "integrity": "sha512-vAPa9vltW+UW/KWtjXeSUFgV3wb1x9d/BeyC6WFI6eBpL0D2f70oGwtOp6193mNW3qusrpgBzMQferPf+Zh8Dw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -2417,14 +2236,11 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "15.5.18",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.18.tgz",
-      "integrity": "sha512-glaCczEWIrHsokFZ3pP08U4BpKxwIdnT+txdOM32OBgpL9Yw4aqx8NejmgtZQZOdstQ5f0L3CasIZudzCuD+nw==",
+      "version": "15.5.22",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.22.tgz",
+      "integrity": "sha512-iknK80pWlNDnkdSr13bd8mMuG3Z2oTxODwsZHvuMY7caMk77+rBLdHVWsy8v2EVa3ZojJ/+wJX5fnq8va6Gv8A==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2436,14 +2252,11 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "15.5.18",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.18.tgz",
-      "integrity": "sha512-oUfg2EgJmU3R0OCOWiokGFUTvZiPfXtriXiuF3YNxRoROCdgvTedHIzYoeKH34gsZxS/V7mHbfq2hpAHwhH1/A==",
+      "version": "15.5.22",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.22.tgz",
+      "integrity": "sha512-penuEdkwU2OOAiS+n4LE8T/VIoCfAI01QcLZTJ2xc3+l4Q22L/DzURocmI2LU1b+8BMQoLAP1Sze3uYAZT05Bg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -2455,14 +2268,11 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "15.5.18",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.18.tgz",
-      "integrity": "sha512-JLxSP3KTd9iu/bvUMQxH7RJo9xKSHf55/6RPE4a6FTSZygGn7uvZbCej0AHXydwkggQGSD9UddSjwv6Xz5ESfA==",
+      "version": "15.5.22",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.22.tgz",
+      "integrity": "sha512-ZM0BKJm3FZ+guG6WT6PcyOLtp6paZ5tngcJC/uUKvLW4Y0TQnnVi1+UGdo8Q6Yxp5gaS82pmC1rD/oFlhkWB3g==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2474,9 +2284,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "15.5.18",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.18.tgz",
-      "integrity": "sha512-ir1v7enP52K2HNz3tQQvwF+x7VNxBk1ciiZ18WBPvxf4C59IqdfmHPJYK3vH7rSxpuCVw/8C712wTXNAtEp+NA==",
+      "version": "15.5.22",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.22.tgz",
+      "integrity": "sha512-rY/YaumrZaS0//94BnHLF5VSRp0GFUO4GvXNuoCBb0cGSci96yO+p1JaNL2aq9YZAYv9cuZRziV02x5IQH/wjg==",
       "cpu": [
         "arm64"
       ],
@@ -2490,9 +2300,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "15.5.18",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.18.tgz",
-      "integrity": "sha512-LIu5me6QTANCd25E7I5uIEfvgQ06RK7tvHAbYo3zCb3VpxQEPvMcSpd87NwUABDT6MbGPdEGR5VRiK4PPTJhQg==",
+      "version": "15.5.22",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.22.tgz",
+      "integrity": "sha512-s5IA4cyrbR2XK/5NWcu5dp8CfPBiKME+UhvNperia7uQybEgg5+LIhGMiY37WQE4rcI4owsDcU4IVUjLoTuDkA==",
       "cpu": [
         "x64"
       ],
@@ -2595,35 +2405,10 @@
         "node": ">=12.4.0"
       }
     },
-    "node_modules/@open-draft/deferred-promise": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
-      "integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@open-draft/logger": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@open-draft/logger/-/logger-0.3.0.tgz",
-      "integrity": "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-node-process": "^1.2.0",
-        "outvariant": "^1.4.0"
-      }
-    },
-    "node_modules/@open-draft/until": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
-      "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@oxc-project/types": {
-      "version": "0.124.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.124.0.tgz",
-      "integrity": "sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==",
+      "version": "0.139.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+      "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -4493,9 +4278,9 @@
       "license": "MIT"
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+      "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
       "cpu": [
         "arm64"
       ],
@@ -4510,9 +4295,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-oArR/ig8wNTPYsXL+Mzhs0oxhxfuHRfG7Ikw7jXsw8mYOtk71W0OkF2VEVh699pdmzjPQsTjlD1JIOoHkLP1Fg==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+      "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
       "cpu": [
         "arm64"
       ],
@@ -4527,9 +4312,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-YzeVqOqjPYvUbJSWJ4EDL8ahbmsIXQpgL3JVipmN+MX0XnXMeWomLN3Fb+nwCmP/jfyqte5I3XRSm7OfQrbyxw==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+      "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
       "cpu": [
         "x64"
       ],
@@ -4544,9 +4329,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-9Erhx956jeQ0nNTyif1+QWAXDRD38ZNjr//bSHrt6wDwB+QkAfl2q6Mn1k6OBPerznjRmbM10lgRb1Pli4xZPw==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+      "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
       "cpu": [
         "x64"
       ],
@@ -4561,9 +4346,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.15.tgz",
-      "integrity": "sha512-cVwk0w8QbZJGTnP/AHQBs5yNwmpgGYStL88t4UIaqcvYJWBfS0s3oqVLZPwsPU6M0zlW4GqjP0Zq5MnAGwFeGA==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+      "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
       "cpu": [
         "arm"
       ],
@@ -4578,9 +4363,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.15.tgz",
-      "integrity": "sha512-eBZ/u8iAK9SoHGanqe/jrPnY0JvBN6iXbVOsbO38mbz+ZJsaobExAm1Iu+rxa4S1l2FjG0qEZn4Rc6X8n+9M+w==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+      "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
       "cpu": [
         "arm64"
       ],
@@ -4595,9 +4380,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.15.tgz",
-      "integrity": "sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+      "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
       "cpu": [
         "arm64"
       ],
@@ -4612,9 +4397,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.15.tgz",
-      "integrity": "sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+      "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
       "cpu": [
         "ppc64"
       ],
@@ -4629,9 +4414,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.15.tgz",
-      "integrity": "sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+      "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
       "cpu": [
         "s390x"
       ],
@@ -4646,9 +4431,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.15.tgz",
-      "integrity": "sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+      "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
       "cpu": [
         "x64"
       ],
@@ -4663,9 +4448,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.15.tgz",
-      "integrity": "sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+      "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
       "cpu": [
         "x64"
       ],
@@ -4680,9 +4465,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+      "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
       "cpu": [
         "arm64"
       ],
@@ -4697,9 +4482,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.15.tgz",
-      "integrity": "sha512-ApLruZq/ig+nhaE7OJm4lDjayUnOHVUa77zGeqnqZ9pn0ovdVbbNPerVibLXDmWeUZXjIYIT8V3xkT58Rm9u5Q==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+      "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
       "cpu": [
         "wasm32"
       ],
@@ -4707,23 +4492,23 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/core": "1.9.2",
-        "@emnapi/runtime": "1.9.2",
-        "@napi-rs/wasm-runtime": "^1.1.3"
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.3.tgz",
-      "integrity": "sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@tybys/wasm-util": "^0.10.1"
+        "@tybys/wasm-util": "^0.10.3"
       },
       "funding": {
         "type": "github",
@@ -4735,9 +4520,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.15.tgz",
-      "integrity": "sha512-KmoUoU7HnN+Si5YWJigfTws1jz1bKBYDQKdbLspz0UaqjjFkddHsqorgiW1mxcAj88lYUE6NC/zJNwT+SloqtA==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+      "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
       "cpu": [
         "arm64"
       ],
@@ -4752,9 +4537,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.15.tgz",
-      "integrity": "sha512-3P2A8L+x75qavWLe/Dll3EYBJLQmtkJN8rfh+U/eR3MqMgL/h98PhYI+JFfXuDPgPeCB7iZAKiqii5vqOvnA0g==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+      "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
       "cpu": [
         "x64"
       ],
@@ -5042,9 +4827,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5059,9 +4841,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5076,9 +4855,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5093,9 +4869,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6196,16 +5969,16 @@
       }
     },
     "node_modules/@ts-morph/common/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/@ts-morph/common/node_modules/fast-glob": {
@@ -6255,9 +6028,9 @@
       }
     },
     "node_modules/@tybys/wasm-util": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -6407,13 +6180,6 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
-    },
-    "node_modules/@types/statuses": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-2.0.6.tgz",
-      "integrity": "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",
@@ -6659,16 +6425,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
@@ -7303,16 +7069,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/ansis": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/ansis/-/ansis-4.2.0.tgz",
-      "integrity": "sha512-HqZ5rWlFjGiV0tDm3UxxgNRqsOTniqoKZu0pIAfh7TZQMGuZK+hH0drySty0si0QXj1ieop4+SkSfPZBPPkHig==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -7633,21 +7389,21 @@
       "license": "MIT"
     },
     "node_modules/body-parser": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
-      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "debug": "^4.4.3",
-        "http-errors": "^2.0.0",
-        "iconv-lite": "^0.7.0",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
         "on-finished": "^2.4.1",
-        "qs": "^6.14.1",
-        "raw-body": "^3.0.1",
-        "type-is": "^2.0.1"
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
       },
       "engines": {
         "node": ">=18"
@@ -7657,10 +7413,24 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7977,16 +7747,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/cli-width": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
-      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">= 12"
       }
     },
     "node_modules/client-only": {
@@ -8415,16 +8175,6 @@
       "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
       "dev": true,
       "license": "BSD-2-Clause"
-    },
-    "node_modules/data-uri-to-buffer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
-      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
-      }
     },
     "node_modules/data-urls": {
       "version": "5.0.0",
@@ -9922,9 +9672,9 @@
       "license": "Unlicense"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "dev": true,
       "funding": [
         {
@@ -9946,30 +9696,6 @@
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
-      }
-    },
-    "node_modules/fetch-blob": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
-      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "node-domexception": "^1.0.0",
-        "web-streams-polyfill": "^3.0.3"
-      },
-      "engines": {
-        "node": "^12.20 || >= 14.13"
       }
     },
     "node_modules/figures": {
@@ -10107,19 +9833,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/formdata-polyfill": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
-      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fetch-blob": "^3.1.2"
-      },
-      "engines": {
-        "node": ">=12.20.0"
-      }
-    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -10217,13 +9930,6 @@
       "integrity": "sha512-sR9BNCjBg6LNgwvxlBd0sBABvQitkLzoVY9MYYROQVX/FvfJ4Mai9LsGhDgd8qYdds0bY77VzYd5iuB+v5rwQQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/fzf": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/fzf/-/fzf-0.5.2.tgz",
-      "integrity": "sha512-Tt4kuxLXFKHy8KT40zwsUPUkg1CrsgY25FxA2U/j/0WgEDCk3ddc/zLTCCcbSHX9FcKtLuVaDGtGE/STWC+j3Q==",
-      "dev": true,
-      "license": "BSD-3-Clause"
     },
     "node_modules/generator-function": {
       "version": "2.0.1",
@@ -10430,9 +10136,9 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10520,16 +10226,6 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/graphql": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.13.1.tgz",
-      "integrity": "sha512-gGgrVCoDKlIZ8fIqXBBb0pPKqDgki0Z/FSKNiQzSGj2uEYHr1tq5wmBegGwJx6QB5S5cM0khSBpi/JFHMCvsmQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
-      }
     },
     "node_modules/has-bigints": {
       "version": "1.1.0",
@@ -10694,13 +10390,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/headers-polyfill": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-4.0.3.tgz",
-      "integrity": "sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/highlight.js": {
       "version": "11.11.1",
       "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
@@ -10711,9 +10400,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.18",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
-      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
+      "version": "4.12.32",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.32.tgz",
+      "integrity": "sha512-XcuyW9qE2kJn07PkecMOBd5Vq/hMy7mmGw+idz1yblbg9N17ijJODrvPkn7/dwL3Kulj8LcRJ69DLOWf91dRUg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -11373,13 +11062,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-node-process": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
-      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -11722,10 +11404,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -12294,9 +11986,19 @@
       "license": "MIT"
     },
     "node_modules/linkify-it": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
-      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
+      "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "uc.micro": "^2.0.0"
@@ -12719,14 +12421,24 @@
       }
     },
     "node_modules/markdown-it": {
-      "version": "14.1.1",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
-      "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
+      "version": "14.3.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.3.0.tgz",
+      "integrity": "sha512-RCEsPjR+sr0x+AuYp601tKTkgFG4YEPLCzHST3cQ/fhlJkqAkz1L2/Qbp1j9qw5SBwQHFBoW8+hoN5xssOF0Tw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1",
-        "entities": "^4.4.0",
-        "linkify-it": "^5.0.0",
+        "entities": "^4.5.0",
+        "linkify-it": "^5.0.2",
         "mdurl": "^2.0.0",
         "punycode.js": "^2.3.1",
         "uc.micro": "^2.1.0"
@@ -13821,65 +13533,10 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
-    "node_modules/msw": {
-      "version": "2.12.10",
-      "resolved": "https://registry.npmjs.org/msw/-/msw-2.12.10.tgz",
-      "integrity": "sha512-G3VUymSE0/iegFnuipujpwyTM2GuZAKXNeerUSrG2+Eg391wW63xFs5ixWsK9MWzr1AGoSkYGmyAzNgbR3+urw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/confirm": "^5.0.0",
-        "@mswjs/interceptors": "^0.41.2",
-        "@open-draft/deferred-promise": "^2.2.0",
-        "@types/statuses": "^2.0.6",
-        "cookie": "^1.0.2",
-        "graphql": "^16.12.0",
-        "headers-polyfill": "^4.0.2",
-        "is-node-process": "^1.2.0",
-        "outvariant": "^1.4.3",
-        "path-to-regexp": "^6.3.0",
-        "picocolors": "^1.1.1",
-        "rettime": "^0.10.1",
-        "statuses": "^2.0.2",
-        "strict-event-emitter": "^0.5.1",
-        "tough-cookie": "^6.0.0",
-        "type-fest": "^5.2.0",
-        "until-async": "^3.0.2",
-        "yargs": "^17.7.2"
-      },
-      "bin": {
-        "msw": "cli/index.js"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mswjs"
-      },
-      "peerDependencies": {
-        "typescript": ">= 4.8.x"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/mute-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
-      "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "funding": [
         {
           "type": "github",
@@ -13928,12 +13585,12 @@
       }
     },
     "node_modules/next": {
-      "version": "15.5.18",
-      "resolved": "https://registry.npmjs.org/next/-/next-15.5.18.tgz",
-      "integrity": "sha512-eKL8zUJkX9Y5lE+RX/2YJoItVdGlIscyVyboeD9wSpp0PaGqjoA4tTpT2qPqz9ax+5IzGESyLSeZ/RCwbSZ2uQ==",
+      "version": "15.5.22",
+      "resolved": "https://registry.npmjs.org/next/-/next-15.5.22.tgz",
+      "integrity": "sha512-mrtal1sRxO4YrlDS98sDuIvGZivKbFix8w7oAL9ZynfOgc3cADQOQgvwtMooc18Qr8bKzvQAcHwHZ0mbJ7zcfQ==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "15.5.18",
+        "@next/env": "15.5.22",
         "@swc/helpers": "0.5.15",
         "caniuse-lite": "^1.0.30001579",
         "postcss": "8.4.31",
@@ -13946,14 +13603,14 @@
         "node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "15.5.18",
-        "@next/swc-darwin-x64": "15.5.18",
-        "@next/swc-linux-arm64-gnu": "15.5.18",
-        "@next/swc-linux-arm64-musl": "15.5.18",
-        "@next/swc-linux-x64-gnu": "15.5.18",
-        "@next/swc-linux-x64-musl": "15.5.18",
-        "@next/swc-win32-arm64-msvc": "15.5.18",
-        "@next/swc-win32-x64-msvc": "15.5.18",
+        "@next/swc-darwin-arm64": "15.5.22",
+        "@next/swc-darwin-x64": "15.5.22",
+        "@next/swc-linux-arm64-gnu": "15.5.22",
+        "@next/swc-linux-arm64-musl": "15.5.22",
+        "@next/swc-linux-x64-gnu": "15.5.22",
+        "@next/swc-linux-x64-musl": "15.5.22",
+        "@next/swc-win32-arm64-msvc": "15.5.22",
+        "@next/swc-win32-x64-msvc": "15.5.22",
         "sharp": "^0.34.3"
       },
       "peerDependencies": {
@@ -14007,27 +13664,6 @@
         "node": "^10 || ^12 || >=14"
       }
     },
-    "node_modules/node-domexception": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-      "deprecated": "Use your platform's native DOMException instead",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "github",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.5.0"
-      }
-    },
     "node_modules/node-exports-info": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/node-exports-info/-/node-exports-info-1.6.0.tgz",
@@ -14057,25 +13693,6 @@
         "semver": "bin/semver.js"
       }
     },
-    "node_modules/node-fetch": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
-      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "data-uri-to-buffer": "^4.0.0",
-        "fetch-blob": "^3.1.4",
-        "formdata-polyfill": "^4.0.10"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/node-fetch"
-      }
-    },
     "node_modules/node-releases": {
       "version": "2.0.36",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
@@ -14084,9 +13701,9 @@
       "license": "MIT"
     },
     "node_modules/nodemailer": {
-      "version": "8.0.5",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.5.tgz",
-      "integrity": "sha512-0PF8Yb1yZuQfQbq+5/pZJrtF6WQcjTd5/S4JOHs9PGFxuTqoB/icwuB44pOdURHJbRKX1PPoJZtY7R4VUoCC8w==",
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-9.0.3.tgz",
+      "integrity": "sha512-n+YP+NKwR5zRWa60k3GiQ6Q3B4KXCoAw40dAKeCtYn020iNN74aWK2liXIC3ZEATeGql7we3tE3t8QwhY0eskw==",
       "license": "MIT-0",
       "engines": {
         "node": ">=6.0.0"
@@ -14419,13 +14036,6 @@
       "integrity": "sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==",
       "license": "MIT"
     },
-    "node_modules/outvariant": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.3.tgz",
-      "integrity": "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/own-keys": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
@@ -14482,13 +14092,6 @@
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "dev": true,
       "license": "BlueOak-1.0.0"
-    },
-    "node_modules/package-manager-detector": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.6.0.tgz",
-      "integrity": "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
@@ -14647,13 +14250,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/path-to-regexp": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
-      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/pathe": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
@@ -14756,15 +14352,15 @@
       }
     },
     "node_modules/postal-mime": {
-      "version": "2.7.4",
-      "resolved": "https://registry.npmjs.org/postal-mime/-/postal-mime-2.7.4.tgz",
-      "integrity": "sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g==",
+      "version": "2.7.5",
+      "resolved": "https://registry.npmjs.org/postal-mime/-/postal-mime-2.7.5.tgz",
+      "integrity": "sha512-GNEXKvWFQnbgO5NlrGzVa0FmWzBZ24PersAWErttSg1Hjpf0ATxTwS5DOMGaOpTG6bUh5cTr7xi0jAD942wCJA==",
       "license": "MIT-0"
     },
     "node_modules/postcss": {
-      "version": "8.5.14",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
-      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "dev": true,
       "funding": [
         {
@@ -14782,7 +14378,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -15193,13 +14789,14 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -15708,13 +15305,13 @@
       }
     },
     "node_modules/resend": {
-      "version": "6.10.0",
-      "resolved": "https://registry.npmjs.org/resend/-/resend-6.10.0.tgz",
-      "integrity": "sha512-i7CwZpYj4Oho1RxsTpLcCUkO08+HiL4NXrm6jLJ2WzJ89UGI8eROSieLONJA3hnUrf1OYnCyfq5F6POnHUMv1Q==",
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/resend/-/resend-6.18.0.tgz",
+      "integrity": "sha512-EjxZ9AVzywJgOlUoIJe9ytBWVrfbUtJbjeoLnRSvpU1sv97Hh9DSwhw+k8kiujrG4Rg4bzTBsjlmwWWuoOxSug==",
       "license": "MIT",
       "dependencies": {
-        "postal-mime": "2.7.4",
-        "svix": "1.88.0"
+        "postal-mime": "2.7.5",
+        "standardwebhooks": "1.0.0"
       },
       "engines": {
         "node": ">=20"
@@ -15786,13 +15383,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/rettime": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/rettime/-/rettime-0.10.1.tgz",
-      "integrity": "sha512-uyDrIlUEH37cinabq0AX4QbgV4HbFZ/gqoiunWQ1UqBtRvTTytwhNYjE++pO/MjPTZL5KQCf2bEoJ/BJNVQ5Kw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/reusify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
@@ -15812,14 +15402,14 @@
       "license": "MIT"
     },
     "node_modules/rolldown": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.15.tgz",
-      "integrity": "sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+      "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.124.0",
-        "@rolldown/pluginutils": "1.0.0-rc.15"
+        "@oxc-project/types": "=0.139.0",
+        "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
         "rolldown": "bin/cli.mjs"
@@ -15828,27 +15418,27 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.0-rc.15",
-        "@rolldown/binding-darwin-arm64": "1.0.0-rc.15",
-        "@rolldown/binding-darwin-x64": "1.0.0-rc.15",
-        "@rolldown/binding-freebsd-x64": "1.0.0-rc.15",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.15",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.15",
-        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.15",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.15",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.15",
-        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.15",
-        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.15",
-        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.15",
-        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.15",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.15",
-        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.15"
+        "@rolldown/binding-android-arm64": "1.1.5",
+        "@rolldown/binding-darwin-arm64": "1.1.5",
+        "@rolldown/binding-darwin-x64": "1.1.5",
+        "@rolldown/binding-freebsd-x64": "1.1.5",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.5",
+        "@rolldown/binding-linux-arm64-musl": "1.1.5",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-musl": "1.1.5",
+        "@rolldown/binding-openharmony-arm64": "1.1.5",
+        "@rolldown/binding-wasm32-wasi": "1.1.5",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.5",
+        "@rolldown/binding-win32-x64-msvc": "1.1.5"
       }
     },
     "node_modules/rolldown/node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.15.tgz",
-      "integrity": "sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "dev": true,
       "license": "MIT"
     },
@@ -16178,13 +15768,12 @@
       "license": "ISC"
     },
     "node_modules/shadcn": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/shadcn/-/shadcn-4.0.7.tgz",
-      "integrity": "sha512-QwnD52EtnZo575yG/mk4fp6n0Qu8HZTVj10dsbg1O8DBLZPZG1V7AGOgTQSTjdsl8Jtye8GJfoKFz5npBkfExg==",
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/shadcn/-/shadcn-4.15.0.tgz",
+      "integrity": "sha512-fFTpfOuRwqjpXGp/sKpAxJkjdgv1jf8bDrW1xi0cVn2k7WJ5ijV/gjkAlkAidGDjhEkgcUuxVdm4oRB9r8BivA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@antfu/ni": "^25.0.0",
         "@babel/core": "^7.28.0",
         "@babel/parser": "^7.28.0",
         "@babel/plugin-transform-typescript": "^7.28.0",
@@ -16202,10 +15791,7 @@
         "fast-glob": "^3.3.3",
         "fs-extra": "^11.3.1",
         "fuzzysort": "^3.1.0",
-        "https-proxy-agent": "^7.0.6",
         "kleur": "^4.1.5",
-        "msw": "^2.10.4",
-        "node-fetch": "^3.3.2",
         "open": "^11.0.0",
         "ora": "^8.2.0",
         "postcss": "^8.5.6",
@@ -16216,12 +15802,16 @@
         "tailwind-merge": "^3.0.1",
         "ts-morph": "^26.0.0",
         "tsconfig-paths": "^4.2.0",
+        "undici": "^7.27.2",
         "validate-npm-package-name": "^7.0.1",
         "zod": "^3.24.1",
         "zod-to-json-schema": "^3.24.6"
       },
       "bin": {
         "shadcn": "dist/index.js"
+      },
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/shadcn/node_modules/fast-glob": {
@@ -16361,15 +15951,15 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -16381,14 +15971,14 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -16619,13 +16209,6 @@
       "engines": {
         "node": ">= 0.4"
       }
-    },
-    "node_modules/strict-event-emitter": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
-      "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/string-argv": {
       "version": "0.3.2",
@@ -17037,35 +16620,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/svix": {
-      "version": "1.88.0",
-      "resolved": "https://registry.npmjs.org/svix/-/svix-1.88.0.tgz",
-      "integrity": "sha512-vm/JrrUd3bVyBE+3L33TIyVSs8gS5fYx7lrISvKlDJXTYX1ACH4REX8P1tHxsSKoZi/rvifM1t0XRc5Vc45THw==",
-      "license": "MIT",
-      "dependencies": {
-        "standardwebhooks": "1.0.0",
-        "uuid": "^10.0.0"
-      }
-    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/tagged-tag": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
-      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/tailwind-merge": {
       "version": "3.5.0",
@@ -17122,14 +16682,14 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -17219,26 +16779,6 @@
       "integrity": "sha512-6L6VymKTzYSrEf4Nev4Xa1LCHKrlTlYCBMTlQKFuddo1CvQcE52I0mwfOJayueUC7MJuXOeHTcIU683lzd0cUA==",
       "license": "MIT"
     },
-    "node_modules/tldts": {
-      "version": "7.0.25",
-      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.25.tgz",
-      "integrity": "sha512-keinCnPbwXEUG3ilrWQZU+CqcTTzHq9m2HhoUP2l7Xmi8l1LuijAXLpAJ5zRW+ifKTNscs4NdCkfkDCBYm352w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tldts-core": "^7.0.25"
-      },
-      "bin": {
-        "tldts": "bin/cli.js"
-      }
-    },
-    "node_modules/tldts-core": {
-      "version": "7.0.25",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.25.tgz",
-      "integrity": "sha512-ZjCZK0rppSBu7rjHYDYsEaMOIbbT+nWF57hKkv4IUmZWBNrBWBOjIElc0mKRgLM8bm7x/BBlof6t2gi/Oq/Asw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -17260,19 +16800,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
-      }
-    },
-    "node_modules/tough-cookie": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
-      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "tldts": "^7.0.5"
-      },
-      "engines": {
-        "node": ">=16"
       }
     },
     "node_modules/tr46": {
@@ -17370,35 +16897,37 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/type-fest": {
-      "version": "5.4.4",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.4.4.tgz",
-      "integrity": "sha512-JnTrzGu+zPV3aXIUhnyWJj4z/wigMsdYajGLIYakqyOW1nPllzXEJee0QQbHj+CTIQtXGlAjuK0UY+2xTyjVAw==",
-      "dev": true,
-      "license": "(MIT OR CC0-1.0)",
-      "dependencies": {
-        "tagged-tag": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/type-is": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
-      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "media-typer": "^1.1.0",
         "mime-types": "^3.0.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/typed-array-buffer": {
@@ -17516,6 +17045,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {
@@ -17693,16 +17232,6 @@
         "@unrs/resolver-binding-win32-x64-msvc": "1.11.1"
       }
     },
-    "node_modules/until-async": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/until-async/-/until-async-3.0.2.tgz",
-      "integrity": "sha512-IiSk4HlzAMqTUseHHe3VhIGyuFmN90zMTpD3Z3y8jeQbzLIq500MVM7Jq2vUAnTKAFPJrqwkzr6PoTcPhGcOiw==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/kettanaito"
-      }
-    },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
@@ -17802,19 +17331,6 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
     },
-    "node_modules/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/validate-npm-package-name": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-7.0.2.tgz",
@@ -17864,17 +17380,17 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.0.8",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.8.tgz",
-      "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+      "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
-        "picomatch": "^4.0.4",
-        "postcss": "^8.5.8",
-        "rolldown": "1.0.0-rc.15",
-        "tinyglobby": "^0.2.15"
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.17",
+        "rolldown": "~1.1.5",
+        "tinyglobby": "^0.2.17"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -17890,7 +17406,7 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.1.0",
+        "@vitejs/devtools": "^0.3.0",
         "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",
@@ -18203,9 +17719,9 @@
       }
     },
     "node_modules/vite/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -18346,16 +17862,6 @@
       },
       "engines": {
         "node": ">= 16"
-      }
-    },
-    "node_modules/web-streams-polyfill": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
-      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/webidl-conversions": {
@@ -18639,9 +18145,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -18833,19 +18339,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
       "integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/yoctocolors-cjs": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.3.tgz",
-      "integrity": "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "lowlight": "^3.3.0",
     "lucide-react": "^0.577.0",
     "next": "^15.5.14",
-    "nodemailer": "^8.0.5",
+    "nodemailer": "^9.0.3",
     "radix-ui": "^1.4.3",
     "react": "19.1.0",
     "react-day-picker": "^10.0.1",

--- a/src/app/(main)/mypage/page.tsx
+++ b/src/app/(main)/mypage/page.tsx
@@ -1,16 +1,28 @@
-import { ChevronRight } from "lucide-react";
 import type { Metadata } from "next";
 import dynamic from "next/dynamic";
 import Link from "next/link";
 import { redirect } from "next/navigation";
 
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "@/components/ui/breadcrumb";
 import { LearningStatsSection } from "@/features/mypage/components/LearningStatsSection";
 import {
   MypageNav,
   type MypageSection,
 } from "@/features/mypage/components/MypageNav";
 import { ReviewWaitingSection } from "@/features/mypage/components/ReviewWaitingSection";
-import { getLearningStats } from "@/features/mypage/queries";
+import type { SupportTab } from "@/features/mypage/components/SupportSection";
+import {
+  getLearningStats,
+  getMyFeedbacks,
+  type MyFeedbacksResult,
+} from "@/features/mypage/queries";
 import { getReviewWaitingNotes } from "@/features/notes/queries";
 import { PushSubscribeCard } from "@/features/notifications/components/PushSubscribeCard";
 import { getHasAnyPushSubscription } from "@/features/notifications/queries";
@@ -33,12 +45,22 @@ const DeleteAccountSection = dynamic(() =>
     (m) => m.DeleteAccountSection,
   ),
 );
+const SupportSection = dynamic(() =>
+  import("@/features/mypage/components/SupportSection").then(
+    (m) => m.SupportSection,
+  ),
+);
 
 export const metadata: Metadata = {
   robots: { index: false, follow: false },
 };
 
-const VALID_SECTIONS: MypageSection[] = ["profile", "stats", "reviews"];
+const VALID_SECTIONS: MypageSection[] = [
+  "profile",
+  "stats",
+  "reviews",
+  "support",
+];
 
 function isValidSection(value: unknown): value is MypageSection {
   return VALID_SECTIONS.includes(value as MypageSection);
@@ -48,17 +70,30 @@ const SECTION_LABELS: Record<MypageSection, string> = {
   profile: "계정 관리",
   stats: "학습 통계",
   reviews: "복습 대기",
+  support: "고객센터",
+};
+
+const VALID_SUPPORT_TABS: SupportTab[] = ["faq", "inquiry"];
+
+function isValidSupportTab(value: unknown): value is SupportTab {
+  return VALID_SUPPORT_TABS.includes(value as SupportTab);
+}
+
+const SUPPORT_TAB_LABELS: Record<SupportTab, string> = {
+  faq: "FAQ",
+  inquiry: "1:1 문의",
 };
 
 type Props = {
-  searchParams: Promise<{ section?: string }>;
+  searchParams: Promise<{ section?: string; tab?: string }>;
 };
 
 export default async function MyPage({ searchParams }: Props) {
-  const { section: rawSection } = await searchParams;
+  const { section: rawSection, tab: rawTab } = await searchParams;
   const section: MypageSection = isValidSection(rawSection)
     ? rawSection
     : "stats";
+  const supportTab: SupportTab = isValidSupportTab(rawTab) ? rawTab : "faq";
 
   const [user, profile] = await Promise.all([getUser(), getProfile()]);
   if (!user || !profile) redirect(ROUTES.LOGIN);
@@ -69,6 +104,7 @@ export default async function MyPage({ searchParams }: Props) {
   let stats: Awaited<ReturnType<typeof getLearningStats>> | null = null;
   let hasAnyPushSubscription = false;
   let reviewWaiting: Awaited<ReturnType<typeof getReviewWaitingNotes>> = [];
+  let feedbackResult: MyFeedbacksResult | null = null;
 
   if (section === "stats") {
     stats = await getLearningStats();
@@ -78,33 +114,52 @@ export default async function MyPage({ searchParams }: Props) {
     });
   } else if (section === "reviews") {
     reviewWaiting = await getReviewWaitingNotes(user.id);
+  } else if (section === "support" && supportTab === "inquiry") {
+    feedbackResult = await getMyFeedbacks(user.id);
   }
 
   return (
     <div className="mx-auto max-w-5xl py-7 px-6">
       {/* Breadcrumb */}
-      <nav
-        aria-label="breadcrumb"
-        className="flex items-center gap-1.5 text-sm text-muted-foreground"
-      >
-        <Link
-          href={ROUTES.HOME}
-          className="transition-colors hover:text-foreground"
-        >
-          홈
-        </Link>
-        <ChevronRight className="size-3.5" />
-        <Link
-          href={ROUTES.MYPAGE}
-          className="transition-colors hover:text-foreground"
-        >
-          마이페이지
-        </Link>
-        <ChevronRight className="size-3.5" />
-        <span className="font-medium text-foreground">
-          {SECTION_LABELS[section]}
-        </span>
-      </nav>
+      <Breadcrumb>
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <BreadcrumbLink asChild>
+              <Link href={ROUTES.HOME}>홈</Link>
+            </BreadcrumbLink>
+          </BreadcrumbItem>
+          <BreadcrumbSeparator />
+          <BreadcrumbItem>
+            <BreadcrumbLink asChild>
+              <Link href={ROUTES.MYPAGE}>마이페이지</Link>
+            </BreadcrumbLink>
+          </BreadcrumbItem>
+          <BreadcrumbSeparator />
+          {section === "support" ? (
+            <>
+              <BreadcrumbItem>
+                <BreadcrumbLink asChild>
+                  <Link href={`${ROUTES.MYPAGE}?section=support`}>
+                    {SECTION_LABELS[section]}
+                  </Link>
+                </BreadcrumbLink>
+              </BreadcrumbItem>
+              <BreadcrumbSeparator />
+              <BreadcrumbItem>
+                <BreadcrumbPage className="font-medium">
+                  {SUPPORT_TAB_LABELS[supportTab]}
+                </BreadcrumbPage>
+              </BreadcrumbItem>
+            </>
+          ) : (
+            <BreadcrumbItem>
+              <BreadcrumbPage className="font-medium">
+                {SECTION_LABELS[section]}
+              </BreadcrumbPage>
+            </BreadcrumbItem>
+          )}
+        </BreadcrumbList>
+      </Breadcrumb>
 
       {/* 페이지 타이틀 */}
       <h1 className="mt-6 mb-6 text-3xl font-bold">마이페이지</h1>
@@ -136,6 +191,13 @@ export default async function MyPage({ searchParams }: Props) {
           )}
           {section === "reviews" && (
             <ReviewWaitingSection notes={reviewWaiting} />
+          )}
+          {section === "support" && (
+            <SupportSection
+              activeTab={supportTab}
+              feedbacks={feedbackResult?.feedbacks ?? []}
+              hasSubmittedToday={feedbackResult?.hasSubmittedToday ?? false}
+            />
           )}
         </div>
       </div>

--- a/src/features/mypage/actions.ts
+++ b/src/features/mypage/actions.ts
@@ -371,9 +371,9 @@ export async function deleteFeedbackAction(feedbackId: string) {
     return { error: "삭제할 수 없습니다. 이미 삭제된 문의사항입니다" };
   }
 
-  // RLS(feedbacks_delete_own_before_reply)와 동일한 규칙을 Storage 삭제 전에
-  // 미리 확인한다. 이미지를 먼저 지운 뒤 답변 존재로 DB 삭제가 막히면
-  // 이미지만 사라지고 행은 남는 상태가 되므로, 여기서 먼저 걸러낸다.
+  // RLS(feedbacks_delete_own_before_reply)와 동일한 규칙을 미리 확인해
+  // 답변이 달린 문의에 더 친절한 에러 메시지를 준다. 최종 판단은 아래
+  // DB 삭제 시점의 RLS가 다시 내리므로 여기서 통과해도 안전이 보장되지는 않는다.
   const { count: replyCount, error: replyError } = await supabase
     .from("feedback_replies")
     .select("id", { count: "exact", head: true })
@@ -388,20 +388,11 @@ export async function deleteFeedbackAction(feedbackId: string) {
     return { error: "삭제할 수 없습니다. 답변이 등록된 문의사항입니다" };
   }
 
-  // 첨부 이미지 삭제가 성공한 뒤에만 DB 행을 삭제한다.
-  // Storage 삭제가 실패하면 행을 지우지 않아 재시도할 수 있게 유지한다.
-  const imagesRemoved = await removeFeedbackImages(
-    supabase,
-    feedback.image_urls,
-  );
-
-  if (!imagesRemoved) {
-    return { error: "이미지 삭제에 실패했습니다. 잠시 후 다시 시도해주세요" };
-  }
-
-  // 위에서 확인한 시점과 삭제 시점 사이에 답변이 새로 달렸을 가능성을
-  // 대비해, RLS(feedbacks_delete_own_before_reply)가 최종적으로 다시 검증한다.
+  // DB 행 삭제를 먼저 확정한다. RLS(feedbacks_delete_own_before_reply)가
+  // 위 사전 확인 이후 새로 달린 답변까지 최종적으로 다시 검증하며,
   // 정책에 걸리면 에러 없이 0건 삭제로 끝나므로 반환 행 유무로 판별한다.
+  // 이미지는 행 삭제가 확정된 뒤에만 지워, 삭제가 막힌 문의의 첨부
+  // 이미지가 먼저 유실되는 상황을 방지한다.
   const { data: deleted, error: deleteError } = await supabase
     .from("feedbacks")
     .delete()
@@ -419,6 +410,20 @@ export async function deleteFeedbackAction(feedbackId: string) {
       error:
         "삭제할 수 없습니다. 답변이 등록되었거나 이미 삭제된 문의사항입니다",
     };
+  }
+
+  // 행은 이미 삭제되었으므로 Storage 정리가 실패해도 사용자에게는
+  // 성공으로 응답한다. 실패 시 고아 파일이 남을 수 있어 로그만 남긴다.
+  const imagesRemoved = await removeFeedbackImages(
+    supabase,
+    feedback.image_urls,
+  );
+
+  if (!imagesRemoved) {
+    console.error(
+      "[deleteFeedbackAction] 이미지 정리 실패, 고아 파일 발생:",
+      feedbackId,
+    );
   }
 
   return { data: { success: true as const } };

--- a/src/features/mypage/actions.ts
+++ b/src/features/mypage/actions.ts
@@ -1,7 +1,9 @@
 "use server";
 
 import { redirect } from "next/navigation";
+import { z } from "zod";
 
+import { getKstDayBoundsUtc } from "@/features/review/lib/kstDay";
 import { ROUTES } from "@/lib/constants/routes";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { createClient } from "@/lib/supabase/server";
@@ -10,6 +12,11 @@ import {
   AVATAR_ALLOWED_TYPES,
   AVATAR_MAX_SIZE,
   changePasswordSchema,
+  FEEDBACK_DAILY_LIMIT_MESSAGE,
+  FEEDBACK_IMAGE_ALLOWED_TYPES,
+  FEEDBACK_IMAGE_MAX_COUNT,
+  FEEDBACK_IMAGE_MAX_SIZE,
+  feedbackSchema,
   profileSchema,
 } from "./schema";
 
@@ -202,4 +209,217 @@ export async function deleteAccountAction() {
 
   await supabase.auth.signOut();
   redirect(ROUTES.LOGIN);
+}
+
+// ---- 피드백 (#266) ----
+
+async function removeFeedbackImages(
+  supabase: Awaited<ReturnType<typeof createClient>>,
+  paths: string[],
+): Promise<boolean> {
+  if (paths.length === 0) return true;
+
+  const { error } = await supabase.storage.from("feedbacks").remove(paths);
+  if (error) {
+    console.error("[feedback] 이미지 정리 실패:", error.message);
+    return false;
+  }
+
+  return true;
+}
+
+export async function createFeedbackAction(
+  _prevState: unknown,
+  formData: FormData,
+) {
+  const parsed = feedbackSchema.safeParse({
+    category: formData.get("category"),
+    title: formData.get("title"),
+    content: formData.get("content"),
+  });
+
+  if (!parsed.success) {
+    return { error: parsed.error.flatten().fieldErrors };
+  }
+
+  const images = formData
+    .getAll("images")
+    .filter((file): file is File => file instanceof File && file.size > 0);
+
+  if (images.length > FEEDBACK_IMAGE_MAX_COUNT) {
+    return {
+      error: `이미지는 최대 ${FEEDBACK_IMAGE_MAX_COUNT}장까지 첨부할 수 있습니다`,
+    };
+  }
+
+  for (const file of images) {
+    if (
+      !(FEEDBACK_IMAGE_ALLOWED_TYPES as readonly string[]).includes(file.type)
+    ) {
+      return { error: "JPG, PNG, GIF, WebP 형식만 업로드 가능합니다" };
+    }
+    if (file.size > FEEDBACK_IMAGE_MAX_SIZE) {
+      return { error: "이미지 크기는 장당 5MB 이하여야 합니다" };
+    }
+  }
+
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return { error: "인증이 필요합니다" };
+  }
+
+  // 하루 1개 사전 체크 — 동시 요청 경합은 unique index가 최종적으로 막는다
+  const { startUtcIso, endUtcIso } = getKstDayBoundsUtc(new Date());
+  const { data: todayRows, error: todayError } = await supabase
+    .from("feedbacks")
+    .select("id")
+    .eq("user_id", user.id)
+    .gte("created_at", startUtcIso)
+    .lt("created_at", endUtcIso)
+    .limit(1);
+
+  if (todayError) {
+    console.error("[createFeedbackAction] 일일 제한 조회 실패:", todayError);
+    return { error: "문의사항 제출에 실패했습니다" };
+  }
+
+  if (todayRows.length > 0) {
+    return { error: FEEDBACK_DAILY_LIMIT_MESSAGE };
+  }
+
+  // 스토리지 경로에 feedback id가 필요하므로 insert 전에 미리 생성한다
+  const feedbackId = crypto.randomUUID();
+  const uploadedPaths: string[] = [];
+
+  for (const file of images) {
+    const ext = file.type.split("/")[1] ?? "bin";
+    const path = `${user.id}/${feedbackId}/${crypto.randomUUID()}.${ext}`;
+
+    const { error: uploadError } = await supabase.storage
+      .from("feedbacks")
+      .upload(path, file, { contentType: file.type });
+
+    if (uploadError) {
+      console.error("[createFeedbackAction] 업로드 실패:", uploadError);
+      await removeFeedbackImages(supabase, uploadedPaths);
+      return { error: "이미지 업로드에 실패했습니다" };
+    }
+
+    uploadedPaths.push(path);
+  }
+
+  const { data, error } = await supabase
+    .from("feedbacks")
+    .insert({
+      id: feedbackId,
+      user_id: user.id,
+      note_id: null,
+      category: parsed.data.category,
+      title: parsed.data.title,
+      content: parsed.data.content,
+      image_urls: uploadedPaths,
+    })
+    .select()
+    .single();
+
+  if (error) {
+    await removeFeedbackImages(supabase, uploadedPaths);
+
+    // 23505: unique_violation — 사전 체크를 통과한 동시 요청이 인덱스에 걸린 경우
+    if (error.code === "23505") {
+      return { error: FEEDBACK_DAILY_LIMIT_MESSAGE };
+    }
+
+    console.error("[createFeedbackAction] insert 실패:", error);
+    return { error: "문의사항 제출에 실패했습니다" };
+  }
+
+  return { data };
+}
+
+export async function deleteFeedbackAction(feedbackId: string) {
+  if (!z.string().uuid().safeParse(feedbackId).success) {
+    return { error: "잘못된 요청입니다" };
+  }
+
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return { error: "인증이 필요합니다" };
+  }
+
+  const { data: feedback, error: fetchError } = await supabase
+    .from("feedbacks")
+    .select("id, image_urls")
+    .eq("id", feedbackId)
+    .eq("user_id", user.id)
+    .maybeSingle();
+
+  if (fetchError) {
+    console.error("[deleteFeedbackAction] 조회 실패:", fetchError);
+    return { error: "문의사항 삭제에 실패했습니다" };
+  }
+
+  if (!feedback) {
+    return { error: "삭제할 수 없습니다. 이미 삭제된 문의사항입니다" };
+  }
+
+  // RLS(feedbacks_delete_own_before_reply)와 동일한 규칙을 Storage 삭제 전에
+  // 미리 확인한다. 이미지를 먼저 지운 뒤 답변 존재로 DB 삭제가 막히면
+  // 이미지만 사라지고 행은 남는 상태가 되므로, 여기서 먼저 걸러낸다.
+  const { count: replyCount, error: replyError } = await supabase
+    .from("feedback_replies")
+    .select("id", { count: "exact", head: true })
+    .eq("feedback_id", feedbackId);
+
+  if (replyError) {
+    console.error("[deleteFeedbackAction] 답변 조회 실패:", replyError);
+    return { error: "문의사항 삭제에 실패했습니다" };
+  }
+
+  if (replyCount && replyCount > 0) {
+    return { error: "삭제할 수 없습니다. 답변이 등록된 문의사항입니다" };
+  }
+
+  // 첨부 이미지 삭제가 성공한 뒤에만 DB 행을 삭제한다.
+  // Storage 삭제가 실패하면 행을 지우지 않아 재시도할 수 있게 유지한다.
+  const imagesRemoved = await removeFeedbackImages(
+    supabase,
+    feedback.image_urls,
+  );
+
+  if (!imagesRemoved) {
+    return { error: "이미지 삭제에 실패했습니다. 잠시 후 다시 시도해주세요" };
+  }
+
+  // 위에서 확인한 시점과 삭제 시점 사이에 답변이 새로 달렸을 가능성을
+  // 대비해, RLS(feedbacks_delete_own_before_reply)가 최종적으로 다시 검증한다.
+  // 정책에 걸리면 에러 없이 0건 삭제로 끝나므로 반환 행 유무로 판별한다.
+  const { data: deleted, error: deleteError } = await supabase
+    .from("feedbacks")
+    .delete()
+    .eq("id", feedbackId)
+    .eq("user_id", user.id)
+    .select("id");
+
+  if (deleteError) {
+    console.error("[deleteFeedbackAction] 삭제 실패:", deleteError);
+    return { error: "문의사항 삭제에 실패했습니다" };
+  }
+
+  if (!deleted?.[0]) {
+    return {
+      error:
+        "삭제할 수 없습니다. 답변이 등록되었거나 이미 삭제된 문의사항입니다",
+    };
+  }
+
+  return { data: { success: true as const } };
 }

--- a/src/features/mypage/components/DeleteFeedbackDialog.tsx
+++ b/src/features/mypage/components/DeleteFeedbackDialog.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { Trash2 } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useState, useTransition } from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+
+import { deleteFeedbackAction } from "../actions";
+
+type DeleteFeedbackDialogProps = {
+  feedbackId: string;
+  feedbackTitle: string;
+};
+
+export function DeleteFeedbackDialog({
+  feedbackId,
+  feedbackTitle,
+}: DeleteFeedbackDialogProps) {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  function handleOpenChange(nextOpen: boolean) {
+    if (!nextOpen) {
+      setError(null);
+    }
+    setOpen(nextOpen);
+  }
+
+  function handleDelete() {
+    setError(null);
+    startTransition(async () => {
+      const result = await deleteFeedbackAction(feedbackId);
+
+      if (result?.error) {
+        setError(result.error);
+        return;
+      }
+
+      setOpen(false);
+      router.refresh();
+    });
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogTrigger asChild>
+        <Button variant="outline" size="sm">
+          <Trash2 className="size-3.5" />
+          삭제
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>문의사항 삭제</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-4">
+          <p className="text-sm text-muted-foreground">
+            <span className="font-medium text-foreground">
+              &ldquo;{feedbackTitle}&rdquo;
+            </span>{" "}
+            문의사항을 삭제할까요? 첨부한 이미지도 함께 삭제되며 되돌릴 수
+            없습니다.
+          </p>
+          {error && <p className="text-sm text-destructive">{error}</p>}
+        </div>
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            disabled={isPending}
+            onClick={() => handleOpenChange(false)}
+          >
+            취소
+          </Button>
+          <Button
+            type="button"
+            variant="destructive"
+            size="sm"
+            disabled={isPending}
+            onClick={handleDelete}
+          >
+            {isPending ? "삭제 중..." : "삭제"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/features/mypage/components/FaqSection.tsx
+++ b/src/features/mypage/components/FaqSection.tsx
@@ -1,0 +1,60 @@
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion";
+
+type FaqItem = {
+  question: string;
+  answer: string;
+};
+
+const FAQ_ITEMS: FaqItem[] = [
+  {
+    question: "복습 주기는 어떻게 되나요?",
+    answer:
+      "노트를 작성하면 1일 → 3일 → 7일 간격으로 총 3번의 복습을 하게 됩니다. 각 복습을 완료하면 다음 단계로 넘어가고, 마지막 복습까지 마치면 해당 노트의 복습이 종료됩니다.",
+  },
+  {
+    question: "복습 알림은 언제 오나요?",
+    answer:
+      "노트 작성 시 설정한 알림 시각에 맞춰 복습 예정일에 알림을 보내드립니다. 알림을 받으려면 마이페이지 > 계정 관리에서 푸시 알림을 허용해주세요.",
+  },
+  {
+    question: "복습을 놓치면 어떻게 되나요?",
+    answer:
+      "예정일이 지나도 복습 대기 노트에 계속 남아있으니 언제든 완료할 수 있습니다. 다만 학습 효과를 위해 가능하면 예정일에 맞춰 복습하는 것을 권장합니다.",
+  },
+  {
+    question: "닉네임이나 프로필 사진은 어떻게 바꾸나요?",
+    answer:
+      "마이페이지 > 계정 관리에서 닉네임과 프로필 사진을 변경할 수 있습니다.",
+  },
+  {
+    question: "회원 탈퇴는 어떻게 하나요?",
+    answer:
+      "마이페이지 > 계정 관리 하단의 회원 탈퇴 메뉴에서 진행할 수 있습니다. 탈퇴 시 작성한 노트를 포함한 모든 데이터가 삭제되며 복구할 수 없습니다.",
+  },
+  {
+    question: "원하는 답변을 찾지 못했어요",
+    answer:
+      "1:1 문의 탭에서 건의사항이나 궁금한 점을 남겨주시면 확인 후 답변드리겠습니다.",
+  },
+];
+
+export function FaqSection() {
+  return (
+    <section>
+      <h2 className="mb-3 text-lg font-semibold">자주 묻는 질문</h2>
+      <Accordion type="single" collapsible>
+        {FAQ_ITEMS.map((item, index) => (
+          <AccordionItem key={item.question} value={`faq-${index}`}>
+            <AccordionTrigger>{item.question}</AccordionTrigger>
+            <AccordionContent>{item.answer}</AccordionContent>
+          </AccordionItem>
+        ))}
+      </Accordion>
+    </section>
+  );
+}

--- a/src/features/mypage/components/FeedbackForm.tsx
+++ b/src/features/mypage/components/FeedbackForm.tsx
@@ -1,0 +1,276 @@
+"use client";
+
+import { ImagePlus, X } from "lucide-react";
+import Image from "next/image";
+import { useRouter } from "next/navigation";
+import { useEffect, useMemo, useRef, useState, useTransition } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Separator } from "@/components/ui/separator";
+import { cn } from "@/lib/utils/cn";
+
+import { createFeedbackAction } from "../actions";
+import {
+  FEEDBACK_CATEGORIES,
+  FEEDBACK_CATEGORY_LABELS,
+  FEEDBACK_CONTENT_MAX_LENGTH,
+  FEEDBACK_IMAGE_ALLOWED_TYPES,
+  FEEDBACK_IMAGE_MAX_COUNT,
+  FEEDBACK_IMAGE_MAX_SIZE,
+  FEEDBACK_TITLE_MAX_LENGTH,
+  type FeedbackCategory,
+} from "../schema";
+
+type FeedbackFormProps = {
+  hasSubmittedToday: boolean;
+};
+
+type FieldErrors = Partial<Record<"category" | "title" | "content", string[]>>;
+
+const inputLikeClassName =
+  "flex h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50";
+
+export function FeedbackForm({ hasSubmittedToday }: FeedbackFormProps) {
+  const router = useRouter();
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [isPending, startTransition] = useTransition();
+
+  const [category, setCategory] = useState<FeedbackCategory>("BUG");
+  const [title, setTitle] = useState("");
+  const [content, setContent] = useState("");
+  const [images, setImages] = useState<File[]>([]);
+
+  const [generalError, setGeneralError] = useState<string | null>(null);
+  const [fieldErrors, setFieldErrors] = useState<FieldErrors | null>(null);
+  const [isSubmitted, setIsSubmitted] = useState(false);
+
+  const previews = useMemo(
+    () => images.map((file) => URL.createObjectURL(file)),
+    [images],
+  );
+  useEffect(() => {
+    return () => previews.forEach((url) => URL.revokeObjectURL(url));
+  }, [previews]);
+
+  const handleAddImages = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const selected = Array.from(e.target.files ?? []);
+    e.target.value = "";
+    if (selected.length === 0) return;
+
+    setGeneralError(null);
+
+    const next = [...images, ...selected];
+    if (next.length > FEEDBACK_IMAGE_MAX_COUNT) {
+      setGeneralError(
+        `이미지는 최대 ${FEEDBACK_IMAGE_MAX_COUNT}장까지 첨부할 수 있습니다`,
+      );
+      return;
+    }
+
+    for (const file of selected) {
+      if (
+        !(FEEDBACK_IMAGE_ALLOWED_TYPES as readonly string[]).includes(file.type)
+      ) {
+        setGeneralError("JPG, PNG, GIF, WebP 형식만 업로드 가능합니다");
+        return;
+      }
+      if (file.size > FEEDBACK_IMAGE_MAX_SIZE) {
+        setGeneralError("이미지 크기는 장당 5MB 이하여야 합니다");
+        return;
+      }
+    }
+
+    setImages(next);
+  };
+
+  const handleRemoveImage = (index: number) => {
+    setImages((prev) => prev.filter((_, i) => i !== index));
+  };
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setGeneralError(null);
+    setFieldErrors(null);
+    setIsSubmitted(false);
+
+    const formData = new FormData();
+    formData.set("category", category);
+    formData.set("title", title);
+    formData.set("content", content);
+    for (const file of images) {
+      formData.append("images", file);
+    }
+
+    startTransition(async () => {
+      try {
+        const result = await createFeedbackAction(null, formData);
+
+        if (result && "data" in result) {
+          setTitle("");
+          setContent("");
+          setImages([]);
+          setIsSubmitted(true);
+          router.refresh();
+          return;
+        }
+
+        if (typeof result?.error === "string") {
+          setGeneralError(result.error);
+        } else if (result?.error) {
+          setFieldErrors(result.error);
+        }
+      } catch {
+        setGeneralError("문의사항 제출에 실패했습니다");
+      }
+    });
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>1:1 문의</CardTitle>
+      </CardHeader>
+      <Separator />
+      <CardContent>
+        <form onSubmit={handleSubmit} className="space-y-4 pt-5">
+          {hasSubmittedToday && (
+            <p className="rounded-md bg-muted px-3 py-2 text-sm text-muted-foreground">
+              오늘은 이미 문의사항을 제출했습니다. 내일 다시 제출할 수 있습니다.
+            </p>
+          )}
+
+          <div className="space-y-2">
+            <Label>분류</Label>
+            <div className="flex gap-2">
+              {FEEDBACK_CATEGORIES.map((value) => (
+                <Button
+                  key={value}
+                  type="button"
+                  size="sm"
+                  variant={category === value ? "default" : "outline"}
+                  onClick={() => setCategory(value)}
+                >
+                  {FEEDBACK_CATEGORY_LABELS[value]}
+                </Button>
+              ))}
+            </div>
+            {fieldErrors?.category && (
+              <p className="text-sm text-destructive">
+                {fieldErrors.category[0]}
+              </p>
+            )}
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="feedback-title">제목</Label>
+            <Input
+              id="feedback-title"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              maxLength={FEEDBACK_TITLE_MAX_LENGTH}
+              placeholder={`제목 (${FEEDBACK_TITLE_MAX_LENGTH}자 이내)`}
+            />
+            {fieldErrors?.title && (
+              <p className="text-sm text-destructive">{fieldErrors.title[0]}</p>
+            )}
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="feedback-content">내용</Label>
+            <textarea
+              id="feedback-content"
+              value={content}
+              onChange={(e) => setContent(e.target.value)}
+              maxLength={FEEDBACK_CONTENT_MAX_LENGTH}
+              placeholder="건의사항이나 문의 내용을 입력해주세요"
+              className={cn(
+                inputLikeClassName,
+                "min-h-32 resize-y py-2 placeholder:text-muted-foreground",
+              )}
+            />
+            <p className="text-right text-xs text-muted-foreground">
+              {content.length.toLocaleString("ko-KR")} /{" "}
+              {FEEDBACK_CONTENT_MAX_LENGTH.toLocaleString("ko-KR")}
+            </p>
+            {fieldErrors?.content && (
+              <p className="text-sm text-destructive">
+                {fieldErrors.content[0]}
+              </p>
+            )}
+          </div>
+
+          <div className="space-y-2">
+            <Label>
+              이미지 첨부{" "}
+              <span className="font-normal text-muted-foreground">
+                ({images.length}/{FEEDBACK_IMAGE_MAX_COUNT})
+              </span>
+            </Label>
+            <div className="flex flex-wrap items-center gap-2">
+              {previews.map((url, index) => (
+                <div key={url} className="relative">
+                  <Image
+                    src={url}
+                    alt={`첨부 이미지 ${index + 1}`}
+                    width={80}
+                    height={80}
+                    unoptimized
+                    className="size-20 rounded-md border object-cover"
+                  />
+                  <button
+                    type="button"
+                    aria-label="이미지 제거"
+                    onClick={() => handleRemoveImage(index)}
+                    className="absolute -right-1.5 -top-1.5 flex size-5 cursor-pointer items-center justify-center rounded-full bg-foreground text-background transition-opacity hover:opacity-80"
+                  >
+                    <X className="size-3" />
+                  </button>
+                </div>
+              ))}
+              {images.length < FEEDBACK_IMAGE_MAX_COUNT && (
+                <>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={() => fileInputRef.current?.click()}
+                  >
+                    <ImagePlus className="size-4" />
+                    추가
+                  </Button>
+                  <span className="text-xs text-muted-foreground">
+                    장당 5MB 이하, JPG·PNG·GIF·WebP
+                  </span>
+                </>
+              )}
+              <input
+                ref={fileInputRef}
+                type="file"
+                multiple
+                accept={FEEDBACK_IMAGE_ALLOWED_TYPES.join(",")}
+                className="hidden"
+                onChange={handleAddImages}
+              />
+            </div>
+          </div>
+
+          {generalError && (
+            <p className="text-sm text-destructive">{generalError}</p>
+          )}
+          {isSubmitted && (
+            <p className="text-sm text-primary">
+              문의사항이 제출되었습니다. 소중한 의견 감사합니다!
+            </p>
+          )}
+
+          <Button type="submit" disabled={isPending || hasSubmittedToday}>
+            {isPending ? "제출 중..." : "제출"}
+          </Button>
+        </form>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/features/mypage/components/FeedbackList.tsx
+++ b/src/features/mypage/components/FeedbackList.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+import { ChevronDown, StickyNote } from "lucide-react";
+import Image from "next/image";
+import Link from "next/link";
+import { useState } from "react";
+
+import { Card } from "@/components/ui/card";
+import { ROUTES } from "@/lib/constants/routes";
+import { cn } from "@/lib/utils/cn";
+
+import type { FeedbackImage, MyFeedback } from "../queries";
+import { FEEDBACK_CATEGORY_LABELS, type FeedbackCategory } from "../schema";
+import { DeleteFeedbackDialog } from "./DeleteFeedbackDialog";
+
+type FeedbackListProps = {
+  feedbacks: MyFeedback[];
+};
+
+function categoryLabel(category: string): string {
+  return FEEDBACK_CATEGORY_LABELS[category as FeedbackCategory] ?? category;
+}
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString("ko-KR");
+}
+
+function FeedbackImages({ images }: { images: FeedbackImage[] }) {
+  const visible = images.filter(
+    (image): image is FeedbackImage & { url: string } => image.url !== null,
+  );
+  if (visible.length === 0) return null;
+
+  return (
+    <div className="flex flex-wrap gap-2">
+      {visible.map((image) => (
+        <a
+          key={image.path}
+          href={image.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="cursor-pointer"
+        >
+          {/* 서명 URL은 remotePatterns 미등록 + 요청마다 달라져 최적화 캐시가 무의미 → unoptimized */}
+          <Image
+            src={image.url}
+            alt="첨부 이미지"
+            width={96}
+            height={96}
+            unoptimized
+            className="size-24 rounded-md border object-cover transition-opacity hover:opacity-80"
+          />
+        </a>
+      ))}
+    </div>
+  );
+}
+
+export function FeedbackList({ feedbacks }: FeedbackListProps) {
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+
+  if (feedbacks.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        아직 제출한 문의사항이 없습니다.
+      </p>
+    );
+  }
+
+  return (
+    <ul className="list-none space-y-3">
+      {feedbacks.map((feedback) => {
+        const isExpanded = expandedId === feedback.id;
+
+        return (
+          <li key={feedback.id}>
+            <Card className="overflow-hidden py-0">
+              <button
+                type="button"
+                aria-expanded={isExpanded}
+                onClick={() => setExpandedId(isExpanded ? null : feedback.id)}
+                className="flex w-full cursor-pointer items-center gap-3 px-4 py-3 text-left transition-colors hover:bg-accent/50"
+              >
+                <span className="shrink-0 rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">
+                  {categoryLabel(feedback.category)}
+                </span>
+                <span className="min-w-0 flex-1 truncate text-sm font-medium">
+                  {feedback.title}
+                </span>
+                <span className="hidden shrink-0 text-xs text-muted-foreground sm:inline">
+                  {formatDate(feedback.created_at)}
+                </span>
+                <span
+                  className={cn(
+                    "shrink-0 rounded-full px-2 py-0.5 text-xs",
+                    feedback.reply
+                      ? "bg-primary/10 text-primary"
+                      : "bg-muted text-muted-foreground",
+                  )}
+                >
+                  {feedback.reply ? "답변 완료" : "답변 대기"}
+                </span>
+                <ChevronDown
+                  className={cn(
+                    "size-4 shrink-0 text-muted-foreground transition-transform",
+                    isExpanded && "rotate-180",
+                  )}
+                />
+              </button>
+
+              {isExpanded && (
+                <div className="space-y-4 border-t px-4 py-4">
+                  <p className="text-sm whitespace-pre-wrap break-words">
+                    {feedback.content}
+                  </p>
+
+                  <FeedbackImages images={feedback.images} />
+
+                  {feedback.note && (
+                    <Link
+                      href={`${ROUTES.NOTES}/${feedback.note.id}`}
+                      className="inline-flex items-center gap-1.5 text-sm text-muted-foreground transition-colors hover:text-foreground"
+                    >
+                      <StickyNote className="size-3.5" />
+                      연결된 노트: {feedback.note.title}
+                    </Link>
+                  )}
+
+                  {feedback.reply ? (
+                    <div className="space-y-2 rounded-md bg-muted/60 px-4 py-3">
+                      <div className="flex items-center justify-between gap-2">
+                        <p className="text-sm font-medium">
+                          {feedback.reply.title}
+                        </p>
+                        <p className="shrink-0 text-xs text-muted-foreground">
+                          {formatDate(feedback.reply.created_at)}
+                        </p>
+                      </div>
+                      <p className="text-sm whitespace-pre-wrap break-words text-muted-foreground">
+                        {feedback.reply.content}
+                      </p>
+                      <FeedbackImages images={feedback.reply.images} />
+                    </div>
+                  ) : (
+                    <div className="flex justify-end">
+                      <DeleteFeedbackDialog
+                        feedbackId={feedback.id}
+                        feedbackTitle={feedback.title}
+                      />
+                    </div>
+                  )}
+                </div>
+              )}
+            </Card>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/src/features/mypage/components/FeedbackSection.tsx
+++ b/src/features/mypage/components/FeedbackSection.tsx
@@ -1,0 +1,29 @@
+import type { MyFeedback } from "../queries";
+import { FeedbackForm } from "./FeedbackForm";
+import { FeedbackList } from "./FeedbackList";
+
+type FeedbackSectionProps = {
+  feedbacks: MyFeedback[];
+  hasSubmittedToday: boolean;
+};
+
+export function FeedbackSection({
+  feedbacks,
+  hasSubmittedToday,
+}: FeedbackSectionProps) {
+  return (
+    <div className="space-y-6">
+      <FeedbackForm hasSubmittedToday={hasSubmittedToday} />
+
+      <section>
+        <h2 className="mb-3 text-lg font-semibold">
+          내가 남긴 문의사항{" "}
+          <span className="text-sm font-normal text-muted-foreground">
+            ({feedbacks.length})
+          </span>
+        </h2>
+        <FeedbackList feedbacks={feedbacks} />
+      </section>
+    </div>
+  );
+}

--- a/src/features/mypage/components/MypageNav.tsx
+++ b/src/features/mypage/components/MypageNav.tsx
@@ -1,15 +1,16 @@
-import { BarChart2, ListTodo, User } from "lucide-react";
+import { BarChart2, Headset, ListTodo, User } from "lucide-react";
 import Link from "next/link";
 
 import { ROUTES } from "@/lib/constants/routes";
 import { cn } from "@/lib/utils/cn";
 
-export type MypageSection = "profile" | "stats" | "reviews";
+export type MypageSection = "profile" | "stats" | "reviews" | "support";
 
 const navItems = [
   { id: "stats" as const, label: "학습 통계", icon: BarChart2 },
   { id: "reviews" as const, label: "복습 대기", icon: ListTodo },
   { id: "profile" as const, label: "계정 관리", icon: User },
+  { id: "support" as const, label: "고객 센터", icon: Headset },
 ];
 
 type MypageNavProps = {

--- a/src/features/mypage/components/SupportSection.tsx
+++ b/src/features/mypage/components/SupportSection.tsx
@@ -1,0 +1,58 @@
+import { HelpCircle, MessageSquare } from "lucide-react";
+import Link from "next/link";
+
+import { ROUTES } from "@/lib/constants/routes";
+import { cn } from "@/lib/utils/cn";
+
+import type { MyFeedback } from "../queries";
+import { FaqSection } from "./FaqSection";
+import { FeedbackSection } from "./FeedbackSection";
+
+export type SupportTab = "faq" | "inquiry";
+
+const SUPPORT_TAB_ITEMS = [
+  { id: "faq" as const, label: "FAQ", icon: HelpCircle },
+  { id: "inquiry" as const, label: "1:1 문의", icon: MessageSquare },
+];
+
+type SupportSectionProps = {
+  activeTab: SupportTab;
+  feedbacks: MyFeedback[];
+  hasSubmittedToday: boolean;
+};
+
+export function SupportSection({
+  activeTab,
+  feedbacks,
+  hasSubmittedToday,
+}: SupportSectionProps) {
+  return (
+    <div className="space-y-6">
+      <nav className="flex gap-1 border-b">
+        {SUPPORT_TAB_ITEMS.map(({ id, label, icon: Icon }) => (
+          <Link
+            key={id}
+            href={`${ROUTES.MYPAGE}?section=support&tab=${id}`}
+            className={cn(
+              "flex items-center gap-1.5 px-4 py-2.5 text-sm font-medium transition-colors",
+              activeTab === id
+                ? "border-b-2 border-primary text-primary"
+                : "text-muted-foreground hover:text-foreground",
+            )}
+          >
+            <Icon className="size-4" />
+            {label}
+          </Link>
+        ))}
+      </nav>
+
+      {activeTab === "faq" && <FaqSection />}
+      {activeTab === "inquiry" && (
+        <FeedbackSection
+          feedbacks={feedbacks}
+          hasSubmittedToday={hasSubmittedToday}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/features/mypage/queries.ts
+++ b/src/features/mypage/queries.ts
@@ -1,4 +1,5 @@
 import { getKstDayBoundsUtc } from "@/features/review/lib/kstDay";
+import { logError } from "@/lib/logger";
 import { getUser } from "@/lib/supabase/getUser";
 import { createServerComponentClient } from "@/lib/supabase/server";
 
@@ -186,4 +187,128 @@ export async function getLearningStats(): Promise<LearningStats> {
     studyStreak,
     onTimeRate: { completed: completedReviews, onTime },
   };
+}
+
+// ---- 피드백 (#266) ----
+
+export type FeedbackImage = { path: string; url: string | null };
+
+export type MyFeedbackReply = {
+  title: string;
+  content: string;
+  created_at: string;
+  images: FeedbackImage[];
+};
+
+export type MyFeedback = {
+  id: string;
+  category: string;
+  title: string;
+  content: string;
+  status: string;
+  created_at: string;
+  note: { id: string; title: string } | null;
+  images: FeedbackImage[];
+  reply: MyFeedbackReply | null;
+};
+
+export type MyFeedbacksResult = {
+  feedbacks: MyFeedback[];
+  hasSubmittedToday: boolean;
+};
+
+// private 버킷이므로 이미지는 서명 URL로만 접근 가능
+const FEEDBACK_SIGNED_URL_EXPIRES_IN = 60 * 60; // 1시간
+
+async function createSignedUrlMap(
+  supabase: Awaited<ReturnType<typeof createServerComponentClient>>,
+  bucket: "feedbacks" | "feedback_replies",
+  paths: string[],
+): Promise<Map<string, string>> {
+  if (paths.length === 0) return new Map();
+
+  const { data, error } = await supabase.storage
+    .from(bucket)
+    .createSignedUrls(paths, FEEDBACK_SIGNED_URL_EXPIRES_IN);
+
+  if (error || !data) {
+    logError(
+      `[getMyFeedbacks] ${bucket} 서명 URL 생성 실패: ${error?.message}`,
+    );
+    return new Map();
+  }
+
+  const map = new Map<string, string>();
+  for (const item of data) {
+    if (item.path && item.signedUrl) map.set(item.path, item.signedUrl);
+  }
+  return map;
+}
+
+function toFeedbackImages(
+  paths: string[],
+  urlMap: Map<string, string>,
+): FeedbackImage[] {
+  return paths.map((path) => ({ path, url: urlMap.get(path) ?? null }));
+}
+
+export async function getMyFeedbacks(
+  userId: string,
+): Promise<MyFeedbacksResult> {
+  const supabase = await createServerComponentClient();
+
+  const { data, error } = await supabase
+    .from("feedbacks")
+    .select(
+      "id, category, title, content, image_urls, status, created_at, note:notes(id, title), reply:feedback_replies(title, content, image_paths, created_at)",
+    )
+    .eq("user_id", userId)
+    .order("created_at", { ascending: false });
+
+  if (error) {
+    logError(`[getMyFeedbacks] 피드백 조회 실패: ${error.message}`);
+    return { feedbacks: [], hasSubmittedToday: false };
+  }
+
+  const rows = data ?? [];
+
+  const [feedbackUrlMap, replyUrlMap] = await Promise.all([
+    createSignedUrlMap(
+      supabase,
+      "feedbacks",
+      rows.flatMap((row) => row.image_urls),
+    ),
+    createSignedUrlMap(
+      supabase,
+      "feedback_replies",
+      rows.flatMap((row) => row.reply?.image_paths ?? []),
+    ),
+  ]);
+
+  const todayKstKey = toKstDateKey(new Date().toISOString());
+
+  const feedbacks: MyFeedback[] = rows.map((row) => ({
+    id: row.id,
+    category: row.category,
+    title: row.title,
+    content: row.content,
+    status: row.status,
+    created_at: row.created_at,
+    note: row.note,
+    images: toFeedbackImages(row.image_urls, feedbackUrlMap),
+    reply: row.reply
+      ? {
+          title: row.reply.title,
+          content: row.reply.content,
+          created_at: row.reply.created_at,
+          images: toFeedbackImages(row.reply.image_paths, replyUrlMap),
+        }
+      : null,
+  }));
+
+  const hasSubmittedToday = feedbacks.some(
+    (feedback) => toKstDateKey(feedback.created_at) === todayKstKey,
+  );
+
+  return { feedbacks, hasSubmittedToday };
 }

--- a/src/features/mypage/schema.ts
+++ b/src/features/mypage/schema.ts
@@ -28,3 +28,48 @@ export const changePasswordSchema = z
 
 export type ProfileFormInput = z.infer<typeof profileSchema>;
 export type ChangePasswordInput = z.infer<typeof changePasswordSchema>;
+
+// ---- 피드백 (#266) ----
+
+export const FEEDBACK_CATEGORIES = ["BUG", "FEATURE", "ETC"] as const;
+export type FeedbackCategory = (typeof FEEDBACK_CATEGORIES)[number];
+
+export const FEEDBACK_CATEGORY_LABELS: Record<FeedbackCategory, string> = {
+  BUG: "버그 신고",
+  FEATURE: "기능 제안",
+  ETC: "기타",
+};
+
+export const FEEDBACK_TITLE_MAX_LENGTH = 100;
+export const FEEDBACK_CONTENT_MAX_LENGTH = 2000;
+export const FEEDBACK_IMAGE_MAX_COUNT = 3;
+// feedbacks 버킷의 file_size_limit(5MB)·allowed_mime_types와 동일하게 유지할 것
+export const FEEDBACK_IMAGE_MAX_SIZE = 5 * 1024 * 1024;
+export const FEEDBACK_IMAGE_ALLOWED_TYPES = AVATAR_ALLOWED_TYPES;
+
+export const FEEDBACK_DAILY_LIMIT_MESSAGE =
+  "문의사항은 하루에 1건만 제출할 수 있습니다. 내일 다시 시도해주세요.";
+
+export const feedbackSchema = z.object({
+  category: z.enum(FEEDBACK_CATEGORIES, {
+    message: "분류를 선택해주세요",
+  }),
+  title: z
+    .string()
+    .trim()
+    .min(1, "제목을 입력해주세요")
+    .max(
+      FEEDBACK_TITLE_MAX_LENGTH,
+      `제목은 ${FEEDBACK_TITLE_MAX_LENGTH}자 이내로 입력해주세요`,
+    ),
+  content: z
+    .string()
+    .trim()
+    .min(1, "내용을 입력해주세요")
+    .max(
+      FEEDBACK_CONTENT_MAX_LENGTH,
+      `내용은 ${FEEDBACK_CONTENT_MAX_LENGTH.toLocaleString("ko-KR")}자 이내로 입력해주세요`,
+    ),
+});
+
+export type FeedbackFormInput = z.infer<typeof feedbackSchema>;

--- a/src/features/mypage/tests/actions.test.ts
+++ b/src/features/mypage/tests/actions.test.ts
@@ -8,8 +8,18 @@ vi.mock("@/lib/supabase/server", () => ({
   createClient: createClientMock,
 }));
 
-import { deleteAvatarAction, uploadAvatarAction } from "../actions";
-import { AVATAR_ALLOWED_TYPES, AVATAR_MAX_SIZE } from "../schema";
+import {
+  createFeedbackAction,
+  deleteAvatarAction,
+  deleteFeedbackAction,
+  uploadAvatarAction,
+} from "../actions";
+import {
+  AVATAR_ALLOWED_TYPES,
+  AVATAR_MAX_SIZE,
+  FEEDBACK_DAILY_LIMIT_MESSAGE,
+  FEEDBACK_IMAGE_MAX_SIZE,
+} from "../schema";
 
 function makeFile(name: string, type: string, size: number): File {
   const content = new Uint8Array(size);
@@ -195,5 +205,425 @@ describe("deleteAvatarAction", () => {
     const result = await deleteAvatarAction();
     expect(result).toEqual({ error: "아바타 삭제에 실패했습니다" });
     expect(supabase.storage.from).not.toHaveBeenCalled();
+  });
+});
+
+// ---- 피드백 (#266) ----
+
+function makeFeedbackSupabaseMock({
+  userId = "user-123",
+  todayRows = [] as { id: string }[],
+  todayError = null as { message: string } | null,
+  insertError = null as { message: string; code?: string } | null,
+  uploadError = null as { message: string } | null,
+  fetchRow = null as { id: string; image_urls: string[] } | null,
+  fetchError = null as { message: string } | null,
+  replyCount = 0,
+  replyError = null as { message: string } | null,
+  deletedRows = [] as { id: string }[],
+  deleteError = null as { message: string } | null,
+  removeError = null as { message: string } | null,
+} = {}) {
+  const insertedRow = { id: "feedback-1" };
+
+  // feedbacks.select() 체인 — 오늘 제출 여부 확인과 삭제 대상 단건 조회에서 공용으로 쓰인다.
+  const limitMock = vi.fn().mockResolvedValue({
+    data: todayError ? null : todayRows,
+    error: todayError,
+  });
+  const maybeSingleMock = vi.fn().mockResolvedValue({
+    data: fetchError ? null : fetchRow,
+    error: fetchError,
+  });
+  const feedbackSelectMock = vi.fn().mockReturnValue({
+    eq: vi.fn().mockReturnThis(),
+    gte: vi.fn().mockReturnThis(),
+    lt: vi.fn().mockReturnThis(),
+    limit: limitMock,
+    maybeSingle: maybeSingleMock,
+  });
+
+  const insertSingle = vi.fn().mockResolvedValue({
+    data: insertError ? null : insertedRow,
+    error: insertError,
+  });
+  const insertMock = vi.fn().mockReturnValue({
+    select: vi.fn().mockReturnValue({ single: insertSingle }),
+  });
+
+  const deleteSelect = vi.fn().mockResolvedValue({
+    data: deleteError ? null : deletedRows,
+    error: deleteError,
+  });
+  const deleteMock = vi.fn().mockReturnValue({
+    eq: vi.fn().mockReturnValue({
+      eq: vi.fn().mockReturnValue({ select: deleteSelect }),
+    }),
+  });
+
+  // feedback_replies.select() 체인 — 삭제 전 답변 존재 여부를 미리 확인한다.
+  const replyEqMock = vi.fn().mockResolvedValue({
+    count: replyError ? null : replyCount,
+    error: replyError,
+  });
+  const replySelectMock = vi.fn().mockReturnValue({ eq: replyEqMock });
+
+  const uploadMock = vi.fn().mockResolvedValue({ error: uploadError });
+  const removeMock = vi.fn().mockResolvedValue({ error: removeError });
+
+  const fromMock = vi.fn((table: string) => {
+    if (table === "feedback_replies") {
+      return { select: replySelectMock };
+    }
+
+    return {
+      select: feedbackSelectMock,
+      insert: insertMock,
+      delete: deleteMock,
+    };
+  });
+
+  return {
+    insertMock,
+    uploadMock,
+    removeMock,
+    deleteMock,
+    replySelectMock,
+    supabase: {
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: userId ? { id: userId } : null },
+        }),
+      },
+      storage: {
+        from: vi.fn().mockReturnValue({
+          upload: uploadMock,
+          remove: removeMock,
+        }),
+      },
+      from: fromMock,
+    },
+  };
+}
+
+function makeFeedbackFormData({
+  category = "BUG",
+  title = "버그 신고",
+  content = "버튼이 동작하지 않습니다",
+  images = [] as File[],
+} = {}) {
+  const formData = new FormData();
+  formData.set("category", category);
+  formData.set("title", title);
+  formData.set("content", content);
+  for (const file of images) {
+    formData.append("images", file);
+  }
+  return formData;
+}
+
+describe("createFeedbackAction", () => {
+  beforeEach(() => {
+    createClientMock.mockReset();
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("스키마 검증 실패 시 fieldErrors 반환", async () => {
+    const result = await createFeedbackAction(
+      null,
+      makeFeedbackFormData({ title: "" }),
+    );
+    expect(result.error).toBeTypeOf("object");
+    expect((result.error as { title?: string[] }).title?.[0]).toBe(
+      "제목을 입력해주세요",
+    );
+  });
+
+  it("이미지 3장 초과 시 에러 반환", async () => {
+    const images = Array.from({ length: 4 }, (_, i) =>
+      makeFile(`img-${i}.png`, "image/png", 1024),
+    );
+    const result = await createFeedbackAction(
+      null,
+      makeFeedbackFormData({ images }),
+    );
+    expect(result).toEqual({
+      error: "이미지는 최대 3장까지 첨부할 수 있습니다",
+    });
+  });
+
+  it("허용되지 않은 이미지 형식이면 에러 반환", async () => {
+    const result = await createFeedbackAction(
+      null,
+      makeFeedbackFormData({
+        images: [makeFile("doc.pdf", "application/pdf", 1024)],
+      }),
+    );
+    expect(result).toEqual({
+      error: "JPG, PNG, GIF, WebP 형식만 업로드 가능합니다",
+    });
+  });
+
+  it("5MB 초과 이미지면 에러 반환", async () => {
+    const result = await createFeedbackAction(
+      null,
+      makeFeedbackFormData({
+        images: [makeFile("big.png", "image/png", FEEDBACK_IMAGE_MAX_SIZE + 1)],
+      }),
+    );
+    expect(result).toEqual({ error: "이미지 크기는 장당 5MB 이하여야 합니다" });
+  });
+
+  it("인증되지 않은 경우 에러 반환", async () => {
+    const { supabase } = makeFeedbackSupabaseMock({ userId: null as never });
+    createClientMock.mockResolvedValue(supabase);
+
+    const result = await createFeedbackAction(null, makeFeedbackFormData());
+    expect(result).toEqual({ error: "인증이 필요합니다" });
+  });
+
+  it("오늘 이미 제출한 경우 일일 제한 에러 반환하고 insert하지 않는다", async () => {
+    const { supabase, insertMock } = makeFeedbackSupabaseMock({
+      todayRows: [{ id: "feedback-0" }],
+    });
+    createClientMock.mockResolvedValue(supabase);
+
+    const result = await createFeedbackAction(null, makeFeedbackFormData());
+    expect(result).toEqual({ error: FEEDBACK_DAILY_LIMIT_MESSAGE });
+    expect(insertMock).not.toHaveBeenCalled();
+  });
+
+  it("업로드 실패 시 이미 업로드된 이미지를 정리하고 에러 반환", async () => {
+    const { supabase, uploadMock, removeMock, insertMock } =
+      makeFeedbackSupabaseMock();
+    uploadMock
+      .mockResolvedValueOnce({ error: null })
+      .mockResolvedValueOnce({ error: { message: "upload failed" } });
+    createClientMock.mockResolvedValue(supabase);
+
+    const result = await createFeedbackAction(
+      null,
+      makeFeedbackFormData({
+        images: [
+          makeFile("a.png", "image/png", 1024),
+          makeFile("b.png", "image/png", 1024),
+        ],
+      }),
+    );
+
+    expect(result).toEqual({ error: "이미지 업로드에 실패했습니다" });
+    expect(removeMock).toHaveBeenCalledTimes(1);
+    expect(removeMock.mock.calls[0]?.[0]).toHaveLength(1);
+    expect(insertMock).not.toHaveBeenCalled();
+  });
+
+  it("insert가 unique 위반(23505)이면 일일 제한 에러로 변환하고 이미지를 정리한다", async () => {
+    const { supabase, removeMock } = makeFeedbackSupabaseMock({
+      insertError: { message: "duplicate", code: "23505" },
+    });
+    createClientMock.mockResolvedValue(supabase);
+
+    const result = await createFeedbackAction(
+      null,
+      makeFeedbackFormData({ images: [makeFile("a.png", "image/png", 1024)] }),
+    );
+
+    expect(result).toEqual({ error: FEEDBACK_DAILY_LIMIT_MESSAGE });
+    expect(removeMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("insert 기타 실패 시 일반 에러 반환", async () => {
+    const { supabase } = makeFeedbackSupabaseMock({
+      insertError: { message: "boom" },
+    });
+    createClientMock.mockResolvedValue(supabase);
+
+    const result = await createFeedbackAction(null, makeFeedbackFormData());
+    expect(result).toEqual({ error: "문의사항 제출에 실패했습니다" });
+  });
+
+  it("성공 시 data 반환하고 입력값대로 insert한다", async () => {
+    const { supabase, insertMock, uploadMock } = makeFeedbackSupabaseMock();
+    createClientMock.mockResolvedValue(supabase);
+
+    const result = await createFeedbackAction(
+      null,
+      makeFeedbackFormData({
+        category: "FEATURE",
+        title: "제안",
+        content: "다크 모드 추가해주세요",
+        images: [makeFile("a.png", "image/png", 1024)],
+      }),
+    );
+
+    expect(result).toEqual({ data: { id: "feedback-1" } });
+    expect(uploadMock).toHaveBeenCalledTimes(1);
+    expect(insertMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        user_id: "user-123",
+        note_id: null,
+        category: "FEATURE",
+        title: "제안",
+        content: "다크 모드 추가해주세요",
+        image_urls: expect.arrayContaining([
+          expect.stringMatching(/^user-123\/.+\.png$/),
+        ]),
+      }),
+    );
+  });
+});
+
+describe("deleteFeedbackAction", () => {
+  const feedbackId = "550e8400-e29b-41d4-a716-446655440000";
+
+  beforeEach(() => {
+    createClientMock.mockReset();
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("uuid가 아니면 에러 반환", async () => {
+    const result = await deleteFeedbackAction("not-a-uuid");
+    expect(result).toEqual({ error: "잘못된 요청입니다" });
+  });
+
+  it("인증되지 않은 경우 에러 반환", async () => {
+    const { supabase } = makeFeedbackSupabaseMock({ userId: null as never });
+    createClientMock.mockResolvedValue(supabase);
+
+    const result = await deleteFeedbackAction(feedbackId);
+    expect(result).toEqual({ error: "인증이 필요합니다" });
+  });
+
+  it("조회 쿼리 실패 시 에러 반환", async () => {
+    const { supabase, removeMock, deleteMock } = makeFeedbackSupabaseMock({
+      fetchError: { message: "boom" },
+    });
+    createClientMock.mockResolvedValue(supabase);
+
+    const result = await deleteFeedbackAction(feedbackId);
+    expect(result).toEqual({ error: "문의사항 삭제에 실패했습니다" });
+    expect(removeMock).not.toHaveBeenCalled();
+    expect(deleteMock).not.toHaveBeenCalled();
+  });
+
+  it("대상 행이 없으면(타인 소유·이미 삭제 등) 에러 반환", async () => {
+    const { supabase, removeMock } = makeFeedbackSupabaseMock({
+      fetchRow: null,
+    });
+    createClientMock.mockResolvedValue(supabase);
+
+    const result = await deleteFeedbackAction(feedbackId);
+    expect(result).toEqual({
+      error: "삭제할 수 없습니다. 이미 삭제된 문의사항입니다",
+    });
+    expect(removeMock).not.toHaveBeenCalled();
+  });
+
+  it("답변 조회 실패 시 에러 반환", async () => {
+    const { supabase, removeMock } = makeFeedbackSupabaseMock({
+      fetchRow: { id: feedbackId, image_urls: [] },
+      replyError: { message: "boom" },
+    });
+    createClientMock.mockResolvedValue(supabase);
+
+    const result = await deleteFeedbackAction(feedbackId);
+    expect(result).toEqual({ error: "문의사항 삭제에 실패했습니다" });
+    expect(removeMock).not.toHaveBeenCalled();
+  });
+
+  it("답변이 이미 등록되어 있으면 이미지 정리 없이 에러 반환", async () => {
+    const { supabase, removeMock, deleteMock } = makeFeedbackSupabaseMock({
+      fetchRow: {
+        id: feedbackId,
+        image_urls: ["user-123/feedback-1/a.png"],
+      },
+      replyCount: 1,
+    });
+    createClientMock.mockResolvedValue(supabase);
+
+    const result = await deleteFeedbackAction(feedbackId);
+    expect(result).toEqual({
+      error: "삭제할 수 없습니다. 답변이 등록된 문의사항입니다",
+    });
+    expect(removeMock).not.toHaveBeenCalled();
+    expect(deleteMock).not.toHaveBeenCalled();
+  });
+
+  it("이미지 삭제 실패 시 DB 행을 지우지 않고 에러 반환", async () => {
+    const paths = ["user-123/feedback-1/a.png"];
+    const { supabase, removeMock, deleteMock } = makeFeedbackSupabaseMock({
+      fetchRow: { id: feedbackId, image_urls: paths },
+      removeError: { message: "storage down" },
+    });
+    createClientMock.mockResolvedValue(supabase);
+
+    const result = await deleteFeedbackAction(feedbackId);
+    expect(result).toEqual({
+      error: "이미지 삭제에 실패했습니다. 잠시 후 다시 시도해주세요",
+    });
+    expect(removeMock).toHaveBeenCalledWith(paths);
+    expect(deleteMock).not.toHaveBeenCalled();
+  });
+
+  it("최종 삭제 쿼리 실패 시 에러 반환", async () => {
+    const { supabase } = makeFeedbackSupabaseMock({
+      fetchRow: { id: feedbackId, image_urls: [] },
+      deleteError: { message: "boom" },
+    });
+    createClientMock.mockResolvedValue(supabase);
+
+    const result = await deleteFeedbackAction(feedbackId);
+    expect(result).toEqual({ error: "문의사항 삭제에 실패했습니다" });
+  });
+
+  it("이미지 정리 후 답변이 새로 달려 최종 삭제가 막히면 에러 반환", async () => {
+    const { supabase } = makeFeedbackSupabaseMock({
+      fetchRow: { id: feedbackId, image_urls: [] },
+      deletedRows: [],
+    });
+    createClientMock.mockResolvedValue(supabase);
+
+    const result = await deleteFeedbackAction(feedbackId);
+    expect(result).toEqual({
+      error:
+        "삭제할 수 없습니다. 답변이 등록되었거나 이미 삭제된 문의사항입니다",
+    });
+  });
+
+  it("성공 시 이미지를 먼저 정리한 뒤 행을 삭제하고 data를 반환한다", async () => {
+    const paths = ["user-123/feedback-1/a.png", "user-123/feedback-1/b.png"];
+    const { supabase, removeMock, deleteMock } = makeFeedbackSupabaseMock({
+      fetchRow: { id: feedbackId, image_urls: paths },
+      deletedRows: [{ id: feedbackId }],
+    });
+    createClientMock.mockResolvedValue(supabase);
+
+    const result = await deleteFeedbackAction(feedbackId);
+    expect(result).toEqual({ data: { success: true } });
+    expect(removeMock).toHaveBeenCalledWith(paths);
+    expect(
+      removeMock.mock.invocationCallOrder[0]! <
+        deleteMock.mock.invocationCallOrder[0]!,
+    ).toBe(true);
+  });
+
+  it("첨부 이미지가 없으면 storage 정리를 호출하지 않는다", async () => {
+    const { supabase, removeMock } = makeFeedbackSupabaseMock({
+      fetchRow: { id: feedbackId, image_urls: [] },
+      deletedRows: [{ id: feedbackId }],
+    });
+    createClientMock.mockResolvedValue(supabase);
+
+    const result = await deleteFeedbackAction(feedbackId);
+    expect(result).toEqual({ data: { success: true } });
+    expect(removeMock).not.toHaveBeenCalled();
   });
 });

--- a/src/features/mypage/tests/actions.test.ts
+++ b/src/features/mypage/tests/actions.test.ts
@@ -557,20 +557,19 @@ describe("deleteFeedbackAction", () => {
     expect(deleteMock).not.toHaveBeenCalled();
   });
 
-  it("이미지 삭제 실패 시 DB 행을 지우지 않고 에러 반환", async () => {
+  it("DB 행 삭제 후 이미지 정리가 실패해도 성공으로 반환한다(고아 파일 로그만 남김)", async () => {
     const paths = ["user-123/feedback-1/a.png"];
     const { supabase, removeMock, deleteMock } = makeFeedbackSupabaseMock({
       fetchRow: { id: feedbackId, image_urls: paths },
+      deletedRows: [{ id: feedbackId }],
       removeError: { message: "storage down" },
     });
     createClientMock.mockResolvedValue(supabase);
 
     const result = await deleteFeedbackAction(feedbackId);
-    expect(result).toEqual({
-      error: "이미지 삭제에 실패했습니다. 잠시 후 다시 시도해주세요",
-    });
+    expect(result).toEqual({ data: { success: true } });
+    expect(deleteMock).toHaveBeenCalled();
     expect(removeMock).toHaveBeenCalledWith(paths);
-    expect(deleteMock).not.toHaveBeenCalled();
   });
 
   it("최종 삭제 쿼리 실패 시 에러 반환", async () => {
@@ -584,7 +583,7 @@ describe("deleteFeedbackAction", () => {
     expect(result).toEqual({ error: "문의사항 삭제에 실패했습니다" });
   });
 
-  it("이미지 정리 후 답변이 새로 달려 최종 삭제가 막히면 에러 반환", async () => {
+  it("사전 확인 후 답변이 새로 달려 최종 삭제가 막히면 에러 반환", async () => {
     const { supabase } = makeFeedbackSupabaseMock({
       fetchRow: { id: feedbackId, image_urls: [] },
       deletedRows: [],
@@ -598,7 +597,7 @@ describe("deleteFeedbackAction", () => {
     });
   });
 
-  it("성공 시 이미지를 먼저 정리한 뒤 행을 삭제하고 data를 반환한다", async () => {
+  it("성공 시 행을 먼저 삭제한 뒤 이미지를 정리하고 data를 반환한다", async () => {
     const paths = ["user-123/feedback-1/a.png", "user-123/feedback-1/b.png"];
     const { supabase, removeMock, deleteMock } = makeFeedbackSupabaseMock({
       fetchRow: { id: feedbackId, image_urls: paths },
@@ -610,8 +609,8 @@ describe("deleteFeedbackAction", () => {
     expect(result).toEqual({ data: { success: true } });
     expect(removeMock).toHaveBeenCalledWith(paths);
     expect(
-      removeMock.mock.invocationCallOrder[0]! <
-        deleteMock.mock.invocationCallOrder[0]!,
+      deleteMock.mock.invocationCallOrder[0]! <
+        removeMock.mock.invocationCallOrder[0]!,
     ).toBe(true);
   });
 

--- a/src/features/mypage/tests/queries.test.ts
+++ b/src/features/mypage/tests/queries.test.ts
@@ -13,7 +13,7 @@ vi.mock("@/lib/supabase/getUser", () => ({
   getUser: getUserMock,
 }));
 
-import { getLearningStats } from "../queries";
+import { getLearningStats, getMyFeedbacks } from "../queries";
 
 type NotesRow = { review_round: number; next_review_at?: string | null };
 type ReviewLogsRow = {
@@ -332,5 +332,195 @@ describe("getLearningStats", () => {
     expect(
       result.recentActivity.find((d) => d.date === "2026-03-29"),
     ).toBeUndefined();
+  });
+});
+
+// ---- 피드백 (#266) ----
+
+type FeedbackQueryRow = {
+  id: string;
+  category: string;
+  title: string;
+  content: string;
+  image_urls: string[];
+  status: string;
+  created_at: string;
+  note: { id: string; title: string } | null;
+  reply: {
+    title: string;
+    content: string;
+    image_paths: string[];
+    created_at: string;
+  } | null;
+};
+
+function makeFeedbackRow(
+  overrides: Partial<FeedbackQueryRow> = {},
+): FeedbackQueryRow {
+  return {
+    id: "feedback-1",
+    category: "BUG",
+    title: "버그 신고",
+    content: "동작하지 않아요",
+    image_urls: [],
+    status: "OPEN",
+    created_at: "2026-05-01T00:00:00.000Z",
+    note: null,
+    reply: null,
+    ...overrides,
+  };
+}
+
+function makeFeedbackQuerySupabase({
+  rows = [] as FeedbackQueryRow[],
+  selectError = null as { message: string } | null,
+  signedUrlError = null as { message: string } | null,
+}: {
+  rows?: FeedbackQueryRow[];
+  selectError?: { message: string } | null;
+  signedUrlError?: { message: string } | null;
+} = {}) {
+  const feedbacksOrder = vi.fn().mockResolvedValue({
+    data: selectError ? null : rows,
+    error: selectError,
+  });
+  const feedbacksEq = vi.fn().mockReturnValue({ order: feedbacksOrder });
+  const feedbacksSelect = vi.fn().mockReturnValue({ eq: feedbacksEq });
+
+  const createSignedUrlsMocks = new Map<string, ReturnType<typeof vi.fn>>();
+  const storageFrom = vi.fn((bucket: string) => {
+    const createSignedUrls =
+      createSignedUrlsMocks.get(bucket) ??
+      vi.fn().mockImplementation((paths: string[]) =>
+        Promise.resolve(
+          signedUrlError
+            ? { data: null, error: signedUrlError }
+            : {
+                data: paths.map((path) => ({
+                  path,
+                  signedUrl: `https://signed.example.com/${bucket}/${path}`,
+                })),
+                error: null,
+              },
+        ),
+      );
+    createSignedUrlsMocks.set(bucket, createSignedUrls);
+    return { createSignedUrls };
+  });
+
+  const from = vi.fn((table: string) => {
+    if (table === "feedbacks") return { select: feedbacksSelect };
+    throw new Error(`unexpected table: ${table}`);
+  });
+
+  return {
+    supabase: { from, storage: { from: storageFrom } },
+    storageFrom,
+  };
+}
+
+describe("getMyFeedbacks", () => {
+  beforeEach(() => {
+    createClientMock.mockReset();
+    // 2026-05-03 12:00 KST
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-03T03:00:00.000Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("조회 실패 시 빈 결과를 반환한다", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const { supabase } = makeFeedbackQuerySupabase({
+      selectError: { message: "boom" },
+    });
+    createClientMock.mockResolvedValue(supabase);
+
+    const result = await getMyFeedbacks("user-123");
+    expect(result).toEqual({ feedbacks: [], hasSubmittedToday: false });
+  });
+
+  it("피드백과 답변 이미지에 서명 URL을 매핑한다", async () => {
+    const { supabase } = makeFeedbackQuerySupabase({
+      rows: [
+        makeFeedbackRow({
+          image_urls: ["user-123/feedback-1/a.png"],
+          note: { id: "note-1", title: "노트 제목" },
+          reply: {
+            title: "답변",
+            content: "확인했습니다",
+            image_paths: ["feedback-1/r.png"],
+            created_at: "2026-05-02T00:00:00.000Z",
+          },
+        }),
+      ],
+    });
+    createClientMock.mockResolvedValue(supabase);
+
+    const result = await getMyFeedbacks("user-123");
+
+    expect(result.feedbacks).toHaveLength(1);
+    const feedback = result.feedbacks[0];
+    expect(feedback?.note).toEqual({ id: "note-1", title: "노트 제목" });
+    expect(feedback?.images).toEqual([
+      {
+        path: "user-123/feedback-1/a.png",
+        url: "https://signed.example.com/feedbacks/user-123/feedback-1/a.png",
+      },
+    ]);
+    expect(feedback?.reply?.images).toEqual([
+      {
+        path: "feedback-1/r.png",
+        url: "https://signed.example.com/feedback_replies/feedback-1/r.png",
+      },
+    ]);
+  });
+
+  it("서명 URL 생성 실패 시 url을 null로 둔다", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const { supabase } = makeFeedbackQuerySupabase({
+      rows: [makeFeedbackRow({ image_urls: ["user-123/feedback-1/a.png"] })],
+      signedUrlError: { message: "boom" },
+    });
+    createClientMock.mockResolvedValue(supabase);
+
+    const result = await getMyFeedbacks("user-123");
+    expect(result.feedbacks[0]?.images).toEqual([
+      { path: "user-123/feedback-1/a.png", url: null },
+    ]);
+  });
+
+  it("이미지가 없으면 서명 URL을 요청하지 않는다", async () => {
+    const { supabase, storageFrom } = makeFeedbackQuerySupabase({
+      rows: [makeFeedbackRow()],
+    });
+    createClientMock.mockResolvedValue(supabase);
+
+    await getMyFeedbacks("user-123");
+    expect(storageFrom).not.toHaveBeenCalled();
+  });
+
+  it("KST 기준 오늘 제출한 피드백이 있으면 hasSubmittedToday가 true다", async () => {
+    // 2026-05-03T00:00Z = KST 2026-05-03 09:00 → 오늘
+    const { supabase } = makeFeedbackQuerySupabase({
+      rows: [makeFeedbackRow({ created_at: "2026-05-03T00:00:00.000Z" })],
+    });
+    createClientMock.mockResolvedValue(supabase);
+
+    const result = await getMyFeedbacks("user-123");
+    expect(result.hasSubmittedToday).toBe(true);
+  });
+
+  it("오늘 제출한 피드백이 없으면 hasSubmittedToday가 false다", async () => {
+    const { supabase } = makeFeedbackQuerySupabase({
+      rows: [makeFeedbackRow({ created_at: "2026-05-02T00:00:00.000Z" })],
+    });
+    createClientMock.mockResolvedValue(supabase);
+
+    const result = await getMyFeedbacks("user-123");
+    expect(result.hasSubmittedToday).toBe(false);
   });
 });

--- a/src/features/mypage/tests/schema.test.ts
+++ b/src/features/mypage/tests/schema.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "vitest";
 
-import { changePasswordSchema, profileSchema } from "../schema";
+import {
+  changePasswordSchema,
+  FEEDBACK_CONTENT_MAX_LENGTH,
+  FEEDBACK_TITLE_MAX_LENGTH,
+  feedbackSchema,
+  profileSchema,
+} from "../schema";
 
 describe("profileSchema", () => {
   it("유효한 닉네임만으로 통과시킨다", () => {
@@ -63,6 +69,80 @@ describe("changePasswordSchema", () => {
       newPassword: "newpass123",
       confirmNewPassword: "different123",
     });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("feedbackSchema", () => {
+  const validInput = {
+    category: "BUG",
+    title: "버그 신고합니다",
+    content: "복습 완료 버튼이 동작하지 않아요",
+  };
+
+  it("유효한 입력을 통과시킨다", () => {
+    const result = feedbackSchema.safeParse(validInput);
+    expect(result.success).toBe(true);
+  });
+
+  it("허용되지 않은 카테고리를 거부한다", () => {
+    const result = feedbackSchema.safeParse({
+      ...validInput,
+      category: "INVALID",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("제목과 내용의 앞뒤 공백을 제거한다", () => {
+    const result = feedbackSchema.safeParse({
+      ...validInput,
+      title: "  제목  ",
+      content: "  내용  ",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.title).toBe("제목");
+      expect(result.data.content).toBe("내용");
+    }
+  });
+
+  it("공백뿐인 제목을 거부한다", () => {
+    const result = feedbackSchema.safeParse({ ...validInput, title: "   " });
+    expect(result.success).toBe(false);
+  });
+
+  it("최대 길이 제목을 통과시키고 초과를 거부한다", () => {
+    expect(
+      feedbackSchema.safeParse({
+        ...validInput,
+        title: "a".repeat(FEEDBACK_TITLE_MAX_LENGTH),
+      }).success,
+    ).toBe(true);
+    expect(
+      feedbackSchema.safeParse({
+        ...validInput,
+        title: "a".repeat(FEEDBACK_TITLE_MAX_LENGTH + 1),
+      }).success,
+    ).toBe(false);
+  });
+
+  it("최대 길이 내용을 통과시키고 초과를 거부한다", () => {
+    expect(
+      feedbackSchema.safeParse({
+        ...validInput,
+        content: "a".repeat(FEEDBACK_CONTENT_MAX_LENGTH),
+      }).success,
+    ).toBe(true);
+    expect(
+      feedbackSchema.safeParse({
+        ...validInput,
+        content: "a".repeat(FEEDBACK_CONTENT_MAX_LENGTH + 1),
+      }).success,
+    ).toBe(false);
+  });
+
+  it("공백뿐인 내용을 거부한다", () => {
+    const result = feedbackSchema.safeParse({ ...validInput, content: "   " });
     expect(result.success).toBe(false);
   });
 });

--- a/src/middleware.test.ts
+++ b/src/middleware.test.ts
@@ -72,6 +72,37 @@ describe("CSP — buildCspEnforced", () => {
     );
   });
 
+  it("TC-CSP-M-02-01. 개발 환경에서는 script-src에 'unsafe-eval'을 포함한다", () => {
+    vi.stubEnv("NODE_ENV", "development");
+
+    const csp = buildCspEnforced(NONCE);
+    const scriptSrc = csp
+      .split("; ")
+      .find((directive) => directive.startsWith("script-src "));
+
+    expect(scriptSrc).toBe(
+      `script-src 'self' 'nonce-${NONCE}' 'strict-dynamic' 'unsafe-eval'`,
+    );
+
+    vi.unstubAllEnvs();
+  });
+
+  it("TC-CSP-M-02-02. 운영 환경에서는 script-src에 'unsafe-eval'을 포함하지 않는다", () => {
+    vi.stubEnv("NODE_ENV", "production");
+
+    const csp = buildCspEnforced(NONCE);
+    const scriptSrc = csp
+      .split("; ")
+      .find((directive) => directive.startsWith("script-src "));
+
+    expect(scriptSrc).toBe(
+      `script-src 'self' 'nonce-${NONCE}' 'strict-dynamic'`,
+    );
+    expect(scriptSrc).not.toContain("'unsafe-eval'");
+
+    vi.unstubAllEnvs();
+  });
+
   it("TC-CSP-M-03. style-src에 'unsafe-inline'이 허용된다 (React 19 hoisting/CSS-in-JS 호환)", () => {
     const csp = buildCspEnforced(NONCE);
     const styleSrc = csp.split("; ").find((d) => d.startsWith("style-src "));
@@ -96,6 +127,30 @@ describe("CSP — buildCspEnforced", () => {
     const csp = buildCspEnforced(NONCE);
     const directives = csp.split("; ");
     expect(directives.every((d) => d.trim().length > 0)).toBe(true);
+  });
+
+  it("TC-CSP-M-07.개발 환경에서는 로컬 Supabase origin을 img-src에 포함한다", () => {
+    vi.stubEnv("NODE_ENV", "development");
+    vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", "http://127.0.0.1:54321");
+
+    const csp = buildCspEnforced(NONCE);
+    const imgSrc = csp.split("; ").find((d) => d.startsWith("img-src "));
+
+    expect(imgSrc).toContain("http://127.0.0.1:54321");
+
+    vi.unstubAllEnvs();
+  });
+
+  it("TC-CSP-M-08.운영 환경에서는 로컬 Supabase origin을 img-src에 포함하지 않는다", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", "http://127.0.0.1:54321");
+
+    const csp = buildCspEnforced(NONCE);
+    const imgSrc = csp.split("; ").find((d) => d.startsWith("img-src "));
+
+    expect(imgSrc).not.toContain("http://127.0.0.1:54321");
+
+    vi.unstubAllEnvs();
   });
 });
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -20,6 +20,36 @@ export const CSP_REPORT_ENDPOINT_GROUP = "csp-endpoint";
 export const CSP_REPORT_PATH = "/api/csp-report";
 
 function buildCspDirectives(nonce: string): string[] {
+  const isDevelopment = process.env.NODE_ENV === "development";
+
+  /**
+   * Next.js 및 Serwist 개발 번들은 HMR과 개발용 번들 실행 과정에서
+   * eval 계열 코드를 사용할 수 있습니다.
+   *
+   * 로컬에서 ENABLE_SW=true로 Service Worker를 활성화하면
+   * @serwist/next의 sw-entry가 CSP에 의해 차단되지 않도록
+   * 개발 환경에서만 'unsafe-eval'을 script-src에 추가합니다.
+   *
+   * 운영 환경에서는 'unsafe-eval'을 허용하지 않아 기존 CSP 강도를 유지합니다.
+   */
+  const scriptSources = ["'self'", `'nonce-${nonce}'`, "'strict-dynamic'"];
+
+  if (isDevelopment) {
+    scriptSources.push("'unsafe-eval'");
+  }
+
+  /**
+   * 로컬 Supabase(Storage) 이미지는 개발 환경에서만 허용합니다.
+   *
+   * 운영 환경은 *.supabase.co만 허용하여 CSP 정책을 유지하고,
+   * 로컬 개발 시에만 Lightbox 등 일반 <img> 요청이 차단되지 않도록
+   * 개발용 Supabase origin을 img-src에 추가합니다.
+   */
+  const localSupabaseOrigin =
+    isDevelopment && process.env.NEXT_PUBLIC_SUPABASE_URL
+      ? new URL(process.env.NEXT_PUBLIC_SUPABASE_URL).origin
+      : undefined;
+
   return [
     "default-src 'self'",
     "object-src 'none'",
@@ -27,17 +57,12 @@ function buildCspDirectives(nonce: string): string[] {
     "frame-ancestors 'none'",
     "frame-src 'none'",
     "form-action 'self'",
-    `script-src 'self' 'nonce-${nonce}' 'strict-dynamic'`,
-    // style-src: React 19의 <style> precedence hoisting, Next.js DevOverlay,
-    //   동적 CSS-in-JS 라이브러리(toast 등), 폰트 inject 등으로 인해
-    //   런타임에 nonce 없이 <style> 태그가 head에 다수 inject된다.
-    //   현 시점에서 nonce-only 정책은 실현 불가하므로 'unsafe-inline'으로 완화한다.
-    //   XSS 방어의 핵심인 script-src는 nonce/strict-dynamic을 유지하므로
-    //   인라인 style만으로 코드 실행은 불가.
+    `script-src ${scriptSources.join(" ")}`,
     "style-src 'self' 'unsafe-inline'",
     [
       "img-src 'self' data: blob:",
       supabaseHostname && `https://${supabaseHostname}`,
+      localSupabaseOrigin,
     ]
       .filter(Boolean)
       .join(" "),

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -34,6 +34,94 @@ export type Database = {
   };
   public: {
     Tables: {
+      feedback_replies: {
+        Row: {
+          content: string;
+          created_at: string;
+          created_by: string;
+          feedback_id: string;
+          id: string;
+          image_paths: string[];
+          title: string;
+          updated_at: string;
+        };
+        Insert: {
+          content: string;
+          created_at?: string;
+          created_by: string;
+          feedback_id: string;
+          id?: string;
+          image_paths?: string[];
+          title: string;
+          updated_at?: string;
+        };
+        Update: {
+          content?: string;
+          created_at?: string;
+          created_by?: string;
+          feedback_id?: string;
+          id?: string;
+          image_paths?: string[];
+          title?: string;
+          updated_at?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "feedback_replies_feedback_id_fkey";
+            columns: ["feedback_id"];
+            isOneToOne: true;
+            referencedRelation: "feedbacks";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
+      feedbacks: {
+        Row: {
+          category: string;
+          content: string;
+          created_at: string;
+          id: string;
+          image_urls: string[];
+          note_id: string | null;
+          status: string;
+          title: string;
+          updated_at: string;
+          user_id: string;
+        };
+        Insert: {
+          category: string;
+          content: string;
+          created_at?: string;
+          id?: string;
+          image_urls?: string[];
+          note_id?: string | null;
+          status?: string;
+          title: string;
+          updated_at?: string;
+          user_id: string;
+        };
+        Update: {
+          category?: string;
+          content?: string;
+          created_at?: string;
+          id?: string;
+          image_urls?: string[];
+          note_id?: string | null;
+          status?: string;
+          title?: string;
+          updated_at?: string;
+          user_id?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "feedbacks_note_id_fkey";
+            columns: ["note_id"];
+            isOneToOne: false;
+            referencedRelation: "notes";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
       notes: {
         Row: {
           content: string;

--- a/src/types/db.helpers.ts
+++ b/src/types/db.helpers.ts
@@ -39,6 +39,8 @@ export type IdOf<T extends TableNameWithId> = Row<T>["id"];
 export type WithId<T extends TableNameWithId> = Pick<Row<T>, "id">;
 
 export const TABLES = {
+  feedbackReplies: "feedback_replies",
+  feedbacks: "feedbacks",
   notes: "notes",
   notifications: "notifications",
   profiles: "profiles",

--- a/src/types/feedbacks.types.ts
+++ b/src/types/feedbacks.types.ts
@@ -1,0 +1,8 @@
+import type { InsertDto, Row } from "@/types/db.helpers";
+
+export type Feedback = Row<"feedbacks">;
+export type FeedbackInsert = InsertDto<"feedbacks">;
+
+export type FeedbackReply = Row<"feedback_replies">;
+
+export type FeedbackId = Feedback["id"];

--- a/supabase/migrations/20260727000000_add_feedback_delete_policy_and_daily_limit.sql
+++ b/supabase/migrations/20260727000000_add_feedback_delete_policy_and_daily_limit.sql
@@ -11,6 +11,9 @@
 --   Server Action에서 사전 체크로 안내 메시지를 주고,
 --   동시 요청 경합은 unique index가 최종적으로 막는다.
 --   당일 피드백을 삭제한 경우에는 같은 날 다시 제출할 수 있다.
+--   하루 1건 제한이 없던 기간에 쌓인 중복 데이터가 있으면 아래 unique index
+--   생성이 unique_violation으로 실패한다. 원인을 바로 알 수 있도록 인덱스
+--   생성 전에 중복 여부를 미리 검사해 명확한 에러 메시지로 막는다.
 
 CREATE POLICY "feedbacks_delete_own_before_reply"
     ON "public"."feedbacks"
@@ -25,6 +28,26 @@ CREATE POLICY "feedbacks_delete_own_before_reply"
         )
     );
 
+
+DO $$
+DECLARE
+    duplicate_count integer;
+BEGIN
+    SELECT count(*) INTO duplicate_count
+    FROM (
+        SELECT "user_id", "public"."kst_date"("created_at")
+        FROM "public"."feedbacks"
+        GROUP BY "user_id", "public"."kst_date"("created_at")
+        HAVING count(*) > 1
+    ) AS "duplicates";
+
+    IF duplicate_count > 0 THEN
+        RAISE EXCEPTION
+            '% 명의 사용자가 하루 1건 제한 도입 전 같은 KST 날짜에 여러 건의 피드백을 남겨 unique index를 생성할 수 없습니다. '
+            '중복 행을 정리(삭제 또는 병합)한 뒤 마이그레이션을 다시 실행하세요.',
+            duplicate_count;
+    END IF;
+END $$;
 
 CREATE UNIQUE INDEX "feedbacks_one_per_user_per_kst_day_idx"
     ON "public"."feedbacks"

--- a/supabase/migrations/20260727000000_add_feedback_delete_policy_and_daily_limit.sql
+++ b/supabase/migrations/20260727000000_add_feedback_delete_policy_and_daily_limit.sql
@@ -1,0 +1,39 @@
+-- 사용자 피드백 삭제 정책, 하루 1개 제출 제한, updated_at 트리거 (#266)
+--
+-- 삭제 정책:
+--   관리자 답변(feedback_replies)이 달리기 전까지만 본인 피드백을 삭제할 수 있다.
+--   답변이 달린 피드백은 운영 기록 보존을 위해 사용자가 삭제할 수 없다.
+--   (스토리지 이미지는 Server Action에서 함께 정리한다.
+--    feedbacks 버킷에는 본인 폴더 DELETE 정책이 이미 존재한다.)
+--
+-- 하루 1개 제한:
+--   KST 날짜 기준 사용자당 하루 1건만 제출할 수 있다.
+--   Server Action에서 사전 체크로 안내 메시지를 주고,
+--   동시 요청 경합은 unique index가 최종적으로 막는다.
+--   당일 피드백을 삭제한 경우에는 같은 날 다시 제출할 수 있다.
+
+CREATE POLICY "feedbacks_delete_own_before_reply"
+    ON "public"."feedbacks"
+    FOR DELETE
+    TO "authenticated"
+    USING (
+        "auth"."uid"() = "user_id"
+        AND NOT EXISTS (
+            SELECT 1
+            FROM "public"."feedback_replies"
+            WHERE "feedback_replies"."feedback_id" = "feedbacks"."id"
+        )
+    );
+
+
+CREATE UNIQUE INDEX "feedbacks_one_per_user_per_kst_day_idx"
+    ON "public"."feedbacks"
+    USING "btree" ("user_id", "public"."kst_date"("created_at"));
+
+
+-- feedbacks에는 updated_at 자동 갱신 트리거가 누락되어 있었다.
+-- 관리자가 상태를 변경(OPEN → RESOLVED)할 때 updated_at이 갱신되도록 추가한다.
+CREATE OR REPLACE TRIGGER "tr_feedbacks_updated_at"
+    BEFORE UPDATE ON "public"."feedbacks"
+    FOR EACH ROW
+    EXECUTE FUNCTION "public"."update_updated_at_column"();


### PR DESCRIPTION
## 개요

마이페이지 사용자 피드백 탭 기능(#266)을 재적용합니다. 이 기능은 development 브랜치 규칙(`feat/이슈번호-작업명 → PR → development`)을 지키지 않고 직행 push되어 `#268`에서 되돌려졌습니다. 기능 자체는 문제가 없어, 이번 PR로 정식 프로세스를 거쳐 다시 반영합니다.

## PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] UI 디자인 변경
- [ ] 코드 리팩토링
- [ ] 테스트 추가/수정
- [ ] 문서 수정
- [ ] 빌드/패키지 설정 변경

## 관련 이슈

closes #266

## 작업 내용

- 마이페이지 사용자 피드백 탭 구현 (`FeedbackForm`, `FeedbackList`, `FeedbackSection`, `DeleteFeedbackDialog`)
- 마이페이지 고객센터 탭 개편: FAQ 서브탭(`FaqSection`) 및 문의 서브탭(`SupportSection`) 추가
- 피드백 삭제 시 Storage 정리 실패로 인한 이미지 유실 방지 로직 추가
- 피드백 첨부 이미지 signed URL 허용 및 CSP 완화 (`next.config.ts`)
  - `remotePatterns`에 `/storage/v1/object/sign/**` 패턴 추가 (private bucket signed URL 대응)
  - Server Action `bodySizeLimit`을 5mb → 30mb로 상향 (관리자 답변 이미지 여러 개 첨부 대응)
- `supabase/migrations/20260727000000_add_feedback_delete_policy_and_daily_limit.sql`: 답변 전 삭제 허용 RLS 정책 + 하루 1개 제한 unique index 추가
- `src/types/database.types.ts`, `src/types/feedbacks.types.ts`, `src/types/db.helpers.ts`: 피드백 관련 타입 추가
- `middleware.ts`: 피드백 관련 라우트 처리 반영
- `.github/ISSUE_TEMPLATE/feature_request.md`: 제목 placeholder를 도메인 라벨 기준으로 일반화

## 테스트 방법

```bash
npm run lint
npm run type-check
npx vitest run
npm run build
```

- `npx vitest run src/features/mypage`로 피드백 관련 단위 테스트만 별도 확인 가능
- 로컬에서 마이페이지 → 피드백 탭 진입 → 작성/목록/삭제 플로우 수동 확인 필요

## 스크린샷 (FE 변경 시)

<!-- TODO: 스크린샷 첨부 -->

## 리뷰 요구사항 (선택)

- `#268`에서 되돌려졌던 변경을 `git revert`로 재적용한 커밋 1개로 구성되어 있습니다. 원본 커밋 8개(#266) 각각의 의도는 이슈 #266 본문 참고 부탁드립니다.
- `next.config.ts`의 `bodySizeLimit` 30mb 상향이 과한지 검토 부탁드립니다.

## 체크리스트

- [x] 코드 컨벤션 준수
- [x] 커밋 메시지 컨벤션 준수
- [x] lint 통과
- [x] typecheck 통과
- [x] (DB 변경 시) migration 포함 및 로컬 재현 확인
- [ ] (권한/RLS 영향 시) 정책 변경 요약 기재 <!-- 확인 필요: 마이그레이션의 RLS 정책 변경 상세 요약 필요 여부 -->
- [ ] UI 변경 시 스크린샷/짧은 설명 첨부 <!-- 확인 필요: 스크린샷 첨부 필요 -->
- [x] 셀프 리뷰 완료
