### PR TITLE
docs: README를 프로젝트 소개로 재작성하고 개발 가이드를 CONTRIBUTING.md로 분리

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,256 @@
+# 기여 가이드 (개발 환경 세팅)
+
+딱다구리 개발에 참여하기 위한 로컬 환경 세팅과 협업 규칙을 정리한 문서입니다.
+서비스 소개는 [README.md](./README.md)를 참고하세요.
+
+## 기술 스택
+
+| 항목         | 버전                          |
+| ------------ | ----------------------------- |
+| Node.js      | 24.14.0 (LTS)                 |
+| Next.js      | ^15.5.14                      |
+| React        | 19.1.0                        |
+| TypeScript   | ^5                            |
+| Tailwind CSS | ^4                            |
+| Supabase     | @supabase/supabase-js ^2.99.1 |
+
+---
+
+## 1. Node.js 버전 설정
+
+nvm을 사용해 Node.js 버전을 맞춰야 합니다.
+
+### nvm 설치 (없는 경우)
+
+```bash
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash
+```
+
+설치 후 터미널 재시작 또는:
+
+```bash
+source ~/.zshrc  # zsh 사용 시
+source ~/.bashrc # bash 사용 시
+```
+
+### Node.js 24.14.0 설치 및 적용
+
+```bash
+nvm install 24.14.0
+nvm use 24.14.0
+nvm alias default 24.14.0
+```
+
+### 버전 확인
+
+```bash
+node -v  # v24.14.0
+npm -v
+```
+
+> 프로젝트에 `.nvmrc`는 없으므로 버전을 직접 지정해 전환합니다.
+> GitHub Actions CI는 Node 20에서 실행되므로, 로컬에서만 재현되는 문제가 있으면 Node 버전 차이를 먼저 의심하세요.
+
+---
+
+## 2. 프로젝트 클론 및 의존성 설치
+
+```bash
+git clone https://github.com/T-in-meet/Woodpecker.git
+cd woodpecker
+npm install
+```
+
+> `npm install` 시 `prepare` 스크립트가 자동 실행되어 **husky(Git Hook)가 활성화**됩니다.
+
+---
+
+## 3. 환경 변수 설정
+
+프로젝트 루트에 `.env.local` 파일을 생성합니다.
+
+```bash
+cp .env.example .env.local
+```
+
+팀 공유 채널에서 환경 변수 값을 받아 `.env.local`에 입력하세요.
+새 환경 변수를 추가하면 `.env.example`에도 반드시 추가합니다.
+
+`NEXT_PUBLIC_*`만 클라이언트 번들에 노출됩니다. 그 외(`SUPABASE_SERVICE_ROLE_KEY`, `VAPID_PRIVATE_KEY`, `CRON_SECRET`, `EMAIL_TICKET_SECRET`, `SUPABASE_HOOK_SECRET`, `RESEND_API_KEY`, `SMTP_*`)는 서버 전용이므로 클라이언트 코드에서 참조하지 않습니다.
+
+### 알림 발송 Cron
+
+복습 알림은 `/api/cron/dispatch-notifications` Route Handler가 발송합니다. 스케줄러는 저장소 밖의 외부 서비스 **cron-job.org**이며, 이 엔드포인트를 주기적으로 호출하는 방식입니다. `vercel.json`에는 crons 설정이 없으므로 실행 주기는 cron-job.org 대시보드에서 확인하세요.
+
+호출에는 `Authorization: Bearer <CRON_SECRET>` 헤더가 필요하고 Route Handler가 이를 검증합니다. 엔드포인트 경로나 `CRON_SECRET`을 바꾸면 cron-job.org 설정도 함께 변경해야 합니다.
+
+---
+
+## 4. 개발 서버 실행
+
+```bash
+npm run dev
+```
+
+브라우저에서 `http://localhost:3000` 접속
+
+---
+
+## 5. 주요 스크립트
+
+| 명령어                        | 설명                                                         |
+| ----------------------------- | ------------------------------------------------------------ |
+| `npm run dev`                 | 개발 서버 실행 (Turbopack, Service Worker 비활성화)          |
+| `npm run dev:sw`              | 개발 서버 실행 (Service Worker 활성화, Web Push 로컬 검증용) |
+| `npm run build`               | 프로덕션 빌드                                                |
+| `npm run start`               | 프로덕션 서버 실행                                           |
+| `npm run lint`                | ESLint 검사                                                  |
+| `npm run type-check`          | TypeScript 타입 검사                                         |
+| `npx vitest run`              | 단위/컴포넌트 테스트 1회 실행                                |
+| `npx playwright test`         | E2E 테스트 (`tests/e2e/`)                                    |
+| `npx prettier --write <경로>` | 포맷 (CI가 `--check`로 검사)                                 |
+
+> **`dev:sw` 보충 설명**
+>
+> - 일반 `npm run dev` 는 Turbopack + Serwist 호환 이슈를 피하기 위해 개발 환경에서 Service Worker(`/sw.js`) 를 비활성화한 상태로 실행됩니다 (`next.config.ts` 의 `disable` 조건 참고).
+> - Web Push 알림 흐름을 로컬에서 검증하려면 SW 가 등록되어야 하므로, `dev:sw` 스크립트가 `ENABLE_SW=true` 환경변수를 주입해 Serwist 를 활성화합니다.
+> - 환경변수 설정에 `cross-env` 를 사용하는 이유: Windows cmd/PowerShell 에서는 `ENABLE_SW=true next dev` 같은 인라인 문법이 동작하지 않습니다. 모든 셸에서 동일하게 동작시키기 위해 `cross-env` 를 거칩니다.
+
+---
+
+## 6. 테스트
+
+- 단위/컴포넌트 테스트는 Vitest(`jsdom` 환경)를 사용하며, 테스트 파일은 대상 파일 옆 `tests/` 폴더에 `*.test.ts(x)`로 둡니다.
+- E2E는 `tests/e2e/`의 Playwright 테스트입니다.
+- 변경 범위가 작아도 관련 테스트는 실행하고 PR을 올립니다.
+
+---
+
+## 7. Git Hook (husky)
+
+커밋 시 자동으로 아래가 실행됩니다.
+
+- **pre-commit**: `lint-staged` 실행 (ESLint + Prettier 자동 수정)
+- **commit-msg**: `commitlint` 실행 (커밋 메시지 규칙 검사)
+
+### 커밋 메시지 규칙
+
+```
+타입: #<issue번호> - 설명 (한글)
+```
+
+| 타입     | 용도             |
+| -------- | ---------------- |
+| feat     | 새 기능          |
+| fix      | 버그 수정        |
+| refactor | 리팩터링         |
+| style    | 코드 포맷팅      |
+| docs     | 문서 수정        |
+| test     | 테스트 추가/수정 |
+| chore    | 빌드/설정 변경   |
+
+commitlint가 `@commitlint/config-conventional`을 사용하므로 위 타입 외에 `perf`, `build`, `ci`, `revert`도 허용됩니다. **`hotfix`는 허용 타입이 아니라 commit-msg 훅에서 거부됩니다** — 긴급 수정도 `fix`를 쓰고 브랜치 이름(`hotfix/...`)으로 구분하세요.
+
+**예시:**
+
+```
+feat: #12 - 로그인 UI 구현
+fix: #34 - 토큰 만료 처리 누락 수정
+```
+
+---
+
+## 8. 브랜치 전략
+
+```
+feat/<issue>-<kebab-summary>  →  development  →  main
+fix/<issue>-<kebab-summary>   →  development  →  main
+hotfix/<kebab-summary>         →  main (+ development 반영)
+```
+
+- `main`, `development` 브랜치 직접 push 금지
+- PR 머지 방식: **Squash Merge**
+- 머지 후 브랜치 삭제
+- PR에는 변경 개요, 관련 이슈, 테스트 방법, UI 변경 시 스크린샷을 포함합니다 (`.github/PULL_REQUEST_TEMPLATE.md`)
+- DB/RLS를 변경했다면 migration 파일과 정책 영향 요약을 PR에 함께 적습니다
+
+---
+
+## 9. CI/CD
+
+`development` 또는 `main`으로 PR을 열면 GitHub Actions(`.github/workflows/ci.yml`)가 자동 실행됩니다.
+
+| Job               | 명령                                    |
+| ----------------- | --------------------------------------- |
+| Lint              | `npm run lint`                          |
+| Format Check      | `npx prettier --check .`                |
+| Dependency Review | `actions/dependency-review-action`      |
+| Type Check        | `npx tsc --noEmit`                      |
+| Test              | `npx vitest run`                        |
+| Build             | `npm run build` (앞의 4개 통과 후 실행) |
+
+**CI 실패 시 머지 불가**
+
+> Format Check가 가장 자주 깨집니다. 파일을 수정했으면 커밋 전에 `npx prettier --write <수정한 파일>`을 실행하세요.
+
+---
+
+## 10. 코드 스타일
+
+- **Prettier**: 설정 파일 없이 기본값을 사용합니다.
+- **ESLint**: `eslint.config.mjs` — `next/core-web-vitals` + `next/typescript` + `simple-import-sort`
+- **import 정렬 순서**:
+  1. 외부 라이브러리 (`react`, `next`, 서드파티)
+  2. 내부 절대경로 (`@/lib`, `@/components`, `@/features`)
+  3. 상대경로 (`./`, `../`)
+  4. 스타일/에셋
+- 클릭 가능한 요소에는 `cursor-pointer`를 적용합니다.
+- 라우트 경로는 문자열을 직접 쓰지 말고 `@/lib/constants/routes`의 상수/헬퍼를 사용합니다.
+
+---
+
+## 11. TypeScript 정책 요약
+
+- `strict: true` + `noUncheckedIndexedAccess` + `exactOptionalPropertyTypes` 적용
+- `type`만 사용 (`interface` 사용 금지)
+- `any` 사용 금지
+- 외부 데이터는 `unknown`으로 받고 Zod로 검증
+- `enum` 금지 → `as const union` 패턴 사용
+
+---
+
+## 12. 코드 배치 기준
+
+| 종류                                   | 위치                                                               |
+| -------------------------------------- | ------------------------------------------------------------------ |
+| 특정 도메인 전용 컴포넌트/훅/로직      | `src/features/[domain]/`                                           |
+| 도메인의 Server Action / 조회 / 스키마 | `src/features/[domain]/`의 `actions.ts`, `queries.ts`, `schema.ts` |
+| 여러 도메인이 쓰는 컴포넌트            | `src/components/` (ui·layout·providers)                            |
+| 여러 도메인이 쓰는 훅                  | `src/hooks/`                                                       |
+| 외부 서비스 어댑터, 순수 유틸(UI 없음) | `src/lib/`                                                         |
+| 전역 DB·도메인 타입                    | `src/types/`                                                       |
+| 라우팅                                 | `src/app/` — 비즈니스 로직을 두지 않습니다                         |
+
+Server Action은 Zod `safeParse`로 입력을 검증하고 `{ data: T } | { error: string | fieldErrors }` 형태로 반환합니다. 인증이 필요한 작업은 `supabase.auth.getUser()`로 사용자를 확인한 뒤 수행합니다.
+
+DB를 변경할 때는 `supabase/migrations/`에 `YYYYMMDDHHMMSS_설명.sql` 형식으로 migration을 추가하고, RLS·제약·RPC에 영향이 있으면 `supabase/tests/`도 함께 갱신합니다. 마이그레이션은 Supabase 대시보드에서 수동 적용합니다.
+
+---
+
+## 13. VSCode 추천 익스텐션
+
+- ESLint
+- Prettier - Code formatter
+- Tailwind CSS IntelliSense
+
+`settings.json`에 아래 추가 권장:
+
+```json
+{
+  "editor.formatOnSave": true,
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": "explicit"
+  }
+}
+```

--- a/README.md
+++ b/README.md
@@ -1,206 +1,102 @@
-# 딱다구리 개발 환경 세팅 가이드
+# 딱다구리 (Woodpecker)
+
+> 기록이 기억이 되는 공간 — 인지 과학 기반 간격 반복 학습 플랫폼
+
+노트를 저장하는 순간 복습 일정이 자동으로 잡히고, 잊어버릴 즈음 알림이 오고, 백지 테스트로 실제로 기억하는지 확인합니다.
+
+🔗 **[서비스 바로가기](https://woodpecker-app.vercel.app)**
+
+<!-- TODO: 데모 GIF 또는 대표 스크린샷 추가 -->
+
+---
+
+## 왜 만들었나
+
+공부한 내용의 **67%는 24시간 안에 잊힙니다** (Ebbinghaus, 1885).
+다시 읽는 것보다 **직접 꺼내보는 인출 연습이 1주일 후 기억 유지량을 50% 이상 높입니다** (Karpicke & Blunt, 2011).
+
+문제는 "복습해야지"라는 생각만으로는 실제로 복습하지 않는다는 점입니다.
+딱다구리는 기록만 하면 복습 시점과 인출 훈련을 서비스가 대신 챙겨줍니다.
+
+## 핵심 학습 흐름
+
+| 단계               | 내용                                                                             |
+| ------------------ | -------------------------------------------------------------------------------- |
+| **1. 기록**        | 노트를 저장하면 복습 일정이 자동 생성됩니다. 캘린더나 알림 설정이 필요 없습니다. |
+| **2. 알림**        | 1일 → 3일 → 7일 간격으로 복습 시점에 웹 푸시 알림을 보냅니다.                    |
+| **3. 백지 테스트** | 빈 화면에 기억나는 내용을 직접 쓰고, 원문과 나란히 비교합니다.                   |
+
+복습을 완료하면 다음 회차(`review_round` 0 → 1 → 2 → 3)가 원자적으로 예약됩니다.
+
+## 주요 기능
+
+- **노트 작성** — TipTap 기반 에디터 (마크다운, 코드 블록 하이라이트, 표, 체크리스트, 이미지, 슬래시 명령)
+- **오늘의 복습** — 오늘 복습할 노트만 모아보기
+- **백지 테스트** — 인출 연습 후 원문과 비교, 완료 시 다음 회차 자동 예약
+- **웹 푸시 알림** — 알림 수신 시간대 설정, 구독 관리
+- **계정** — 이메일 인증 가입, OAuth 로그인, 비밀번호 재설정, 계정 삭제
+- **마이페이지** — 프로필, 학습 통계
+- **고객센터** — 1:1 문의(이미지 첨부), FAQ
+- **관리자** — 사용자·문의 관리, 기능 플래그, 실험 화면
+
+<!-- TODO: 기능별 스크린샷 -->
 
 ## 기술 스택
 
-| 항목         | 버전                          |
-| ------------ | ----------------------------- |
-| Node.js      | 24.14.0 (LTS)                 |
-| Next.js      | 15.5.12                       |
-| React        | 19.1.0                        |
-| TypeScript   | ^5                            |
-| Tailwind CSS | ^4                            |
-| Supabase     | @supabase/supabase-js ^2.99.1 |
+| 영역       | 사용 기술                                     |
+| ---------- | --------------------------------------------- |
+| 프레임워크 | Next.js 15 (App Router), React 19, TypeScript |
+| 백엔드/DB  | Supabase (Postgres, Auth, Storage, RLS, RPC)  |
+| 상태 관리  | TanStack Query (서버 상태)                    |
+| UI         | Tailwind CSS v4, shadcn/ui, lucide            |
+| 에디터     | TipTap                                        |
+| 알림       | Web Push (serwist), cron-job.org 스케줄러     |
+| 검증       | Zod                                           |
+| 이메일     | Resend / Nodemailer                           |
+| 테스트     | Vitest, Testing Library, Playwright           |
+| 배포/CI    | Vercel, GitHub Actions                        |
 
----
+## 아키텍처 개요
 
-## 1. Node.js 버전 설정
+```text
+src/
+├── app/          # 라우팅 전용 (App Router) — (auth) · (main) · (legal) · admin · api
+├── features/     # 도메인 모듈 — auth · notes · review · notifications · mypage · editor · landing · admin
+├── components/   # 공용 UI (ui · layout · providers)
+├── hooks/        # 전역 훅
+├── lib/          # Supabase 클라이언트, 상수, 검증, Web Push, 로거
+└── types/        # DB·도메인 타입
 
-nvm을 사용해 Node.js 버전을 맞춰야 합니다.
-
-### nvm 설치 (없는 경우)
-
-```bash
-curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash
+supabase/migrations/   # DB 마이그레이션
+tests/e2e/             # Playwright E2E
 ```
 
-설치 후 터미널 재시작 또는:
+- 화면 보호와 데이터 접근은 Supabase Auth 세션 + RLS를 기본으로 하고, cron·계정 삭제처럼 service role이 필요한 작업만 admin 클라이언트를 사용합니다.
+- 복습 완료 처리는 Postgres RPC(`complete_review_and_schedule_next`)로 원자적으로 수행합니다.
+- 알림 발송은 `/api/cron/dispatch-notifications`를 외부 스케줄러(cron-job.org)가 주기적으로 호출하는 구조입니다.
+
+## 빠른 시작
 
 ```bash
-source ~/.zshrc  # zsh 사용 시
-source ~/.bashrc # bash 사용 시
-```
-
-### Node.js 24.14.0 설치 및 적용
-
-```bash
-nvm install 24.14.0
-nvm use 24.14.0
-nvm alias default 24.14.0
-```
-
-### 버전 확인
-
-```bash
-node -v  # v24.14.0
-npm -v
-```
-
-> 프로젝트 루트에 `.nvmrc` 파일이 있어 `nvm use`만 입력해도 자동 전환됩니다.
-
----
-
-## 2. 프로젝트 클론 및 의존성 설치
-
-```bash
-git clone <레포지토리 URL>
+git clone https://github.com/T-in-meet/Woodpecker.git
 cd woodpecker
 npm install
-```
-
-> `npm install` 시 `prepare` 스크립트가 자동 실행되어 **husky(Git Hook)가 활성화**됩니다.
-
----
-
-## 3. 환경 변수 설정
-
-프로젝트 루트에 `.env.local` 파일을 생성합니다.
-
-```bash
-cp .env.example .env.local
-```
-
-팀 공유 채널에서 환경 변수 값을 받아 `.env.local`에 입력하세요.
-
-### Vercel Cron
-
-`vercel.json`의 `/api/cron/dispatch-notifications`는 복습 알림 지연을 줄이기 위해 5분 간격(`*/5 * * * *`)으로 실행합니다. 이 주기는 Vercel Pro/Team 이상 플랜을 전제로 하며, Hobby 플랜 배포 시에는 플랜 또는 스케줄 조정이 필요합니다.
-
----
-
-## 4. 개발 서버 실행
-
-```bash
+cp .env.example .env.local   # 환경 변수 값 입력 필요
 npm run dev
 ```
 
-브라우저에서 `http://localhost:3000` 접속
+`http://localhost:3000` 접속. Node.js 버전, 환경 변수, Git Hook 등 상세 세팅은 [CONTRIBUTING.md](./CONTRIBUTING.md)를 참고하세요.
 
----
+## 문서
 
-## 5. 주요 스크립트
+- [CONTRIBUTING.md](./CONTRIBUTING.md) — 개발 환경 세팅, 커밋·브랜치 규칙, CI, 코드 스타일
+- [src/features/review/README.md](./src/features/review/README.md) — 복습 플로우 상세
+- [supabase/migrations/](./supabase/migrations/) — DB 스키마 변경 이력
 
-| 명령어           | 설명                                                         |
-| ---------------- | ------------------------------------------------------------ |
-| `npm run dev`    | 개발 서버 실행 (Turbopack, Service Worker 비활성화)          |
-| `npm run dev:sw` | 개발 서버 실행 (Service Worker 활성화, Web Push 로컬 검증용) |
-| `npm run build`  | 프로덕션 빌드                                                |
-| `npm run start`  | 프로덕션 서버 실행                                           |
-| `npm run lint`   | ESLint 검사                                                  |
+## 팀
 
-> **`dev:sw` 보충 설명**
->
-> - 일반 `npm run dev` 는 Turbopack + Serwist 호환 이슈를 피하기 위해 개발 환경에서 Service Worker(`/sw.js`) 를 비활성화한 상태로 실행됩니다 (`next.config.ts` 의 `disable` 조건 참고).
-> - Web Push 알림 흐름을 로컬에서 검증하려면 SW 가 등록되어야 하므로, `dev:sw` 스크립트가 `ENABLE_SW=true` 환경변수를 주입해 Serwist 를 활성화합니다.
-> - 환경변수 설정에 `cross-env` 를 사용하는 이유: Windows cmd/PowerShell 에서는 `ENABLE_SW=true next dev` 같은 인라인 문법이 동작하지 않습니다. 모든 셸에서 동일하게 동작시키기 위해 `cross-env` 를 거칩니다.
+<!-- TODO: 팀원 및 역할 -->
 
----
+## 라이선스
 
-## 6. Git Hook (husky)
-
-커밋 시 자동으로 아래가 실행됩니다.
-
-- **pre-commit**: `lint-staged` 실행 (ESLint + Prettier 자동 수정)
-- **commit-msg**: `commitlint` 실행 (커밋 메시지 규칙 검사)
-
-### 커밋 메시지 규칙
-
-```
-타입: #<issue번호> - 설명 (한글)
-```
-
-| 타입     | 용도             |
-| -------- | ---------------- |
-| feat     | 새 기능          |
-| fix      | 버그 수정        |
-| refactor | 리팩터링         |
-| style    | 코드 포맷팅      |
-| docs     | 문서 수정        |
-| test     | 테스트 추가/수정 |
-| chore    | 빌드/설정 변경   |
-| hotfix   | 긴급 수정        |
-
-**예시:**
-
-```
-feat: #12 - 로그인 UI 구현
-fix: #34 - 토큰 만료 처리 누락 수정
-```
-
----
-
-## 7. 브랜치 전략
-
-```
-feat/#<issue>-<kebab-summary>  →  develop  →  main
-fix/#<issue>-<kebab-summary>   →  develop  →  main
-hotfix/<kebab-summary>         →  main (+ develop 반영)
-```
-
-- `main`, `develop` 브랜치 직접 push 금지
-- PR 머지 방식: **Squash Merge**
-- 머지 후 브랜치 삭제
-
----
-
-## 8. CI/CD
-
-PR 생성 시 GitHub Actions가 자동 실행됩니다.
-
-- lint 검사
-- TypeScript 타입 체크
-- 빌드 검사
-
-**CI 실패 시 머지 불가**
-
----
-
-## 9. 코드 스타일
-
-- **Prettier**: 기본값 사용 (`.prettierrc` 참고)
-- **ESLint**: `eslint-config-next` + `@typescript-eslint/recommended` + `simple-import-sort`
-- **import 정렬 순서**:
-  1. 외부 라이브러리 (`react`, `next`, 서드파티)
-  2. 내부 절대경로 (`@/lib`, `@/components`, `@/features`)
-  3. 상대경로 (`./`, `../`)
-  4. 스타일/에셋
-
----
-
-## 10. TypeScript 정책 요약
-
-- `strict: true` + `noUncheckedIndexedAccess` + `exactOptionalPropertyTypes` 적용
-- `type`만 사용 (`interface` 사용 금지)
-- `any` 사용 금지
-- 외부 데이터는 `unknown`으로 받고 Zod로 검증
-- `enum` 금지 → `as const union` 패턴 사용
-
----
-
-## 11. VSCode 추천 익스텐션
-
-- ESLint
-- Prettier - Code formatter
-- Tailwind CSS IntelliSense
-- TypeScript Vue Plugin (Volar)
-
-`settings.json`에 아래 추가 권장:
-
-```json
-{
-  "editor.formatOnSave": true,
-  "editor.defaultFormatter": "esbenp.prettier-vscode",
-  "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": "explicit"
-  }
-}
-```
+<!-- TODO: 라이선스 결정 후 명시 -->


### PR DESCRIPTION
## 개요

README가 "개발 환경 세팅 가이드" 역할만 하고 있어, 저장소를 처음 여는 사람이 딱다구리가 어떤 서비스인지 알 수 없었습니다.
README를 프로젝트 소개 문서로 재작성하고, 기존 세팅·협업 규칙은 `CONTRIBUTING.md`로 분리했습니다.

작업 중 기존 README에서 현재 코드와 맞지 않는 서술 9건을 발견해 함께 정정했습니다. 특히 브랜치명(`develop`), CI 게이트 목록, 커밋 타입(`hotfix`), cron 스케줄러 설명은 그대로 따라 하면 실제로 막히는 항목이었습니다.

## PR 유형

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] UI 디자인 변경
- [ ] 코드 리팩토링
- [ ] 테스트 추가/수정
- [x] 문서 수정
- [ ] 빌드/패키지 설정 변경

## 관련 이슈

없음 — 문서 정리 작업이라 별도 이슈 없이 진행했습니다.

## 작업 내용

### README.md — 프로젝트 소개로 재작성 (248줄 변경)

- 서비스 한 줄 소개 + 배포 링크
- "왜 만들었나" — 망각곡선(Ebbinghaus, 1885)과 인출 연습 효과(Karpicke & Blunt, 2011)
- 핵심 학습 흐름 3단계(기록 → 알림 → 백지 테스트)와 주요 기능 목록
- 기술 스택 표, 아키텍처 개요(디렉터리 구조 + RLS·RPC·cron 동작 요약)
- 빠른 시작, 문서 링크
- 문구는 `src/features/landing/content.ts`의 랜딩 카피와 `src/app/llms.txt/route.ts`의 서비스 설명에서 가져왔습니다.
- 데모 GIF, 기능별 스크린샷, 팀원, 라이선스는 `<!-- TODO -->`로 비워 뒀습니다.

### CONTRIBUTING.md — 신규 (256줄)

기존 README 1~11번 항목을 옮기면서 아래를 정정·보강했습니다.

**정정한 사실 오류**

| 항목     | 기존                                    | 수정                                                                                                                        |
| -------- | --------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
| cron     | "`vercel.json`의 5분 간격, Vercel Pro 전제" | `vercel.json`에 crons 설정 없음. 외부 스케줄러 cron-job.org가 `/api/cron/dispatch-notifications`를 호출하며 `Authorization: Bearer <CRON_SECRET>` 검증 |
| 브랜치   | `develop`, `feat/#<issue>-...`          | `development`, `feat/<issue>-...` (실제 브랜치에 `#` 없음)                                                                    |
| CI       | lint·타입·빌드 3개                      | 실제 6개 Job (Format Check, Test, Dependency Review가 누락돼 있었음)                                                          |
| 커밋 타입 | `hotfix` 포함                           | commitlint(config-conventional)가 거부하므로 제거, `perf`·`build`·`ci`·`revert` 추가                                          |
| Node     | "`.nvmrc`가 있어 `nvm use`만 하면 됨"   | `.nvmrc` 없음. CI는 Node 20으로 실행된다는 점 명시                                                                            |
| Prettier | "`.prettierrc` 참고"                    | 설정 파일 없이 기본값 사용                                                                                                   |
| ESLint   | `@typescript-eslint/recommended`        | 실제 구성(`next/core-web-vitals` + `next/typescript` + `simple-import-sort`)                                                  |
| Next.js  | 15.5.12                                 | ^15.5.14                                                                                                                     |
| VSCode   | "TypeScript Vue Plugin (Volar)" 추천    | 무관한 항목이라 삭제                                                                                                         |

**새로 추가한 내용**

- 테스트 섹션(Vitest·Playwright 위치와 실행 규칙) — 기존 README에 테스트 항목이 없었습니다
- 코드 배치 기준 표, Server Action 반환 계약, 마이그레이션 절차
- 환경 변수의 클라이언트 노출 규칙(`NEXT_PUBLIC_*`)과 서버 전용 변수 목록
- 주요 스크립트 표에 `type-check`, `vitest run`, `playwright test`, `prettier --write` 추가

## 테스트 방법

문서 변경이라 런타임 영향은 없으나, CI 게이트와 동일한 검증을 로컬에서 모두 실행했습니다.

```bash
npm run lint          # 통과
npm run type-check    # 통과
npx vitest run        # 168개 파일 / 1550개 테스트 통과
npm run build         # 성공
npx prettier --check README.md CONTRIBUTING.md   # 통과
```

문서 내용은 다음을 대조해 검증했습니다.

- `.github/workflows/ci.yml` — CI Job 6개
- `.commitlintrc.json`, `.husky/commit-msg` — 허용 커밋 타입
- `vercel.json`, `src/app/api/cron/dispatch-notifications/route.ts` — cron 동작 방식
- `eslint.config.mjs`, `package.json` — 린트 구성과 스크립트
- `git branch -a` — 실제 브랜치 명명 규칙

## 스크린샷 (FE 변경 시)

해당 없음 (UI 변경 없음)

## 리뷰 요구사항 (선택)

1. **README의 서비스 소개 문구**가 팀이 생각하는 제품 방향과 맞는지 봐주세요. 랜딩 페이지 카피를 기준으로 작성했습니다.
2. **`.nvmrc`를 추가할지** 결정이 필요합니다. 현재 문서에는 "없다"고 적었는데, CI가 Node 20이라 `.nvmrc`를 20으로 두면 로컬과 CI가 일치합니다.
3. **라이선스와 팀 소개**는 TODO로 비워 뒀습니다. 저장소 공개 계획이 있다면 채워야 합니다.
4. 로컬(Windows)에서 `npx prettier --check .`를 돌리면 CRLF 때문에 565개 파일이 실패로 잡힙니다. 이번 변경과 무관하고 CI(Linux)에서는 통과하지만, `.gitattributes`로 줄바꿈을 고정해 두면 로컬 혼선을 줄일 수 있습니다.

## 체크리스트

- [x] 코드 컨벤션 준수
- [ ] 커밋 메시지 컨벤션 준수 <!-- 이슈 없이 진행해 `#이슈번호`를 생략했습니다 -->
- [x] lint 통과
- [x] typecheck 통과
- [ ] (DB 변경 시) migration 포함 및 로컬 재현 확인 <!-- 해당 없음 -->
- [ ] (권한/RLS 영향 시) 정책 변경 요약 기재 <!-- 해당 없음 -->
- [ ] UI 변경 시 스크린샷/짧은 설명 첨부 <!-- 해당 없음 -->
- [ ] 셀프 리뷰 완료
