### PR TITLE
Feat/263 feedback notifications

### DIFF
--- a/src/app/api/notifications/read/route.test.ts
+++ b/src/app/api/notifications/read/route.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { createClientMock } = vi.hoisted(() => ({
+  createClientMock: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: createClientMock,
+}));
+
+import * as notificationsReadRoute from "./route";
+
+const USER_ID = "11111111-1111-4111-8111-111111111111";
+const NOTIFICATION_ID = "22222222-2222-4222-8222-222222222222";
+
+/**
+ * Creates the Supabase surface used by the notification read route.
+ */
+function createSupabaseMock({
+  rpcData = true,
+  rpcError = null,
+  user = { id: USER_ID },
+}: {
+  rpcData?: boolean | null;
+  rpcError?: { message: string } | null;
+  user?: { id: string } | null;
+} = {}) {
+  return {
+    auth: {
+      getUser: vi.fn().mockResolvedValue({
+        data: { user },
+      }),
+    },
+    rpc: vi.fn().mockResolvedValue({
+      data: rpcError ? null : rpcData,
+      error: rpcError,
+    }),
+  };
+}
+
+/**
+ * Creates a JSON request for the notification read route.
+ */
+function createReadRequest(body: unknown) {
+  return new Request("http://localhost/api/notifications/read", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
+describe("/api/notifications/read", () => {
+  beforeEach(() => {
+    createClientMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("marks a non-review notification as read for the current user", async () => {
+    const supabase = createSupabaseMock();
+    createClientMock.mockResolvedValue(supabase);
+
+    const response = await notificationsReadRoute.POST(
+      createReadRequest({
+        notificationId: NOTIFICATION_ID,
+        type: "FEEDBACK_REPLY",
+      }),
+    );
+
+    await expect(response.json()).resolves.toEqual({ updated: true });
+    expect(response.status).toBe(200);
+    expect(supabase.rpc).toHaveBeenCalledWith("mark_notification_as_read", {
+      p_notification_id: NOTIFICATION_ID,
+    });
+  });
+
+  it("skips review notifications before opening a Supabase client", async () => {
+    const response = await notificationsReadRoute.POST(
+      createReadRequest({
+        notificationId: NOTIFICATION_ID,
+        type: "REVIEW",
+      }),
+    );
+
+    await expect(response.json()).resolves.toEqual({ updated: false });
+    expect(response.status).toBe(200);
+    expect(createClientMock).not.toHaveBeenCalled();
+  });
+
+  it("returns bad request for invalid input", async () => {
+    const response = await notificationsReadRoute.POST(
+      createReadRequest({
+        notificationId: "not-a-uuid",
+        type: "FEEDBACK_REPLY",
+      }),
+    );
+
+    await expect(response.json()).resolves.toEqual({
+      error: "invalid_request",
+    });
+    expect(response.status).toBe(400);
+    expect(createClientMock).not.toHaveBeenCalled();
+  });
+
+  it("returns unauthorized without a logged-in user", async () => {
+    const supabase = createSupabaseMock({ user: null });
+    createClientMock.mockResolvedValue(supabase);
+
+    const response = await notificationsReadRoute.POST(
+      createReadRequest({
+        notificationId: NOTIFICATION_ID,
+        type: "FEEDBACK_REPLY",
+      }),
+    );
+
+    await expect(response.json()).resolves.toEqual({ error: "unauthorized" });
+    expect(response.status).toBe(401);
+    expect(supabase.rpc).not.toHaveBeenCalled();
+  });
+
+  it("returns an error when the read RPC fails", async () => {
+    const error = { message: "rpc failed" };
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const supabase = createSupabaseMock({ rpcError: error });
+    createClientMock.mockResolvedValue(supabase);
+
+    const response = await notificationsReadRoute.POST(
+      createReadRequest({
+        notificationId: NOTIFICATION_ID,
+        type: "FEEDBACK_REPLY",
+      }),
+    );
+
+    await expect(response.json()).resolves.toEqual({
+      error: "notification_read_failed",
+    });
+    expect(response.status).toBe(500);
+    expect(errorSpy).toHaveBeenCalledWith({
+      event: "notifications.read.failed",
+      error,
+    });
+  });
+});

--- a/src/app/api/notifications/read/route.ts
+++ b/src/app/api/notifications/read/route.ts
@@ -1,0 +1,68 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+
+import { NOTIFICATION_TYPES } from "@/lib/constants/notifications";
+import { logError } from "@/lib/logger";
+import { createClient } from "@/lib/supabase/server";
+
+export const dynamic = "force-dynamic";
+
+const markNotificationReadRequestSchema = z
+  .object({
+    notificationId: z.string().uuid(),
+    type: z.string(),
+  })
+  .strict();
+
+/**
+ * Marks a non-review user notification as read for the current session user.
+ *
+ * REVIEW notifications are intentionally skipped because review completion is
+ * the only event that consumes them.
+ */
+export async function POST(request: Request) {
+  let payload: unknown;
+
+  try {
+    payload = await request.json();
+  } catch {
+    return NextResponse.json({ error: "invalid_request" }, { status: 400 });
+  }
+
+  const parsed = markNotificationReadRequestSchema.safeParse(payload);
+
+  if (!parsed.success) {
+    return NextResponse.json({ error: "invalid_request" }, { status: 400 });
+  }
+
+  if (parsed.data.type === NOTIFICATION_TYPES.REVIEW) {
+    return NextResponse.json({ updated: false });
+  }
+
+  try {
+    const supabase = await createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+    }
+
+    const { data, error } = await supabase.rpc("mark_notification_as_read", {
+      p_notification_id: parsed.data.notificationId,
+    });
+
+    if (error) {
+      throw error;
+    }
+
+    return NextResponse.json({ updated: data ?? false });
+  } catch (error) {
+    logError({ event: "notifications.read.failed", error });
+    return NextResponse.json(
+      { error: "notification_read_failed" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/notifications/route.test.ts
+++ b/src/app/api/notifications/route.test.ts
@@ -1,37 +1,19 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const {
-  createAdminClientMock,
-  createClientMock,
-  getAdminNotificationListMock,
-  getAdminUnreadNotificationCountsMock,
-  getNotificationListMock,
-  getUnreadCountMock,
-} = vi.hoisted(() => ({
-  createAdminClientMock: vi.fn(),
-  createClientMock: vi.fn(),
-  getAdminNotificationListMock: vi.fn(),
-  getAdminUnreadNotificationCountsMock: vi.fn(),
-  getNotificationListMock: vi.fn(),
-  getUnreadCountMock: vi.fn(),
-}));
+const { createClientMock, getNotificationListMock, getUnreadCountMock } =
+  vi.hoisted(() => ({
+    createClientMock: vi.fn(),
+    getNotificationListMock: vi.fn(),
+    getUnreadCountMock: vi.fn(),
+  }));
 
 vi.mock("@/lib/supabase/server", () => ({
   createClient: createClientMock,
 }));
 
-vi.mock("@/lib/supabase/admin", () => ({
-  createAdminClient: createAdminClientMock,
-}));
-
 vi.mock("@/features/notifications/queries", () => ({
   getNotificationList: getNotificationListMock,
   getUnreadCount: getUnreadCountMock,
-}));
-
-vi.mock("@/features/admin/notifications/queries.internal", () => ({
-  getAdminNotificationListFor: getAdminNotificationListMock,
-  getAdminUnreadNotificationCountsFor: getAdminUnreadNotificationCountsMock,
 }));
 
 import * as notificationsRoute from "./route";
@@ -49,38 +31,12 @@ function createSupabaseMock(user: { id: string } | null = { id: USER_ID }) {
   };
 }
 
-function createAdminSupabaseMock(role: "ADMIN" | "USER" | null = "USER") {
-  const maybeSingle = vi.fn().mockResolvedValue({
-    data: role ? { role } : null,
-    error: null,
-  });
-  const eq = vi.fn().mockReturnValue({ maybeSingle });
-  const select = vi.fn().mockReturnValue({ eq });
-
-  return {
-    eq,
-    maybeSingle,
-    select,
-    supabase: {
-      from: vi.fn().mockReturnValue({ select }),
-    },
-  };
-}
-
 describe("/api/notifications", () => {
   beforeEach(() => {
-    createAdminClientMock.mockReset();
     createClientMock.mockReset();
-    getAdminNotificationListMock.mockReset();
-    getAdminUnreadNotificationCountsMock.mockReset();
     getNotificationListMock.mockReset();
     getUnreadCountMock.mockReset();
     createClientMock.mockResolvedValue(createSupabaseMock());
-    createAdminClientMock.mockReturnValue(
-      createAdminSupabaseMock("USER").supabase,
-    );
-    getAdminNotificationListMock.mockResolvedValue([]);
-    getAdminUnreadNotificationCountsMock.mockResolvedValue({});
   });
 
   afterEach(() => {
@@ -121,59 +77,38 @@ describe("/api/notifications", () => {
       supabase,
       userId: USER_ID,
     });
-    expect(getAdminNotificationListMock).not.toHaveBeenCalled();
-    expect(getAdminUnreadNotificationCountsMock).not.toHaveBeenCalled();
   });
 
-  it("merges admin notifications for admin users", async () => {
+  it("keeps admin notifications out of the user notification response", async () => {
     const supabase = createSupabaseMock();
     createClientMock.mockResolvedValue(supabase);
-    createAdminClientMock.mockReturnValue(
-      createAdminSupabaseMock("ADMIN").supabase,
-    );
     getNotificationListMock.mockResolvedValue([
       {
         id: "22222222-2222-4222-8222-222222222222",
         sent_at: "2026-07-27T01:00:00.000Z",
-        title: "개인 알림",
+        title: "사용자 알림",
       },
     ]);
     getUnreadCountMock.mockResolvedValue(1);
-    getAdminNotificationListMock.mockResolvedValue([
-      {
-        id: "33333333-3333-4333-8333-333333333333",
-        sent_at: "2026-07-27T02:00:00.000Z",
-        source: "ADMIN",
-        title: "운영 오류 알림",
-      },
-    ]);
-    getAdminUnreadNotificationCountsMock.mockResolvedValue({
-      OPERATIONAL_ERROR: 2,
-    });
 
     const response = await notificationsRoute.GET();
 
     await expect(response.json()).resolves.toEqual({
       items: [
         {
-          id: "33333333-3333-4333-8333-333333333333",
-          sent_at: "2026-07-27T02:00:00.000Z",
-          source: "ADMIN",
-          title: "운영 오류 알림",
-        },
-        {
           id: "22222222-2222-4222-8222-222222222222",
           sent_at: "2026-07-27T01:00:00.000Z",
-          title: "개인 알림",
+          title: "사용자 알림",
         },
       ],
-      unreadCount: 3,
+      unreadCount: 1,
     });
     expect(response.status).toBe(200);
-    expect(getAdminNotificationListMock).toHaveBeenCalledWith(USER_ID, {
+    expect(getNotificationListMock).toHaveBeenCalledWith({
       limit: 20,
+      supabase,
+      userId: USER_ID,
     });
-    expect(getAdminUnreadNotificationCountsMock).toHaveBeenCalledWith(USER_ID);
   });
 
   it("returns unauthorized when there is no logged-in user", async () => {

--- a/src/app/api/notifications/route.ts
+++ b/src/app/api/notifications/route.ts
@@ -1,55 +1,19 @@
 import { NextResponse } from "next/server";
 
 import {
-  getAdminNotificationListFor,
-  getAdminUnreadNotificationCountsFor,
-} from "@/features/admin/notifications/queries.internal";
-import {
   getNotificationList,
   getUnreadCount,
-  type NotificationListItemType,
 } from "@/features/notifications/queries";
 import { logError } from "@/lib/logger";
-import { createAdminClient } from "@/lib/supabase/admin";
 import { createClient } from "@/lib/supabase/server";
 
 export const dynamic = "force-dynamic";
 
 const NOTIFICATION_LIST_LIMIT = 20;
 
-async function getIsAdmin(userId: string) {
-  const adminClient = createAdminClient();
-  const { data, error } = await adminClient
-    .from("profiles")
-    .select("role")
-    .eq("id", userId)
-    .maybeSingle();
-
-  if (error) {
-    throw error;
-  }
-
-  return data?.role === "ADMIN";
-}
-
-function sumAdminUnreadCounts(
-  counts: Awaited<ReturnType<typeof getAdminUnreadNotificationCountsFor>>,
-) {
-  return Object.values(counts).reduce((sum, count) => sum + (count ?? 0), 0);
-}
-
-function mergeNotificationLists(
-  items: NotificationListItemType[],
-  adminItems: NotificationListItemType[],
-) {
-  return [...items, ...adminItems]
-    .sort(
-      (left, right) =>
-        new Date(right.sent_at).getTime() - new Date(left.sent_at).getTime(),
-    )
-    .slice(0, NOTIFICATION_LIST_LIMIT);
-}
-
+/**
+ * Returns unread user notifications for the current session user.
+ */
 export async function GET() {
   try {
     const supabase = await createClient();
@@ -61,28 +25,18 @@ export async function GET() {
       return NextResponse.json({ error: "unauthorized" }, { status: 401 });
     }
 
-    const isAdmin = await getIsAdmin(user.id);
-    const [items, unreadCount, adminItems, adminUnreadCounts] =
-      await Promise.all([
-        getNotificationList({
-          limit: NOTIFICATION_LIST_LIMIT,
-          supabase,
-          userId: user.id,
-        }),
-        getUnreadCount({ supabase, userId: user.id }),
-        isAdmin
-          ? getAdminNotificationListFor(user.id, {
-              limit: NOTIFICATION_LIST_LIMIT,
-            })
-          : Promise.resolve([]),
-        isAdmin
-          ? getAdminUnreadNotificationCountsFor(user.id)
-          : Promise.resolve({}),
-      ]);
+    const [items, unreadCount] = await Promise.all([
+      getNotificationList({
+        limit: NOTIFICATION_LIST_LIMIT,
+        supabase,
+        userId: user.id,
+      }),
+      getUnreadCount({ supabase, userId: user.id }),
+    ]);
 
     return NextResponse.json({
-      items: mergeNotificationLists(items, adminItems),
-      unreadCount: unreadCount + sumAdminUnreadCounts(adminUnreadCounts),
+      items,
+      unreadCount,
     });
   } catch (error) {
     logError({ event: "notifications.get.failed", error });

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -2,6 +2,7 @@ import Image from "next/image";
 import Link from "next/link";
 
 import { Button } from "@/components/ui/button";
+import { AdminNotificationBell } from "@/features/admin/notifications/components/AdminNotificationBell";
 import { NotificationBell } from "@/features/notifications/components/NotificationBell";
 import { ROUTES } from "@/lib/constants/routes";
 import { getProfile } from "@/lib/supabase/getProfile";
@@ -39,6 +40,9 @@ export async function Header() {
           {profile && user ? (
             <>
               <NotificationBell userId={user.id} />
+              {profile.role === "ADMIN" ? (
+                <AdminNotificationBell adminUserId={user.id} />
+              ) : null}
               <UserMenu
                 nickname={profile.nickname}
                 email={user.email ?? ""}

--- a/src/features/admin/feedbacks/actions.ts
+++ b/src/features/admin/feedbacks/actions.ts
@@ -1,5 +1,11 @@
 "use server";
 
+import { createUserNotification } from "@/features/notifications/create-user-notification";
+import {
+  buildFeedbackReplyNotificationDefinition,
+  USER_NOTIFICATION_DEFINITIONS,
+} from "@/features/notifications/definitions";
+import { NOTIFICATION_TYPES } from "@/lib/constants/notifications";
 import { createAdminClient } from "@/lib/supabase/admin";
 
 import { requireAdmin } from "../utils/require-admin";
@@ -76,7 +82,7 @@ export async function saveFeedbackReply(
   const supabase = createAdminClient();
   const { data: feedback, error: feedbackError } = await supabase
     .from("feedbacks")
-    .select("id")
+    .select("id, title, user_id")
     .eq("id", feedbackId)
     .single();
 
@@ -99,6 +105,7 @@ export async function saveFeedbackReply(
     }
 
     const previousImagePaths = existingReply?.image_paths ?? [];
+    const isFirstReply = !existingReply;
 
     for (const file of imageFiles) {
       const path = createFeedbackReplyImagePath(feedbackId, file);
@@ -152,6 +159,35 @@ export async function saveFeedbackReply(
     // DB 저장은 성공한 상태이므로, 제거 실패는 사용자 저장 실패로 되돌리지 않는다.
     if (removedImagePaths.length > 0) {
       await supabase.storage.from("feedback_replies").remove(removedImagePaths);
+    }
+
+    if (isFirstReply) {
+      const notificationDefinition = buildFeedbackReplyNotificationDefinition({
+        feedbackId,
+      });
+
+      try {
+        await createUserNotification({
+          actorUserId: adminUserId,
+          body: `"${feedback.title}" 피드백에 관리자 답변이 등록되었습니다.`,
+          clickPath: notificationDefinition.clickPath,
+          metadata: {
+            feedbackId,
+          },
+          operation: "feedback_reply_notification",
+          pushEnabled:
+            USER_NOTIFICATION_DEFINITIONS[NOTIFICATION_TYPES.FEEDBACK_REPLY]
+              .pushEnabled,
+          title: "피드백 답변이 등록되었습니다.",
+          type: NOTIFICATION_TYPES.FEEDBACK_REPLY,
+          userId: feedback.user_id,
+        });
+      } catch (notificationError) {
+        console.error(
+          "[saveFeedbackReply] notification failed:",
+          notificationError,
+        );
+      }
     }
 
     return { ok: true };

--- a/src/features/admin/feedbacks/actions.ts
+++ b/src/features/admin/feedbacks/actions.ts
@@ -234,12 +234,6 @@ export async function deleteFeedbackReply(
     },
   );
 
-  console.log("[deleteFeedbackReply] RPC 결과", {
-    feedbackId,
-    data,
-    error,
-  });
-
   if (error || !data || data.length === 0) {
     return { ok: false, message: "답변 삭제에 실패했습니다." };
   }

--- a/src/features/admin/feedbacks/actions.ts
+++ b/src/features/admin/feedbacks/actions.ts
@@ -227,43 +227,30 @@ export async function deleteFeedbackReply(
   await requireAdmin();
 
   const supabase = createAdminClient();
-  const { data: reply, error: replyLoadError } = await supabase
-    .from("feedback_replies")
-    .select("id, image_paths")
-    .eq("feedback_id", feedbackId)
-    .maybeSingle();
+  const { data, error } = await supabase.rpc(
+    "delete_feedback_reply_with_notifications",
+    {
+      p_feedback_id: feedbackId,
+    },
+  );
 
-  if (replyLoadError) {
-    return { ok: false, message: "답변 정보를 불러오지 못했습니다." };
-  }
+  console.log("[deleteFeedbackReply] RPC 결과", {
+    feedbackId,
+    data,
+    error,
+  });
 
-  if (!reply) {
-    return { ok: false, message: "삭제할 답변이 없습니다." };
-  }
-
-  const { error: deleteError } = await supabase
-    .from("feedback_replies")
-    .delete()
-    .eq("id", reply.id);
-
-  if (deleteError) {
+  if (error || !data || data.length === 0) {
     return { ok: false, message: "답변 삭제에 실패했습니다." };
   }
 
-  const { error: statusError } = await supabase
-    .from("feedbacks")
-    .update({ status: "OPEN" })
-    .eq("id", feedbackId);
-
-  if (statusError) {
-    return { ok: false, message: "피드백 상태 변경에 실패했습니다." };
-  }
-
   // DB 삭제가 끝난 뒤 Storage object를 정리한다. 실패해도 row 삭제를 되돌리지는 않는다.
-  if (reply.image_paths.length > 0) {
+  const imagePaths = data[0]?.image_paths ?? [];
+
+  if (imagePaths.length > 0) {
     const { error: removeError } = await supabase.storage
       .from("feedback_replies")
-      .remove(reply.image_paths);
+      .remove(imagePaths);
 
     if (removeError) {
       console.error(

--- a/src/features/admin/feedbacks/actions.ts
+++ b/src/features/admin/feedbacks/actions.ts
@@ -48,6 +48,8 @@ export async function saveFeedbackReply(
     content: formData.get("content"),
   });
 
+  const notifyUser = formData.get("notifyUser") === "true";
+
   if (!parsed.success) {
     return {
       ok: false,
@@ -106,6 +108,7 @@ export async function saveFeedbackReply(
 
     const previousImagePaths = existingReply?.image_paths ?? [];
     const isFirstReply = !existingReply;
+    const shouldNotifyUser = isFirstReply || notifyUser;
 
     for (const file of imageFiles) {
       const path = createFeedbackReplyImagePath(feedbackId, file);
@@ -161,15 +164,23 @@ export async function saveFeedbackReply(
       await supabase.storage.from("feedback_replies").remove(removedImagePaths);
     }
 
-    if (isFirstReply) {
+    if (shouldNotifyUser) {
       const notificationDefinition = buildFeedbackReplyNotificationDefinition({
         feedbackId,
       });
 
+      const notificationTitle = isFirstReply
+        ? "피드백에 답변이 등록되었습니다."
+        : "피드백 답변이 수정되었습니다.";
+
+      const notificationBody = isFirstReply
+        ? `"${feedback.title}" 피드백에 관리자 답변이 등록되었습니다.`
+        : `"${feedback.title}" 피드백의 관리자 답변이 수정되었습니다.`;
+
       try {
         await createUserNotification({
           actorUserId: adminUserId,
-          body: `"${feedback.title}" 피드백에 관리자 답변이 등록되었습니다.`,
+          body: notificationBody,
           clickPath: notificationDefinition.clickPath,
           metadata: {
             feedbackId,
@@ -178,7 +189,7 @@ export async function saveFeedbackReply(
           pushEnabled:
             USER_NOTIFICATION_DEFINITIONS[NOTIFICATION_TYPES.FEEDBACK_REPLY]
               .pushEnabled,
-          title: "피드백 답변이 등록되었습니다.",
+          title: notificationTitle,
           type: NOTIFICATION_TYPES.FEEDBACK_REPLY,
           userId: feedback.user_id,
         });

--- a/src/features/admin/feedbacks/components/AdminFeedbackReplyPanel.tsx
+++ b/src/features/admin/feedbacks/components/AdminFeedbackReplyPanel.tsx
@@ -7,6 +7,7 @@ import { useForm } from "react-hook-form";
 
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Separator } from "@/components/ui/separator";
@@ -53,6 +54,7 @@ export function AdminFeedbackReplyPanel({
 }: AdminFeedbackReplyPanelProps) {
   const router = useRouter();
   const [isEditing, setIsEditing] = useState(!feedback.reply);
+  const [notifyUser, setNotifyUser] = useState(false);
   const [previewImages, setPreviewImages] = useState<PreviewImage[]>([]);
   const [selectedImageIndex, setSelectedImageIndex] = useState<number | null>(
     null,
@@ -95,6 +97,7 @@ export function AdminFeedbackReplyPanel({
       currentImages.forEach((image) => URL.revokeObjectURL(image.url));
       return [];
     });
+    setNotifyUser(false);
     setIsEditing(!feedback.reply);
   }, [feedback.reply, reset]);
 
@@ -165,6 +168,7 @@ export function AdminFeedbackReplyPanel({
     // 기존 이미지 path와 새 File을 분리해 보내면 Server Action이 유지/추가/삭제를 판별할 수 있다.
     formData.set("title", values.title);
     formData.set("content", values.content);
+    formData.set("notifyUser", String(notifyUser));
     existingImagePaths.forEach((path) =>
       formData.append("existingImagePaths", path),
     );
@@ -176,6 +180,7 @@ export function AdminFeedbackReplyPanel({
     });
 
     if (result.ok) {
+      setNotifyUser(false);
       setIsEditing(false);
       router.refresh();
     }
@@ -206,7 +211,10 @@ export function AdminFeedbackReplyPanel({
                   variant="outline"
                   size="sm"
                   disabled={deleteMutation.isPending}
-                  onClick={() => setIsEditing(true)}
+                  onClick={() => {
+                    setNotifyUser(false);
+                    setIsEditing(true);
+                  }}
                 >
                   <Pencil aria-hidden="true" />
                   수정
@@ -321,6 +329,31 @@ export function AdminFeedbackReplyPanel({
                 ) : null}
               </div>
 
+              {feedback.reply ? (
+                <div className="flex items-start gap-3 rounded-md border p-4">
+                  <Checkbox
+                    id="reply-notify-user"
+                    checked={notifyUser}
+                    disabled={saveMutation.isPending}
+                    onCheckedChange={(checked) =>
+                      setNotifyUser(checked === true)
+                    }
+                  />
+
+                  <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:gap-2">
+                    <Label
+                      htmlFor="reply-notify-user"
+                      className="cursor-pointer font-medium"
+                    >
+                      사용자에게 알림 전송
+                    </Label>
+                    <p className="text-xs text-muted-foreground sm:whitespace-nowrap">
+                      수정된 답변을 사용자에게 다시 알립니다.
+                    </p>
+                  </div>
+                </div>
+              ) : null}
+
               {generalError ? (
                 <p className="text-sm text-destructive">{generalError}</p>
               ) : null}
@@ -343,6 +376,7 @@ export function AdminFeedbackReplyPanel({
                         );
                         return [];
                       });
+                      setNotifyUser(false);
                       setIsEditing(false);
                     }}
                   >

--- a/src/features/admin/feedbacks/tests/actions.test.ts
+++ b/src/features/admin/feedbacks/tests/actions.test.ts
@@ -7,6 +7,8 @@ const {
   validateFeedbackReplyImageFilesMock,
   validateFeedbackReplyImageFileSignaturesMock,
   createFeedbackReplyImagePathMock,
+  createUserNotificationMock,
+  buildFeedbackReplyNotificationDefinitionMock,
 } = vi.hoisted(() => ({
   createAdminClientMock: vi.fn(),
   requireAdminMock: vi.fn(),
@@ -14,6 +16,8 @@ const {
   validateFeedbackReplyImageFilesMock: vi.fn(),
   validateFeedbackReplyImageFileSignaturesMock: vi.fn(),
   createFeedbackReplyImagePathMock: vi.fn(),
+  createUserNotificationMock: vi.fn(),
+  buildFeedbackReplyNotificationDefinitionMock: vi.fn(),
 }));
 
 vi.mock("@/lib/supabase/admin", () => ({
@@ -37,6 +41,23 @@ vi.mock("@/features/admin/feedbacks/utils/feedback-reply-image", () => ({
   createFeedbackReplyImagePath: createFeedbackReplyImagePathMock,
 }));
 
+vi.mock("@/features/notifications/create-user-notification", () => ({
+  createUserNotification: createUserNotificationMock,
+}));
+
+vi.mock("@/features/notifications/definitions", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("@/features/notifications/definitions")
+    >();
+
+  return {
+    ...actual,
+    buildFeedbackReplyNotificationDefinition:
+      buildFeedbackReplyNotificationDefinitionMock,
+  };
+});
+
 import { deleteFeedbackReply, saveFeedbackReply } from "../actions";
 
 type QueryResult<T> = {
@@ -45,7 +66,11 @@ type QueryResult<T> = {
 };
 
 type SupabaseMockOptions = {
-  feedbackResult?: QueryResult<{ id: string } | null>;
+  feedbackResult?: QueryResult<{
+    id: string;
+    title: string;
+    user_id: string;
+  } | null>;
   existingReplyResult?: QueryResult<{ image_paths: string[] } | null>;
   replyLoadResult?: QueryResult<{
     id: string;
@@ -64,7 +89,11 @@ type SupabaseMockOptions = {
  */
 function createSupabaseMock(options: SupabaseMockOptions = {}) {
   const feedbackResult = options.feedbackResult ?? {
-    data: { id: "feedback-1" },
+    data: {
+      id: "feedback-1",
+      title: "테스트 피드백",
+      user_id: "user-1",
+    },
     error: null,
   };
 
@@ -237,6 +266,13 @@ describe("saveFeedbackReply", () => {
     createFeedbackReplyImagePathMock.mockImplementation(
       (feedbackId: string, file: File) => `${feedbackId}/${file.name}`,
     );
+    buildFeedbackReplyNotificationDefinitionMock.mockReturnValue({
+      clickPath: "/feedbacks/feedback-1",
+    });
+
+    createUserNotificationMock.mockResolvedValue({
+      ok: true,
+    });
   });
 
   it("입력값 검증에 실패하면 필드 오류를 반환하고 DB에 접근하지 않는다", async () => {
@@ -348,6 +384,115 @@ describe("saveFeedbackReply", () => {
       "id",
       "feedback-1",
     );
+  });
+
+  it("최초 답변 저장 시 사용자 알림을 생성한다", async () => {
+    const supabase = createSupabaseMock({
+      existingReplyResult: {
+        data: null,
+        error: null,
+      },
+    });
+
+    createAdminClientMock.mockReturnValue(supabase.client);
+
+    const result = await saveFeedbackReply("feedback-1", createValidFormData());
+
+    expect(result).toEqual({ ok: true });
+
+    expect(buildFeedbackReplyNotificationDefinitionMock).toHaveBeenCalledWith({
+      feedbackId: "feedback-1",
+    });
+
+    expect(createUserNotificationMock).toHaveBeenCalledWith({
+      actorUserId: "admin-1",
+      body: '"테스트 피드백" 피드백에 관리자 답변이 등록되었습니다.',
+      clickPath: "/feedbacks/feedback-1",
+      metadata: {
+        feedbackId: "feedback-1",
+      },
+      operation: "feedback_reply_notification",
+      pushEnabled: expect.any(Boolean),
+      title: "피드백에 답변이 등록되었습니다.",
+      type: expect.any(String),
+      userId: "user-1",
+    });
+  });
+
+  it("기존 답변 수정 시 알림을 선택하지 않으면 사용자 알림을 생성하지 않는다", async () => {
+    const supabase = createSupabaseMock({
+      existingReplyResult: {
+        data: {
+          image_paths: [],
+        },
+        error: null,
+      },
+    });
+
+    createAdminClientMock.mockReturnValue(supabase.client);
+
+    const result = await saveFeedbackReply("feedback-1", createValidFormData());
+
+    expect(result).toEqual({ ok: true });
+    expect(buildFeedbackReplyNotificationDefinitionMock).not.toHaveBeenCalled();
+    expect(createUserNotificationMock).not.toHaveBeenCalled();
+  });
+
+  it("기존 답변 수정 시 알림을 선택하면 수정 알림을 생성한다", async () => {
+    const supabase = createSupabaseMock({
+      existingReplyResult: {
+        data: {
+          image_paths: [],
+        },
+        error: null,
+      },
+    });
+
+    createAdminClientMock.mockReturnValue(supabase.client);
+
+    const formData = createValidFormData();
+    formData.set("notifyUser", "true");
+
+    const result = await saveFeedbackReply("feedback-1", formData);
+
+    expect(result).toEqual({ ok: true });
+
+    expect(createUserNotificationMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actorUserId: "admin-1",
+        body: '"테스트 피드백" 피드백의 관리자 답변이 수정되었습니다.',
+        clickPath: "/feedbacks/feedback-1",
+        metadata: {
+          feedbackId: "feedback-1",
+        },
+        title: "피드백 답변이 수정되었습니다.",
+        userId: "user-1",
+      }),
+    );
+  });
+
+  it("사용자 알림 생성이 예외를 던져도 답변 저장 성공을 유지한다", async () => {
+    const supabase = createSupabaseMock();
+
+    createAdminClientMock.mockReturnValue(supabase.client);
+    createUserNotificationMock.mockRejectedValue(
+      new Error("notification failed"),
+    );
+
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+
+    const result = await saveFeedbackReply("feedback-1", createValidFormData());
+
+    expect(result).toEqual({ ok: true });
+    expect(createUserNotificationMock).toHaveBeenCalledOnce();
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "[saveFeedbackReply] notification failed:",
+      expect.any(Error),
+    );
+
+    consoleErrorSpy.mockRestore();
   });
 
   it("기존 이미지와 새 이미지를 함께 저장한다", async () => {

--- a/src/features/admin/feedbacks/tests/actions.test.ts
+++ b/src/features/admin/feedbacks/tests/actions.test.ts
@@ -65,6 +65,11 @@ type QueryResult<T> = {
   error: { message: string } | null;
 };
 
+type DeleteFeedbackReplyRpcRow = {
+  deleted_notification_count: number;
+  image_paths: string[];
+};
+
 type SupabaseMockOptions = {
   feedbackResult?: QueryResult<{
     id: string;
@@ -82,6 +87,7 @@ type SupabaseMockOptions = {
   deleteError?: { message: string } | null;
   openStatusError?: { message: string } | null;
   removeErrors?: Array<{ message: string } | null>;
+  rpcResult?: QueryResult<DeleteFeedbackReplyRpcRow[] | null>;
 };
 
 /**
@@ -195,6 +201,17 @@ function createSupabaseMock(options: SupabaseMockOptions = {}) {
     upload: uploadMock,
     remove: removeMock,
   }));
+  const rpcMock = vi.fn().mockResolvedValue(
+    options.rpcResult ?? {
+      data: [
+        {
+          deleted_notification_count: 1,
+          image_paths: replyLoadResult.data?.image_paths ?? [],
+        },
+      ],
+      error: null,
+    },
+  );
 
   const fromMock = vi.fn((table: string) => {
     if (table === "feedbacks") {
@@ -218,6 +235,7 @@ function createSupabaseMock(options: SupabaseMockOptions = {}) {
   return {
     client: {
       from: fromMock,
+      rpc: rpcMock,
       storage: {
         from: storageFromMock,
       },
@@ -236,6 +254,7 @@ function createSupabaseMock(options: SupabaseMockOptions = {}) {
       storageFromMock,
       uploadMock,
       removeMock,
+      rpcMock,
     },
   };
 }
@@ -701,53 +720,15 @@ describe("deleteFeedbackReply", () => {
     requireAdminMock.mockResolvedValue("admin-1");
   });
 
-  it("답변 조회에 실패하면 삭제를 중단한다", async () => {
+  it("RPC로 답변, 피드백 상태, 관련 사용자 알림을 하나의 DB 작업으로 삭제한다", async () => {
     const supabase = createSupabaseMock({
-      replyLoadResult: {
-        data: null,
-        error: {
-          message: "reply load failed",
-        },
-      },
-    });
-
-    createAdminClientMock.mockReturnValue(supabase.client);
-
-    const result = await deleteFeedbackReply("feedback-1");
-
-    expect(result).toEqual({
-      ok: false,
-      message: "답변 정보를 불러오지 못했습니다.",
-    });
-    expect(supabase.mocks.deleteMock).not.toHaveBeenCalled();
-  });
-
-  it("삭제할 답변이 없으면 안내 메시지를 반환한다", async () => {
-    const supabase = createSupabaseMock({
-      replyLoadResult: {
-        data: null,
-        error: null,
-      },
-    });
-
-    createAdminClientMock.mockReturnValue(supabase.client);
-
-    const result = await deleteFeedbackReply("feedback-1");
-
-    expect(result).toEqual({
-      ok: false,
-      message: "삭제할 답변이 없습니다.",
-    });
-    expect(supabase.mocks.deleteMock).not.toHaveBeenCalled();
-  });
-
-  it("답변을 삭제하고 피드백 상태를 OPEN으로 변경한다", async () => {
-    const supabase = createSupabaseMock({
-      replyLoadResult: {
-        data: {
-          id: "reply-1",
-          image_paths: [],
-        },
+      rpcResult: {
+        data: [
+          {
+            deleted_notification_count: 2,
+            image_paths: [],
+          },
+        ],
         error: null,
       },
     });
@@ -757,21 +738,24 @@ describe("deleteFeedbackReply", () => {
     const result = await deleteFeedbackReply("feedback-1");
 
     expect(result).toEqual({ ok: true });
-    expect(supabase.mocks.deleteMock).toHaveBeenCalledOnce();
-    expect(supabase.mocks.deleteEqMock).toHaveBeenCalledWith("id", "reply-1");
-    expect(supabase.mocks.updateMock).toHaveBeenCalledWith({
-      status: "OPEN",
-    });
-    expect(supabase.mocks.openStatusEqMock).toHaveBeenCalledWith(
-      "id",
-      "feedback-1",
+    expect(supabase.mocks.rpcMock).toHaveBeenCalledWith(
+      "delete_feedback_reply_with_notifications",
+      {
+        p_feedback_id: "feedback-1",
+      },
+    );
+    expect(supabase.mocks.fromMock).not.toHaveBeenCalledWith(
+      "feedback_replies",
     );
   });
 
-  it("답변 삭제에 실패하면 피드백 상태를 변경하지 않는다", async () => {
+  it("RPC 실패 시 삭제 실패 메시지를 반환하고 Storage를 정리하지 않는다", async () => {
     const supabase = createSupabaseMock({
-      deleteError: {
-        message: "delete failed",
+      rpcResult: {
+        data: null,
+        error: {
+          message: "feedback_reply_not_found",
+        },
       },
     });
 
@@ -783,13 +767,14 @@ describe("deleteFeedbackReply", () => {
       ok: false,
       message: "답변 삭제에 실패했습니다.",
     });
-    expect(supabase.mocks.updateMock).not.toHaveBeenCalled();
+    expect(supabase.mocks.removeMock).not.toHaveBeenCalled();
   });
 
-  it("피드백 상태 변경에 실패하면 실패 결과를 반환한다", async () => {
+  it("RPC 결과가 비어 있으면 삭제 실패 메시지를 반환한다", async () => {
     const supabase = createSupabaseMock({
-      openStatusError: {
-        message: "status update failed",
+      rpcResult: {
+        data: [],
+        error: null,
       },
     });
 
@@ -799,19 +784,21 @@ describe("deleteFeedbackReply", () => {
 
     expect(result).toEqual({
       ok: false,
-      message: "피드백 상태 변경에 실패했습니다.",
+      message: "답변 삭제에 실패했습니다.",
     });
   });
 
-  it("연결된 답변 이미지를 Storage에서 제거한다", async () => {
+  it("RPC 성공 후 연결된 답변 이미지를 Storage에서 제거한다", async () => {
     const imagePaths = ["feedback-1/a.png", "feedback-1/b.png"];
 
     const supabase = createSupabaseMock({
-      replyLoadResult: {
-        data: {
-          id: "reply-1",
-          image_paths: imagePaths,
-        },
+      rpcResult: {
+        data: [
+          {
+            deleted_notification_count: 1,
+            image_paths: imagePaths,
+          },
+        ],
         error: null,
       },
     });
@@ -826,11 +813,13 @@ describe("deleteFeedbackReply", () => {
 
   it("Storage 이미지 제거에 실패해도 DB 삭제 성공을 유지한다", async () => {
     const supabase = createSupabaseMock({
-      replyLoadResult: {
-        data: {
-          id: "reply-1",
-          image_paths: ["feedback-1/a.png"],
-        },
+      rpcResult: {
+        data: [
+          {
+            deleted_notification_count: 1,
+            image_paths: ["feedback-1/a.png"],
+          },
+        ],
         error: null,
       },
       removeErrors: [
@@ -849,11 +838,13 @@ describe("deleteFeedbackReply", () => {
 
   it("연결된 이미지가 없으면 Storage remove를 호출하지 않는다", async () => {
     const supabase = createSupabaseMock({
-      replyLoadResult: {
-        data: {
-          id: "reply-1",
-          image_paths: [],
-        },
+      rpcResult: {
+        data: [
+          {
+            deleted_notification_count: 1,
+            image_paths: [],
+          },
+        ],
         error: null,
       },
     });

--- a/src/features/admin/notifications/actions.test.ts
+++ b/src/features/admin/notifications/actions.test.ts
@@ -2,7 +2,10 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { ADMIN_NOTIFICATION_TYPES } from "@/lib/constants/notifications";
 
-import { markAdminNotificationsAsReadAction } from "./actions";
+import {
+  markAdminNotificationsAsReadAction,
+  markAllAdminNotificationsAsReadAction,
+} from "./actions";
 
 const { createAdminClientMock, requireAdminMock } = vi.hoisted(() => ({
   createAdminClientMock: vi.fn(),
@@ -26,6 +29,13 @@ function createSupabaseMock({
   eventsError?: unknown;
   readsError?: unknown;
 }) {
+  const eventsSelectResult = {
+    eq: vi.fn(),
+    then: vi.fn(
+      (resolve: (value: { data: unknown[] | null; error: unknown }) => void) =>
+        resolve({ data: events, error: eventsError }),
+    ),
+  };
   const eventsClickPathEq = vi.fn().mockResolvedValue({
     data: events,
     error: eventsError,
@@ -33,8 +43,10 @@ function createSupabaseMock({
   const eventsTypeEq = vi.fn().mockReturnValue({
     eq: eventsClickPathEq,
   });
+  eventsSelectResult.eq = eventsTypeEq;
   const eventsSelect = vi.fn().mockReturnValue({
-    eq: eventsTypeEq,
+    eq: eventsSelectResult.eq,
+    then: eventsSelectResult.then,
   });
   const readsUpsert = vi.fn().mockResolvedValue({
     error: readsError,
@@ -58,6 +70,7 @@ function createSupabaseMock({
   return {
     eventsClickPathEq,
     eventsSelect,
+    eventsSelectResult,
     eventsTypeEq,
     from,
     readsUpsert,
@@ -173,5 +186,44 @@ describe("markAdminNotificationsAsReadAction", () => {
       message: "관리자 알림 읽음 처리에 실패했습니다.",
       ok: false,
     });
+  });
+
+  it("marks all admin notification events as read without touching user notifications", async () => {
+    const supabaseMock = createSupabaseMock({
+      events: [{ id: "event-1" }, { id: "event-2" }],
+    });
+    createAdminClientMock.mockReturnValue(supabaseMock.supabase);
+
+    const result = await markAllAdminNotificationsAsReadAction();
+
+    expect(result).toEqual({ ok: true, updated: 2 });
+    expect(supabaseMock.from).toHaveBeenCalledWith("admin_notification_events");
+    expect(supabaseMock.eventsSelect).toHaveBeenCalledWith("id");
+    expect(supabaseMock.readsUpsert).toHaveBeenCalledWith(
+      [
+        {
+          admin_user_id: "admin-user-id",
+          event_id: "event-1",
+        },
+        {
+          admin_user_id: "admin-user-id",
+          event_id: "event-2",
+        },
+      ],
+      { onConflict: "event_id,admin_user_id" },
+    );
+    expect(supabaseMock.from).not.toHaveBeenCalledWith("notifications");
+  });
+
+  it("returns success without upsert when there are no admin notification events", async () => {
+    const supabaseMock = createSupabaseMock({
+      events: [],
+    });
+    createAdminClientMock.mockReturnValue(supabaseMock.supabase);
+
+    const result = await markAllAdminNotificationsAsReadAction();
+
+    expect(result).toEqual({ ok: true, updated: 0 });
+    expect(supabaseMock.readsUpsert).not.toHaveBeenCalled();
   });
 });

--- a/src/features/admin/notifications/actions.test.ts
+++ b/src/features/admin/notifications/actions.test.ts
@@ -20,14 +20,21 @@ vi.mock("../utils/require-admin", () => ({
   requireAdmin: requireAdminMock,
 }));
 
+/**
+ * 관리자 알림 읽음 처리 액션에서 사용하는 Supabase mock을 생성합니다.
+ */
 function createSupabaseMock({
   events,
   eventsError = null,
   readsError = null,
+  rpcData = 0,
+  rpcError = null,
 }: {
   events: unknown[] | null;
   eventsError?: unknown;
   readsError?: unknown;
+  rpcData?: number | null;
+  rpcError?: unknown;
 }) {
   const eventsSelectResult = {
     eq: vi.fn(),
@@ -50,6 +57,10 @@ function createSupabaseMock({
   });
   const readsUpsert = vi.fn().mockResolvedValue({
     error: readsError,
+  });
+  const rpc = vi.fn().mockResolvedValue({
+    data: rpcError ? null : rpcData,
+    error: rpcError,
   });
   const from = vi.fn((table: string) => {
     if (table === "admin_notification_events") {
@@ -74,7 +85,8 @@ function createSupabaseMock({
     eventsTypeEq,
     from,
     readsUpsert,
-    supabase: { from },
+    rpc,
+    supabase: { from, rpc },
   };
 }
 
@@ -188,36 +200,29 @@ describe("markAdminNotificationsAsReadAction", () => {
     });
   });
 
-  it("marks all admin notification events as read without touching user notifications", async () => {
+  it("marks all unread admin notification events as read through the RPC", async () => {
     const supabaseMock = createSupabaseMock({
       events: [{ id: "event-1" }, { id: "event-2" }],
+      rpcData: 2,
     });
     createAdminClientMock.mockReturnValue(supabaseMock.supabase);
 
     const result = await markAllAdminNotificationsAsReadAction();
 
     expect(result).toEqual({ ok: true, updated: 2 });
-    expect(supabaseMock.from).toHaveBeenCalledWith("admin_notification_events");
-    expect(supabaseMock.eventsSelect).toHaveBeenCalledWith("id");
-    expect(supabaseMock.readsUpsert).toHaveBeenCalledWith(
-      [
-        {
-          admin_user_id: "admin-user-id",
-          event_id: "event-1",
-        },
-        {
-          admin_user_id: "admin-user-id",
-          event_id: "event-2",
-        },
-      ],
-      { onConflict: "event_id,admin_user_id" },
+    expect(supabaseMock.rpc).toHaveBeenCalledWith(
+      "mark_all_admin_notifications_as_read",
+      {
+        p_admin_user_id: "admin-user-id",
+      },
     );
-    expect(supabaseMock.from).not.toHaveBeenCalledWith("notifications");
+    expect(supabaseMock.from).not.toHaveBeenCalled();
   });
 
-  it("returns success without upsert when there are no admin notification events", async () => {
+  it("returns success when the mark-all RPC has no unread events to insert", async () => {
     const supabaseMock = createSupabaseMock({
       events: [],
+      rpcData: 0,
     });
     createAdminClientMock.mockReturnValue(supabaseMock.supabase);
 
@@ -225,5 +230,20 @@ describe("markAdminNotificationsAsReadAction", () => {
 
     expect(result).toEqual({ ok: true, updated: 0 });
     expect(supabaseMock.readsUpsert).not.toHaveBeenCalled();
+  });
+
+  it("returns an error when the mark-all RPC fails", async () => {
+    const supabaseMock = createSupabaseMock({
+      events: [],
+      rpcError: { message: "rpc failed" },
+    });
+    createAdminClientMock.mockReturnValue(supabaseMock.supabase);
+
+    const result = await markAllAdminNotificationsAsReadAction();
+
+    expect(result).toEqual({
+      message: "관리자 알림 읽음 처리에 실패했습니다.",
+      ok: false,
+    });
   });
 });

--- a/src/features/admin/notifications/actions.ts
+++ b/src/features/admin/notifications/actions.ts
@@ -31,6 +31,42 @@ export type MarkAdminNotificationsAsReadResult =
       ok: false;
     };
 
+type AdminNotificationReadSupabaseClient = ReturnType<typeof createAdminClient>;
+
+type AdminNotificationReadRow = {
+  admin_user_id: string;
+  event_id: string;
+};
+
+/**
+ * 관리자 알림 event id 목록을 현재 관리자 기준 읽음 row로 저장합니다.
+ *
+ * @param supabase 관리자 권한 Supabase client
+ * @param adminUserId 읽음 처리할 관리자 사용자 ID
+ * @param eventIds 읽음 처리할 관리자 알림 event ID 목록
+ * @returns 읽음 row 저장 성공 여부
+ */
+async function upsertAdminNotificationReads(
+  supabase: AdminNotificationReadSupabaseClient,
+  adminUserId: string,
+  eventIds: string[],
+): Promise<{ error: unknown | null }> {
+  if (eventIds.length === 0) {
+    return { error: null };
+  }
+
+  const rows: AdminNotificationReadRow[] = eventIds.map((eventId) => ({
+    admin_user_id: adminUserId,
+    event_id: eventId,
+  }));
+
+  const { error } = await supabase
+    .from("admin_notification_reads")
+    .upsert(rows, { onConflict: "event_id,admin_user_id" });
+
+  return { error };
+}
+
 /**
  * 현재 관리자 기준으로 특정 관리자 알림 이벤트들을 읽음 처리합니다.
  *
@@ -73,15 +109,53 @@ export async function markAdminNotificationsAsReadAction(
     return { ok: true, updated: 0 };
   }
 
-  const { error: readsError } = await supabase
-    .from("admin_notification_reads")
-    .upsert(
-      events.map((event) => ({
-        admin_user_id: adminUserId,
-        event_id: event.id,
-      })),
-      { onConflict: "event_id,admin_user_id" },
-    );
+  const { error: readsError } = await upsertAdminNotificationReads(
+    supabase,
+    adminUserId,
+    events.map((event) => event.id),
+  );
+
+  if (readsError) {
+    return {
+      message: "관리자 알림 읽음 처리에 실패했습니다.",
+      ok: false,
+    };
+  }
+
+  return { ok: true, updated: events.length };
+}
+
+/**
+ * 현재 관리자에게 표시될 수 있는 모든 관리자 알림을 읽음 처리합니다.
+ *
+ * 관리자 알림은 사용자 notifications 테이블과 독립적이므로 이 액션은
+ * admin_notification_reads 테이블만 갱신합니다.
+ *
+ * @returns 읽음 처리 결과와 대상 event 수
+ */
+export async function markAllAdminNotificationsAsReadAction(): Promise<MarkAdminNotificationsAsReadResult> {
+  const adminUserId = await requireAdmin();
+  const supabase = createAdminClient();
+  const { data: events, error: eventsError } = await supabase
+    .from("admin_notification_events")
+    .select("id");
+
+  if (eventsError) {
+    return {
+      message: "관리자 알림 조회에 실패했습니다.",
+      ok: false,
+    };
+  }
+
+  if (!events || events.length === 0) {
+    return { ok: true, updated: 0 };
+  }
+
+  const { error: readsError } = await upsertAdminNotificationReads(
+    supabase,
+    adminUserId,
+    events.map((event) => event.id),
+  );
 
   if (readsError) {
     return {

--- a/src/features/admin/notifications/actions.ts
+++ b/src/features/admin/notifications/actions.ts
@@ -136,33 +136,19 @@ export async function markAdminNotificationsAsReadAction(
 export async function markAllAdminNotificationsAsReadAction(): Promise<MarkAdminNotificationsAsReadResult> {
   const adminUserId = await requireAdmin();
   const supabase = createAdminClient();
-  const { data: events, error: eventsError } = await supabase
-    .from("admin_notification_events")
-    .select("id");
-
-  if (eventsError) {
-    return {
-      message: "관리자 알림 조회에 실패했습니다.",
-      ok: false,
-    };
-  }
-
-  if (!events || events.length === 0) {
-    return { ok: true, updated: 0 };
-  }
-
-  const { error: readsError } = await upsertAdminNotificationReads(
-    supabase,
-    adminUserId,
-    events.map((event) => event.id),
+  const { data, error } = await supabase.rpc(
+    "mark_all_admin_notifications_as_read",
+    {
+      p_admin_user_id: adminUserId,
+    },
   );
 
-  if (readsError) {
+  if (error) {
     return {
       message: "관리자 알림 읽음 처리에 실패했습니다.",
       ok: false,
     };
   }
 
-  return { ok: true, updated: events.length };
+  return { ok: true, updated: data ?? 0 };
 }

--- a/src/features/admin/notifications/components/AdminNotificationBell.test.tsx
+++ b/src/features/admin/notifications/components/AdminNotificationBell.test.tsx
@@ -1,0 +1,178 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ADMIN_NOTIFICATION_TYPES } from "@/lib/constants/notifications";
+
+import { ADMIN_UNREAD_NOTIFICATION_COUNTS_QUERY_KEY } from "../query-keys";
+
+const {
+  getAdminNotificationListMock,
+  getAdminUnreadNotificationCountsMock,
+  markAllMutateAsyncMock,
+  markReadMutateAsyncMock,
+  usePathnameMock,
+} = vi.hoisted(() => ({
+  getAdminNotificationListMock: vi.fn(),
+  getAdminUnreadNotificationCountsMock: vi.fn(),
+  markAllMutateAsyncMock: vi.fn(),
+  markReadMutateAsyncMock: vi.fn(),
+  usePathnameMock: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  usePathname: usePathnameMock,
+  useRouter: () => ({
+    push: vi.fn(),
+  }),
+}));
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("@/features/admin/notifications/queries", () => ({
+  getAdminNotificationList: getAdminNotificationListMock,
+  getAdminUnreadNotificationCounts: getAdminUnreadNotificationCountsMock,
+}));
+
+vi.mock("../hooks/use-mark-admin-notifications-as-read", () => ({
+  useMarkAllAdminNotificationsAsRead: () => ({
+    isPending: false,
+    mutateAsync: markAllMutateAsyncMock,
+  }),
+  useMarkAdminNotificationsAsRead: () => ({
+    mutateAsync: markReadMutateAsyncMock,
+  }),
+}));
+
+import { AdminNotificationBell } from "./AdminNotificationBell";
+
+const ADMIN_USER_ID = "11111111-1111-4111-8111-111111111111";
+
+/**
+ * 관리자 알림 Bell을 QueryClientProvider와 함께 렌더링합니다.
+ */
+function renderAdminNotificationBell() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+
+  const view = render(
+    <QueryClientProvider client={queryClient}>
+      <AdminNotificationBell adminUserId={ADMIN_USER_ID} />
+    </QueryClientProvider>,
+  );
+
+  return { queryClient, ...view };
+}
+
+describe("AdminNotificationBell", () => {
+  beforeEach(() => {
+    getAdminNotificationListMock.mockReset();
+    getAdminUnreadNotificationCountsMock.mockReset();
+    markAllMutateAsyncMock.mockReset();
+    markReadMutateAsyncMock.mockReset();
+    usePathnameMock.mockReset();
+    usePathnameMock.mockReturnValue("/admin");
+    getAdminNotificationListMock.mockResolvedValue([
+      {
+        body: "운영 오류가 발생했습니다.",
+        click_path: "/admin/operational-errors/error-id",
+        id: "22222222-2222-4222-8222-222222222222",
+        note_id: null,
+        noteTitle: null,
+        read_at: null,
+        review_log_id: null,
+        sent_at: "2026-07-27T01:00:00.000Z",
+        source: "ADMIN",
+        status: "SENT",
+        title: "운영 오류 알림",
+        type: ADMIN_NOTIFICATION_TYPES.OPERATIONAL_ERROR,
+      },
+    ]);
+    getAdminUnreadNotificationCountsMock.mockResolvedValue({
+      [ADMIN_NOTIFICATION_TYPES.OPERATIONAL_ERROR]: 1,
+    });
+    markAllMutateAsyncMock.mockResolvedValue({
+      ok: true,
+      updated: 1,
+    });
+  });
+
+  it("renders admin notifications and marks only admin notifications as read in bulk", async () => {
+    const user = userEvent.setup();
+    renderAdminNotificationBell();
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: "읽지 않은 관리자 알림 1개",
+      }),
+    );
+
+    expect(await screen.findByText("운영 오류 알림")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "전체 읽음" }));
+
+    expect(markAllMutateAsyncMock).toHaveBeenCalledOnce();
+    await waitFor(() => {
+      expect(
+        screen.getByText("새 관리자 알림이 없습니다."),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("uses the shared sidebar unread count query and fetches the list only when opened", async () => {
+    const user = userEvent.setup();
+    renderAdminNotificationBell();
+
+    expect(getAdminNotificationListMock).not.toHaveBeenCalled();
+
+    await screen.findByRole("button", {
+      name: "읽지 않은 관리자 알림 1개",
+    });
+
+    expect(getAdminUnreadNotificationCountsMock).toHaveBeenCalledOnce();
+    expect(getAdminNotificationListMock).not.toHaveBeenCalled();
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "읽지 않은 관리자 알림 1개",
+      }),
+    );
+
+    await waitFor(() => {
+      expect(getAdminNotificationListMock).toHaveBeenCalledOnce();
+    });
+  });
+
+  it("refreshes the open admin notification list when the shared unread count changes", async () => {
+    const user = userEvent.setup();
+    const { queryClient } = renderAdminNotificationBell();
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: "읽지 않은 관리자 알림 1개",
+      }),
+    );
+    await waitFor(() => {
+      expect(getAdminNotificationListMock).toHaveBeenCalledOnce();
+    });
+
+    queryClient.setQueryData(ADMIN_UNREAD_NOTIFICATION_COUNTS_QUERY_KEY.all, {
+      [ADMIN_NOTIFICATION_TYPES.OPERATIONAL_ERROR]: 2,
+    });
+
+    await waitFor(() => {
+      expect(getAdminNotificationListMock).toHaveBeenCalledTimes(2);
+    });
+    expect(
+      screen.getByRole("button", {
+        name: "읽지 않은 관리자 알림 2개",
+      }),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/features/admin/notifications/components/AdminNotificationBell.tsx
+++ b/src/features/admin/notifications/components/AdminNotificationBell.tsx
@@ -1,0 +1,296 @@
+"use client";
+
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { BellRing, Loader2 } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+  getAdminNotificationList,
+  getAdminUnreadNotificationCounts,
+} from "@/features/admin/notifications/queries";
+import { cn } from "@/lib/utils/cn";
+
+import { useAdminUnreadNotificationCounts } from "../hooks/use-admin-unread-notification-counts";
+import { useMarkAllAdminNotificationsAsRead } from "../hooks/use-mark-admin-notifications-as-read";
+import { ADMIN_NOTIFICATIONS_QUERY_KEY } from "../query-keys";
+import {
+  AdminNotificationList,
+  type AdminNotificationListItemType,
+} from "./AdminNotificationList";
+
+const ADMIN_NOTIFICATION_LIST_LIMIT = 20;
+
+type AdminNotificationBellProps = {
+  adminUserId: string;
+};
+
+/**
+ * 관리자 알림 타입별 count map을 총 unread count로 합산합니다.
+ *
+ * @param counts 관리자 알림 타입별 unread count
+ * @returns 전체 관리자 unread count
+ */
+function sumAdminUnreadCounts(
+  counts: Awaited<ReturnType<typeof getAdminUnreadNotificationCounts>>,
+) {
+  return Object.values(counts).reduce((sum, count) => sum + (count ?? 0), 0);
+}
+
+/**
+ * 관리자 Bell에서 사용할 알림 목록을 조회합니다.
+ *
+ * @returns 관리자 알림 목록
+ */
+async function fetchAdminNotificationList(): Promise<
+  AdminNotificationListItemType[]
+> {
+  const items = await getAdminNotificationList({
+    limit: ADMIN_NOTIFICATION_LIST_LIMIT,
+  });
+
+  return items.filter(isAdminNotificationListItem);
+}
+
+/**
+ * 관리자 알림 item이 관리자 전용 목록 item인지 확인합니다.
+ *
+ * @param item 확인할 알림 item
+ * @returns 관리자 알림 item 여부
+ */
+function isAdminNotificationListItem(
+  item: Awaited<ReturnType<typeof getAdminNotificationList>>[number],
+): item is AdminNotificationListItemType {
+  return item.source === "ADMIN";
+}
+
+/**
+ * 읽음 처리된 관리자 알림을 관리자 Bell 캐시에서 제거합니다.
+ *
+ * @param current 현재 관리자 알림 응답
+ * @param notificationId 제거할 관리자 알림 event ID
+ * @returns 갱신된 관리자 알림 응답
+ */
+export function removeReadAdminNotificationFromResponse(
+  current: AdminNotificationListItemType[] | undefined,
+  notificationId: string,
+) {
+  if (!current) return current;
+
+  const hasItem = current.some((item) => item.id === notificationId);
+
+  if (!hasItem) return current;
+
+  return current.filter((item) => item.id !== notificationId);
+}
+
+/**
+ * 현재 관리자 알림 응답을 모두 읽은 상태로 비웁니다.
+ *
+ * @param current 현재 관리자 알림 응답
+ * @returns 빈 관리자 알림 응답
+ */
+function removeAllAdminNotificationsFromResponse(
+  current: AdminNotificationListItemType[] | undefined,
+) {
+  if (!current) return current;
+
+  return [];
+}
+
+/**
+ * 관리자 전용 알림 Bell입니다.
+ *
+ * 사용자 알림과 별도 query/action을 사용하며, 읽음 처리는
+ * admin_notification_reads만 갱신합니다.
+ */
+export function AdminNotificationBell({
+  adminUserId,
+}: AdminNotificationBellProps) {
+  const [open, setOpen] = useState(false);
+  const queryClient = useQueryClient();
+  const ref = useRef<HTMLDivElement>(null);
+  const previousUnreadCountRef = useRef(0);
+  const adminNotificationsQueryKey =
+    ADMIN_NOTIFICATIONS_QUERY_KEY.user(adminUserId);
+  const markAllReadMutation = useMarkAllAdminNotificationsAsRead();
+  const {
+    data: unreadCounts = {},
+    isFetching: isCountFetching,
+    isLoading: isCountLoading,
+  } = useAdminUnreadNotificationCounts();
+
+  const {
+    data: adminItems = [],
+    isError,
+    isFetching: isListFetching,
+    isLoading: isListLoading,
+    refetch,
+  } = useQuery({
+    enabled: open,
+    queryFn: fetchAdminNotificationList,
+    queryKey: adminNotificationsQueryKey,
+    retry: 1,
+  });
+
+  const unreadCount = sumAdminUnreadCounts(unreadCounts);
+
+  useEffect(() => {
+    if (previousUnreadCountRef.current === unreadCount) return;
+
+    previousUnreadCountRef.current = unreadCount;
+
+    if (!open) return;
+
+    void refetch();
+  }, [open, refetch, unreadCount]);
+
+  useEffect(() => {
+    if (!open) return;
+
+    const handleMouseDown = (event: MouseEvent) => {
+      if (ref.current && !ref.current.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    };
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setOpen(false);
+    };
+
+    document.addEventListener("mousedown", handleMouseDown);
+    document.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      document.removeEventListener("mousedown", handleMouseDown);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [open]);
+
+  const displayCount = unreadCount > 99 ? "99+" : String(unreadCount);
+  const buttonLabel =
+    unreadCount > 0 ? `읽지 않은 관리자 알림 ${unreadCount}개` : "관리자 알림";
+  const hasHiddenUnreadNotifications = unreadCount > adminItems.length;
+  const isFetching = isCountFetching || isListFetching;
+
+  /**
+   * 관리자 알림 목록 열림 상태를 전환합니다.
+   */
+  const handleToggle = () => {
+    const nextOpen = !open;
+    setOpen(nextOpen);
+  };
+
+  /**
+   * 관리자 알림 대상 페이지로 이동할 때 Bell을 닫습니다.
+   */
+  const handleItemNavigate = () => {
+    setOpen(false);
+  };
+
+  /**
+   * 읽음 처리된 관리자 알림을 현재 Bell 캐시에서 제거합니다.
+   *
+   * @param notificationId 읽음 처리된 관리자 알림 event ID
+   */
+  const handleItemRead = (notificationId: string) => {
+    queryClient.setQueryData<AdminNotificationListItemType[]>(
+      adminNotificationsQueryKey,
+      (current) =>
+        removeReadAdminNotificationFromResponse(current, notificationId),
+    );
+  };
+
+  /**
+   * 현재 관리자의 모든 관리자 알림을 읽음 처리합니다.
+   */
+  const handleAllRead = async () => {
+    const result = await markAllReadMutation.mutateAsync();
+
+    if (!result.ok) return;
+
+    queryClient.setQueryData<AdminNotificationListItemType[]>(
+      adminNotificationsQueryKey,
+      removeAllAdminNotificationsFromResponse,
+    );
+  };
+
+  return (
+    <div ref={ref} className="relative">
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon-lg"
+        aria-label={buttonLabel}
+        aria-expanded={open}
+        className="relative"
+        onClick={handleToggle}
+      >
+        {isCountLoading ? (
+          <Loader2 className="animate-spin" aria-hidden="true" />
+        ) : (
+          <BellRing aria-hidden="true" />
+        )}
+        {unreadCount > 0 ? (
+          <span
+            aria-hidden="true"
+            className={cn(
+              "absolute -right-0.5 -top-0.5 flex min-w-4 items-center justify-center rounded-full bg-destructive px-1 text-[0.65rem] font-semibold leading-4  text-white",
+              unreadCount > 99 && "min-w-6",
+            )}
+          >
+            {displayCount}
+          </span>
+        ) : null}
+      </Button>
+
+      {open ? (
+        <div className="fixed inset-x-4 top-19 z-50 overflow-hidden rounded-lg border bg-background shadow-lg sm:absolute sm:left-auto sm:right-0 sm:top-full sm:mt-2 sm:w-[min(calc(100vw-2rem),24rem)]">
+          <div className="flex items-center justify-between gap-3 px-4 py-3">
+            <div>
+              <p className="text-sm font-semibold">관리자 알림</p>
+              <p className="text-xs text-muted-foreground">
+                읽지 않은 관리자 알림 {unreadCount}개
+              </p>
+            </div>
+
+            <div className="flex items-center gap-2">
+              {isFetching ? (
+                <Loader2
+                  className="size-4 animate-spin text-muted-foreground"
+                  aria-hidden="true"
+                />
+              ) : null}
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                disabled={
+                  unreadCount === 0 ||
+                  isCountLoading ||
+                  markAllReadMutation.isPending
+                }
+                onClick={handleAllRead}
+              >
+                전체 읽음
+              </Button>
+            </div>
+          </div>
+
+          <AdminNotificationList
+            items={adminItems}
+            isError={isError}
+            isLoading={isListLoading}
+            onItemNavigate={handleItemNavigate}
+            onItemRead={handleItemRead}
+          />
+
+          {hasHiddenUnreadNotifications ? (
+            <p className="border-t border-border/60 px-4 py-2 text-xs text-muted-foreground">
+              최근 {adminItems.length}개만 표시됩니다.
+            </p>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/features/admin/notifications/components/AdminNotificationList.test.tsx
+++ b/src/features/admin/notifications/components/AdminNotificationList.test.tsx
@@ -1,0 +1,85 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ADMIN_NOTIFICATION_TYPES } from "@/lib/constants/notifications";
+
+const { markReadMutateAsyncMock, routerPushMock } = vi.hoisted(() => ({
+  markReadMutateAsyncMock: vi.fn(),
+  routerPushMock: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: routerPushMock,
+  }),
+}));
+
+vi.mock("../hooks/use-mark-admin-notifications-as-read", () => ({
+  useMarkAdminNotificationsAsRead: () => ({
+    mutateAsync: markReadMutateAsyncMock,
+  }),
+}));
+
+import {
+  AdminNotificationList,
+  type AdminNotificationListItemType,
+} from "./AdminNotificationList";
+
+const ADMIN_NOTIFICATION_ID = "11111111-1111-4111-8111-111111111111";
+const ADMIN_CLICK_PATH = "/admin/operational-errors/error-id";
+
+/**
+ * 관리자 알림 목록 테스트용 item을 생성합니다.
+ */
+function createAdminNotificationItem(): AdminNotificationListItemType {
+  return {
+    body: "운영 오류가 발생했습니다.",
+    click_path: ADMIN_CLICK_PATH,
+    id: ADMIN_NOTIFICATION_ID,
+    note_id: null,
+    noteTitle: null,
+    read_at: null,
+    review_log_id: null,
+    sent_at: "2026-07-27T01:00:00.000Z",
+    source: "ADMIN",
+    status: "SENT",
+    title: "운영 오류 알림",
+    type: ADMIN_NOTIFICATION_TYPES.OPERATIONAL_ERROR,
+  };
+}
+
+describe("AdminNotificationList", () => {
+  beforeEach(() => {
+    markReadMutateAsyncMock.mockReset();
+    routerPushMock.mockReset();
+  });
+
+  it("marks an admin notification as read before navigation", async () => {
+    const user = userEvent.setup();
+    const onItemRead = vi.fn();
+    const onItemNavigate = vi.fn();
+    markReadMutateAsyncMock.mockResolvedValue({
+      ok: true,
+      updated: 1,
+    });
+
+    render(
+      <AdminNotificationList
+        items={[createAdminNotificationItem()]}
+        onItemNavigate={onItemNavigate}
+        onItemRead={onItemRead}
+      />,
+    );
+
+    await user.click(screen.getByRole("link", { name: /운영 오류 알림/ }));
+
+    expect(markReadMutateAsyncMock).toHaveBeenCalledWith({
+      clickPath: ADMIN_CLICK_PATH,
+      type: ADMIN_NOTIFICATION_TYPES.OPERATIONAL_ERROR,
+    });
+    expect(onItemRead).toHaveBeenCalledWith(ADMIN_NOTIFICATION_ID);
+    expect(onItemNavigate).toHaveBeenCalledOnce();
+    expect(routerPushMock).toHaveBeenCalledWith(ADMIN_CLICK_PATH);
+  });
+});

--- a/src/features/admin/notifications/components/AdminNotificationList.tsx
+++ b/src/features/admin/notifications/components/AdminNotificationList.tsx
@@ -1,0 +1,156 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import type { MouseEvent } from "react";
+
+import type { NotificationListItemType } from "@/features/notifications/schema";
+import { NOTIFICATION_STATUS } from "@/lib/constants/notifications";
+import { formatDateTime } from "@/lib/utils/formatDate";
+import type { AdminNotificationType } from "@/types/notifications.types";
+
+import { useMarkAdminNotificationsAsRead } from "../hooks/use-mark-admin-notifications-as-read";
+
+export type AdminNotificationListItemType = NotificationListItemType & {
+  source: "ADMIN";
+  type: AdminNotificationType;
+};
+
+type AdminNotificationListProps = {
+  isError?: boolean;
+  isLoading?: boolean;
+  items: AdminNotificationListItemType[];
+  onItemNavigate?: () => void;
+  onItemRead?: (notificationId: string) => void;
+};
+
+/**
+ * 관리자 알림 상태에 대한 표시 라벨을 반환합니다.
+ *
+ * @param status 알림 읽음 상태
+ * @returns 관리자에게 보여줄 상태 라벨
+ */
+function getAdminNotificationStatusLabel(
+  status: NotificationListItemType["status"],
+): string {
+  if (status === NOTIFICATION_STATUS.SENT) return "새 알림";
+  return "읽음";
+}
+
+/**
+ * 관리자 알림 클릭이 새 탭, 새 창, 보조 클릭인지 확인합니다.
+ *
+ * @param event 링크 클릭 이벤트
+ * @returns 기본 라우팅을 유지해야 하는 수정 클릭 여부
+ */
+function isModifiedClick(event: MouseEvent<HTMLAnchorElement>) {
+  return (
+    event.altKey ||
+    event.ctrlKey ||
+    event.metaKey ||
+    event.shiftKey ||
+    event.button !== 0
+  );
+}
+
+/**
+ * 관리자 알림 목록을 표시하고 클릭한 관리자 알림만 관리자 read row로 저장합니다.
+ */
+export function AdminNotificationList({
+  isError = false,
+  isLoading = false,
+  items,
+  onItemNavigate,
+  onItemRead,
+}: AdminNotificationListProps) {
+  const router = useRouter();
+  const markReadMutation = useMarkAdminNotificationsAsRead();
+
+  if (isLoading) {
+    return (
+      <ul className="max-h-96 overflow-y-auto" aria-label="관리자 알림 목록">
+        {Array.from({ length: 3 }, (_, index) => (
+          <li key={index} className="border-t border-border/60 px-4 py-3">
+            <div className="h-4 w-28 animate-pulse rounded bg-muted" />
+            <div className="mt-2 h-3 w-44 animate-pulse rounded bg-muted" />
+          </li>
+        ))}
+      </ul>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className="border-t border-border/60 px-4 py-8 text-center text-sm text-muted-foreground">
+        관리자 알림을 불러오지 못했습니다.
+      </div>
+    );
+  }
+
+  if (items.length === 0) {
+    return (
+      <div className="border-t border-border/60 px-4 py-8 text-center text-sm text-muted-foreground">
+        새 관리자 알림이 없습니다.
+      </div>
+    );
+  }
+
+  return (
+    <ul className="max-h-96 overflow-y-auto" aria-label="관리자 알림 목록">
+      {items.map((item) => (
+        <li
+          key={item.id}
+          className="flex items-start gap-2 border-t border-border/60 px-4 py-3 transition-colors hover:bg-muted/40"
+        >
+          <Link
+            href={item.click_path}
+            className="min-w-0 flex-1"
+            onClick={async (event) => {
+              if (isModifiedClick(event)) {
+                onItemNavigate?.();
+                return;
+              }
+
+              event.preventDefault();
+
+              try {
+                const result = await markReadMutation.mutateAsync({
+                  clickPath: item.click_path,
+                  type: item.type,
+                });
+
+                if (result.ok && result.updated > 0) {
+                  onItemRead?.(item.id);
+                }
+              } catch {
+                // 읽음 처리는 부가 작업이므로 실패해도 관리자 대상 이동은 유지한다.
+              }
+
+              onItemNavigate?.();
+              router.push(item.click_path);
+            }}
+          >
+            <div className="min-w-0">
+              <div className="flex items-center gap-2">
+                <span className="truncate text-sm font-medium text-foreground">
+                  {item.title}
+                </span>
+                <span className="shrink-0 rounded-full bg-muted px-2 py-0.5 text-[0.7rem] font-medium text-muted-foreground">
+                  {getAdminNotificationStatusLabel(item.status)}
+                </span>
+              </div>
+              {item.body ? (
+                <p className="mt-1 line-clamp-2 text-xs text-muted-foreground">
+                  {item.body}
+                </p>
+              ) : null}
+              <p className="mt-2 text-[0.7rem] text-muted-foreground/80">
+                {formatDateTime(item.sent_at)}
+              </p>
+            </div>
+          </Link>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/features/admin/notifications/hooks/use-admin-unread-notification-counts.ts
+++ b/src/features/admin/notifications/hooks/use-admin-unread-notification-counts.ts
@@ -1,13 +1,9 @@
 import { useQuery } from "@tanstack/react-query";
 
 import { getAdminUnreadNotificationCounts } from "../queries";
+import { ADMIN_UNREAD_NOTIFICATION_COUNTS_QUERY_KEY } from "../query-keys";
 
-/**
- * 관리자 알림 unread count query key factory입니다.
- */
-export const ADMIN_UNREAD_NOTIFICATION_COUNTS_QUERY_KEY = {
-  all: ["admin-unread-notification-counts"] as const,
-};
+export { ADMIN_UNREAD_NOTIFICATION_COUNTS_QUERY_KEY };
 
 /**
  * 현재 관리자 기준 읽지 않은 관리자 알림 개수를 조회합니다.

--- a/src/features/admin/notifications/hooks/use-mark-admin-notifications-as-read.ts
+++ b/src/features/admin/notifications/hooks/use-mark-admin-notifications-as-read.ts
@@ -1,12 +1,30 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 
-import { NOTIFICATIONS_QUERY_KEY } from "@/features/notifications/query-keys";
-
 import {
   markAdminNotificationsAsReadAction,
   type MarkAdminNotificationsAsReadInput,
+  markAllAdminNotificationsAsReadAction,
 } from "../actions";
-import { ADMIN_UNREAD_NOTIFICATION_COUNTS_QUERY_KEY } from "./use-admin-unread-notification-counts";
+import {
+  ADMIN_NOTIFICATIONS_QUERY_KEY,
+  ADMIN_UNREAD_NOTIFICATION_COUNTS_QUERY_KEY,
+} from "../query-keys";
+
+/**
+ * 관리자 알림 관련 query cache를 갱신합니다.
+ *
+ * @param queryClient TanStack Query client
+ */
+function invalidateAdminNotificationQueries(
+  queryClient: ReturnType<typeof useQueryClient>,
+) {
+  void queryClient.invalidateQueries({
+    queryKey: ADMIN_NOTIFICATIONS_QUERY_KEY.all,
+  });
+  void queryClient.invalidateQueries({
+    queryKey: ADMIN_UNREAD_NOTIFICATION_COUNTS_QUERY_KEY.all,
+  });
+}
 
 /**
  * 현재 관리자 기준 특정 관리자 알림 이벤트들을 읽음 처리합니다.
@@ -22,12 +40,25 @@ export function useMarkAdminNotificationsAsRead() {
     onSuccess: (result) => {
       if (!result.ok) return;
 
-      void queryClient.invalidateQueries({
-        queryKey: NOTIFICATIONS_QUERY_KEY.all,
-      });
-      void queryClient.invalidateQueries({
-        queryKey: ADMIN_UNREAD_NOTIFICATION_COUNTS_QUERY_KEY.all,
-      });
+      invalidateAdminNotificationQueries(queryClient);
+    },
+  });
+}
+
+/**
+ * 현재 관리자 기준 모든 관리자 알림을 읽음 처리합니다.
+ *
+ * 성공 시 관리자 알림 Bell과 관리자 사이드바 badge count를 함께 갱신합니다.
+ */
+export function useMarkAllAdminNotificationsAsRead() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: () => markAllAdminNotificationsAsReadAction(),
+    onSuccess: (result) => {
+      if (!result.ok) return;
+
+      invalidateAdminNotificationQueries(queryClient);
     },
   });
 }

--- a/src/features/admin/notifications/queries.internal.ts
+++ b/src/features/admin/notifications/queries.internal.ts
@@ -76,7 +76,7 @@ function incrementUnreadCount(
 }
 
 /**
- * 관리자 알림 이벤트 row를 공용 알림 목록 item으로 변환합니다.
+ * 관리자 알림 이벤트 row를 관리자 Bell에서 사용하는 알림 item으로 변환합니다.
  *
  * @param event 관리자 알림 RPC에서 반환한 이벤트 row
  * @returns 알림 목록 컴포넌트가 사용하는 item

--- a/src/features/admin/notifications/query-keys.ts
+++ b/src/features/admin/notifications/query-keys.ts
@@ -1,0 +1,16 @@
+/**
+ * 관리자 알림 목록 query key factory입니다.
+ */
+export const ADMIN_NOTIFICATIONS_QUERY_KEY = {
+  all: ["admin-notifications"] as const,
+
+  user: (adminUserId: string) =>
+    [...ADMIN_NOTIFICATIONS_QUERY_KEY.all, adminUserId] as const,
+};
+
+/**
+ * 관리자 알림 unread count query key factory입니다.
+ */
+export const ADMIN_UNREAD_NOTIFICATION_COUNTS_QUERY_KEY = {
+  all: ["admin-unread-notification-counts"] as const,
+};

--- a/src/features/notifications/components/NotificationBell.tsx
+++ b/src/features/notifications/components/NotificationBell.tsx
@@ -23,6 +23,22 @@ const ROUTE_CHANGE_REFETCH_COOLDOWN_MS = 30_000;
 
 class UnauthorizedNotificationError extends Error {}
 
+export function removeReadNotificationFromResponse(
+  current: NotificationsResponseType | undefined,
+  notificationId: string,
+) {
+  if (!current) return current;
+
+  const hasItem = current.items.some((item) => item.id === notificationId);
+
+  if (!hasItem) return current;
+
+  return {
+    items: current.items.filter((item) => item.id !== notificationId),
+    unreadCount: Math.max(current.unreadCount - 1, 0),
+  };
+}
+
 async function fetchNotifications(): Promise<NotificationsResponseType> {
   const response = await fetch("/api/notifications", {
     credentials: "same-origin",
@@ -131,6 +147,13 @@ export function NotificationBell({ userId }: NotificationBellProps) {
     setOpen(false);
   };
 
+  const handleItemRead = (notificationId: string) => {
+    queryClient.setQueryData<NotificationsResponseType>(
+      notificationsQueryKey,
+      (current) => removeReadNotificationFromResponse(current, notificationId),
+    );
+  };
+
   const hasHiddenUnreadNotifications = unreadCount > data.items.length;
 
   return (
@@ -183,6 +206,7 @@ export function NotificationBell({ userId }: NotificationBellProps) {
             items={data.items}
             isError={isError}
             isLoading={isLoading}
+            onItemRead={handleItemRead}
             onItemNavigate={handleItemNavigate}
           />
 

--- a/src/features/notifications/components/NotificationBell.tsx
+++ b/src/features/notifications/components/NotificationBell.tsx
@@ -13,7 +13,10 @@ import {
   notificationsResponseSchema,
   type NotificationsResponseType,
 } from "../schema";
-import { NotificationList } from "./NotificationList";
+import {
+  NotificationList,
+  type UserNotificationListItemType,
+} from "./NotificationList";
 
 const EMPTY_NOTIFICATIONS: NotificationsResponseType = {
   items: [],
@@ -60,6 +63,18 @@ async function fetchNotifications(): Promise<NotificationsResponseType> {
   }
 
   return parsed.data;
+}
+
+/**
+ * 알림 응답 item이 사용자 알림 item인지 확인합니다.
+ *
+ * @param item 확인할 알림 item
+ * @returns 사용자 알림 item 여부
+ */
+function isUserNotificationListItem(
+  item: NotificationsResponseType["items"][number],
+): item is UserNotificationListItemType {
+  return item.source === "USER";
 }
 
 type NotificationBellProps = {
@@ -133,6 +148,7 @@ export function NotificationBell({ userId }: NotificationBellProps) {
   const displayCount = unreadCount > 99 ? "99+" : String(unreadCount);
   const buttonLabel =
     unreadCount > 0 ? `읽지 않은 알림 ${unreadCount}개` : "알림";
+  const userItems = data.items.filter(isUserNotificationListItem);
 
   const handleToggle = () => {
     const nextOpen = !open;
@@ -154,7 +170,7 @@ export function NotificationBell({ userId }: NotificationBellProps) {
     );
   };
 
-  const hasHiddenUnreadNotifications = unreadCount > data.items.length;
+  const hasHiddenUnreadNotifications = unreadCount > userItems.length;
 
   return (
     <div ref={ref} className="relative">
@@ -203,7 +219,7 @@ export function NotificationBell({ userId }: NotificationBellProps) {
           </div>
 
           <NotificationList
-            items={data.items}
+            items={userItems}
             isError={isError}
             isLoading={isLoading}
             onItemRead={handleItemRead}
@@ -212,7 +228,7 @@ export function NotificationBell({ userId }: NotificationBellProps) {
 
           {hasHiddenUnreadNotifications && (
             <p className="border-t border-border/60 px-4 py-2 text-xs text-muted-foreground">
-              최근 {data.items.length}개만 표시됩니다.
+              최근 {userItems.length}개만 표시됩니다.
             </p>
           )}
         </div>

--- a/src/features/notifications/components/NotificationList.tsx
+++ b/src/features/notifications/components/NotificationList.tsx
@@ -10,11 +10,11 @@ import {
 } from "@/lib/constants/notifications";
 import { formatDateTime } from "@/lib/utils/formatDate";
 
+import { markNotificationAsReadAction } from "../actions";
 import {
   ADMIN_NOTIFICATION_DEFINITIONS,
   USER_NOTIFICATION_DEFINITIONS,
 } from "../definitions";
-import { markNotificationAsReadAction } from "../actions";
 import type { NotificationListItemType } from "../schema";
 
 type NotificationListProps = {

--- a/src/features/notifications/components/NotificationList.tsx
+++ b/src/features/notifications/components/NotificationList.tsx
@@ -1,20 +1,27 @@
 "use client";
 
 import Link from "next/link";
+import { useRouter } from "next/navigation";
+import type { MouseEvent } from "react";
 
-import { NOTIFICATION_STATUS } from "@/lib/constants/notifications";
+import {
+  NOTIFICATION_STATUS,
+  NOTIFICATION_TYPES,
+} from "@/lib/constants/notifications";
 import { formatDateTime } from "@/lib/utils/formatDate";
 
 import {
   ADMIN_NOTIFICATION_DEFINITIONS,
   USER_NOTIFICATION_DEFINITIONS,
 } from "../definitions";
+import { markNotificationAsReadAction } from "../actions";
 import type { NotificationListItemType } from "../schema";
 
 type NotificationListProps = {
   items: NotificationListItemType[];
   isError?: boolean;
   isLoading?: boolean;
+  onItemRead?: (notificationId: string) => void;
   onItemNavigate?: () => void;
 };
 
@@ -65,12 +72,33 @@ function getNotificationDescription(item: NotificationListItemType): string {
   return USER_NOTIFICATION_DEFINITIONS[type].label;
 }
 
+function shouldMarkAsReadOnClick(item: NotificationListItemType) {
+  // REVIEW는 복습 완료 RPC에서 READ 처리한다. 그 외 알림은 클릭을 소비로 본다.
+  return (
+    item.status === NOTIFICATION_STATUS.SENT &&
+    item.type !== NOTIFICATION_TYPES.REVIEW
+  );
+}
+
+function isModifiedClick(event: MouseEvent<HTMLAnchorElement>) {
+  return (
+    event.altKey ||
+    event.ctrlKey ||
+    event.metaKey ||
+    event.shiftKey ||
+    event.button !== 0
+  );
+}
+
 export function NotificationList({
   items,
   isError = false,
   isLoading = false,
+  onItemRead,
   onItemNavigate,
 }: NotificationListProps) {
+  const router = useRouter();
+
   if (isLoading) {
     return (
       <ul className="max-h-96 overflow-y-auto" aria-label="알림 목록">
@@ -134,8 +162,26 @@ export function NotificationList({
             <Link
               href={item.click_path}
               className="min-w-0 flex-1"
-              onClick={() => {
+              onClick={async (event) => {
+                if (!shouldMarkAsReadOnClick(item) || isModifiedClick(event)) {
+                  onItemNavigate?.();
+                  return;
+                }
+
+                event.preventDefault();
+
+                try {
+                  const result = await markNotificationAsReadAction(item.id);
+
+                  if (result.success && result.updated) {
+                    onItemRead?.(item.id);
+                  }
+                } catch {
+                  // 읽음 처리는 부가 작업이므로 실패해도 알림 대상 이동은 유지한다.
+                }
+
                 onItemNavigate?.();
+                router.push(item.click_path);
               }}
             >
               {content}

--- a/src/features/notifications/components/NotificationList.tsx
+++ b/src/features/notifications/components/NotificationList.tsx
@@ -7,18 +7,21 @@ import type { MouseEvent } from "react";
 import {
   NOTIFICATION_STATUS,
   NOTIFICATION_TYPES,
+  type NotificationKindType,
 } from "@/lib/constants/notifications";
 import { formatDateTime } from "@/lib/utils/formatDate";
 
 import { markNotificationAsReadAction } from "../actions";
-import {
-  ADMIN_NOTIFICATION_DEFINITIONS,
-  USER_NOTIFICATION_DEFINITIONS,
-} from "../definitions";
+import { USER_NOTIFICATION_DEFINITIONS } from "../definitions";
 import type { NotificationListItemType } from "../schema";
 
+export type UserNotificationListItemType = NotificationListItemType & {
+  source: "USER";
+  type: NotificationKindType;
+};
+
 type NotificationListProps = {
-  items: NotificationListItemType[];
+  items: UserNotificationListItemType[];
   isError?: boolean;
   isLoading?: boolean;
   onItemRead?: (notificationId: string) => void;
@@ -37,42 +40,27 @@ function getStatusLabel(status: NotificationListItemType["status"]): string {
 }
 
 /**
- * 알림 출처에 대한 표시 라벨을 반환합니다.
- *
- * @param source 알림 생성 출처
- * @returns 사용자에게 보여줄 출처 라벨
- */
-function getSourceLabel(source: NotificationListItemType["source"]): string {
-  return source === "ADMIN" ? "관리자" : "개인";
-}
-
-/**
  * 본문이나 노트 제목이 없는 알림에 사용할 타입별 fallback 라벨을 반환합니다.
  *
  * @param item 표시할 알림 item
  * @returns 알림 설명 문구
  */
-function getNotificationDescription(item: NotificationListItemType): string {
+function getNotificationDescription(
+  item: UserNotificationListItemType,
+): string {
   if (item.noteTitle) return item.noteTitle;
   if (item.body) return item.body;
 
-  if (
-    Object.prototype.hasOwnProperty.call(
-      ADMIN_NOTIFICATION_DEFINITIONS,
-      item.type,
-    )
-  ) {
-    const type = item.type as keyof typeof ADMIN_NOTIFICATION_DEFINITIONS;
-
-    return ADMIN_NOTIFICATION_DEFINITIONS[type].label;
-  }
-
-  const type = item.type as keyof typeof USER_NOTIFICATION_DEFINITIONS;
-
-  return USER_NOTIFICATION_DEFINITIONS[type].label;
+  return USER_NOTIFICATION_DEFINITIONS[item.type].label;
 }
 
-function shouldMarkAsReadOnClick(item: NotificationListItemType) {
+/**
+ * 사용자 알림 클릭 시 즉시 읽음 처리할 대상인지 확인합니다.
+ *
+ * @param item 클릭한 사용자 알림 item
+ * @returns 클릭 시 읽음 처리해야 하면 true
+ */
+function shouldMarkAsReadOnClick(item: UserNotificationListItemType) {
   // REVIEW는 복습 완료 RPC에서 READ 처리한다. 그 외 알림은 클릭을 소비로 본다.
   return (
     item.status === NOTIFICATION_STATUS.SENT &&
@@ -80,6 +68,12 @@ function shouldMarkAsReadOnClick(item: NotificationListItemType) {
   );
 }
 
+/**
+ * 사용자 알림 링크 클릭이 새 탭, 새 창, 보조 클릭인지 확인합니다.
+ *
+ * @param event 링크 클릭 이벤트
+ * @returns 기본 링크 동작을 유지해야 하는 수정 클릭 여부
+ */
 function isModifiedClick(event: MouseEvent<HTMLAnchorElement>) {
   return (
     event.altKey ||
@@ -137,9 +131,6 @@ export function NotificationList({
             <div className="flex items-center gap-2">
               <span className="truncate text-sm font-medium text-foreground">
                 {item.title}
-              </span>
-              <span className="shrink-0 rounded-full bg-primary/10 px-2 py-0.5 text-[0.7rem] font-medium text-primary">
-                {getSourceLabel(item.source)}
               </span>
               <span className="shrink-0 rounded-full bg-muted px-2 py-0.5 text-[0.7rem] font-medium text-muted-foreground">
                 {getStatusLabel(item.status)}

--- a/src/features/notifications/definitions.ts
+++ b/src/features/notifications/definitions.ts
@@ -85,11 +85,11 @@ export const ADMIN_NOTIFICATION_DEFINITIONS = {
  * @returns 피드백 답변 사용자 알림 정의
  */
 export function buildFeedbackReplyNotificationDefinition({
-  feedbackId,
+  feedbackId: _feedbackId,
 }: BuildFeedbackReplyDefinitionInput) {
   return {
     ...USER_NOTIFICATION_DEFINITIONS[NOTIFICATION_TYPES.FEEDBACK_REPLY],
-    clickPath: `${ROUTES.MYPAGE}?feedbackId=${encodeURIComponent(feedbackId)}`,
+    clickPath: `${ROUTES.MYPAGE}?section=support&tab=inquiry`,
   };
 }
 

--- a/src/features/notifications/tests/NotificationBell.test.tsx
+++ b/src/features/notifications/tests/NotificationBell.test.tsx
@@ -24,11 +24,12 @@ import {
   NotificationBell,
   removeReadNotificationFromResponse,
 } from "../components/NotificationBell";
+import type { NotificationsResponseType } from "../schema";
 
 const USER_A_ID = "11111111-1111-4111-8111-111111111111";
 const USER_B_ID = "22222222-2222-4222-8222-222222222222";
 
-const NOTIFICATION_RESPONSE = {
+const NOTIFICATION_RESPONSE: NotificationsResponseType = {
   unreadCount: 1,
   items: [
     {

--- a/src/features/notifications/tests/NotificationBell.test.tsx
+++ b/src/features/notifications/tests/NotificationBell.test.tsx
@@ -8,15 +8,22 @@ import {
   NOTIFICATION_TYPES,
 } from "@/lib/constants/notifications";
 
-const { usePathnameMock } = vi.hoisted(() => ({
+const { routerPushMock, usePathnameMock } = vi.hoisted(() => ({
+  routerPushMock: vi.fn(),
   usePathnameMock: vi.fn(),
 }));
 
 vi.mock("next/navigation", () => ({
   usePathname: usePathnameMock,
+  useRouter: () => ({
+    push: routerPushMock,
+  }),
 }));
 
-import { NotificationBell } from "../components/NotificationBell";
+import {
+  NotificationBell,
+  removeReadNotificationFromResponse,
+} from "../components/NotificationBell";
 
 const USER_A_ID = "11111111-1111-4111-8111-111111111111";
 const USER_B_ID = "22222222-2222-4222-8222-222222222222";
@@ -40,6 +47,7 @@ const NOTIFICATION_RESPONSE = {
     },
   ],
 };
+const NOTIFICATION_ITEM = NOTIFICATION_RESPONSE.items[0]!;
 
 function createJsonResponse(payload: unknown, status = 200) {
   return new Response(JSON.stringify(payload), {
@@ -75,6 +83,7 @@ function renderNotificationBell({
 describe("NotificationBell", () => {
   beforeEach(() => {
     usePathnameMock.mockReset();
+    routerPushMock.mockReset();
     usePathnameMock.mockReturnValue("/notes");
     vi.stubGlobal(
       "fetch",
@@ -206,5 +215,47 @@ describe("NotificationBell", () => {
       expect(fetch).toHaveBeenCalledTimes(3);
     });
     expect(screen.queryByText("Interval note")).not.toBeInTheDocument();
+  });
+});
+
+describe("removeReadNotificationFromResponse", () => {
+  it("removes the matched notification and decreases the unread count", () => {
+    expect(
+      removeReadNotificationFromResponse(
+        {
+          unreadCount: 2,
+          items: [
+            NOTIFICATION_ITEM,
+            {
+              ...NOTIFICATION_ITEM,
+              id: "66666666-6666-4666-8666-666666666666",
+            },
+          ],
+        },
+        "33333333-3333-4333-8333-333333333333",
+      ),
+    ).toEqual({
+      unreadCount: 1,
+      items: [
+        {
+          ...NOTIFICATION_ITEM,
+          id: "66666666-6666-4666-8666-666666666666",
+        },
+      ],
+    });
+  });
+
+  it("keeps the unread count unchanged when the notification is not cached", () => {
+    const response = {
+      unreadCount: 2,
+      items: [NOTIFICATION_ITEM],
+    };
+
+    expect(
+      removeReadNotificationFromResponse(
+        response,
+        "77777777-7777-4777-8777-777777777777",
+      ),
+    ).toBe(response);
   });
 });

--- a/src/features/notifications/tests/NotificationList.test.tsx
+++ b/src/features/notifications/tests/NotificationList.test.tsx
@@ -3,7 +3,6 @@ import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
-  ADMIN_NOTIFICATION_TYPES,
   NOTIFICATION_STATUS,
   NOTIFICATION_TYPES,
 } from "@/lib/constants/notifications";
@@ -24,13 +23,13 @@ vi.mock("../actions", () => ({
   markNotificationAsReadAction: markNotificationAsReadActionMock,
 }));
 
+import type { UserNotificationListItemType } from "../components/NotificationList";
 import { NotificationList } from "../components/NotificationList";
-import type { NotificationListItemType } from "../schema";
 
 const NOTIFICATION_ID = "11111111-1111-4111-8111-111111111111";
 const NOTE_ID = "22222222-2222-4222-8222-222222222222";
 
-function createNotificationItem(): NotificationListItemType {
+function createNotificationItem(): UserNotificationListItemType {
   return {
     id: NOTIFICATION_ID,
     title: "복습할 시간이에요!",
@@ -58,7 +57,6 @@ describe("NotificationList", () => {
 
     expect(screen.getByText("복습할 시간이에요!")).toBeInTheDocument();
     expect(screen.getByText("간격 반복 정리")).toBeInTheDocument();
-    expect(screen.getByText("개인")).toBeInTheDocument();
     expect(screen.getByText("새 알림")).toBeInTheDocument();
     expect(screen.getByRole("link")).toHaveAttribute(
       "href",
@@ -66,46 +64,10 @@ describe("NotificationList", () => {
     );
   });
 
-  it("renders admin notification source labels", () => {
-    render(
-      <NotificationList
-        items={[
-          {
-            ...createNotificationItem(),
-            body: "notifications / dispatch_push / push_send",
-            click_path:
-              "/admin/operational-errors/44444444-4444-4444-8444-444444444444",
-            note_id: null,
-            noteTitle: null,
-            review_log_id: null,
-            source: "ADMIN",
-            title: "Push 알림 전송에 실패했습니다.",
-            type: "OPERATIONAL_ERROR",
-          },
-        ]}
-      />,
-    );
-
-    expect(screen.getByText("관리자")).toBeInTheDocument();
-    expect(
-      screen.getByText("notifications / dispatch_push / push_send"),
-    ).toBeInTheDocument();
-  });
-
   it("uses type labels when a notification has no body or note title", () => {
     render(
       <NotificationList
         items={[
-          {
-            ...createNotificationItem(),
-            body: null,
-            note_id: null,
-            noteTitle: null,
-            review_log_id: null,
-            source: "ADMIN",
-            title: "새 피드백이 도착했습니다.",
-            type: ADMIN_NOTIFICATION_TYPES.FEEDBACK_CREATED,
-          },
           {
             ...createNotificationItem(),
             body: null,
@@ -120,7 +82,6 @@ describe("NotificationList", () => {
       />,
     );
 
-    expect(screen.getByText("사용자 피드백")).toBeInTheDocument();
     expect(screen.getByText("시스템")).toBeInTheDocument();
     expect(screen.queryByText("복습 알림")).not.toBeInTheDocument();
   });
@@ -159,7 +120,7 @@ describe("NotificationList", () => {
       review_log_id: null,
       title: "피드백 답변이 등록되었습니다.",
       type: NOTIFICATION_TYPES.FEEDBACK_REPLY,
-    } satisfies NotificationListItemType;
+    } satisfies UserNotificationListItemType;
     markNotificationAsReadActionMock.mockResolvedValue({
       success: true,
       updated: true,
@@ -198,7 +159,7 @@ describe("NotificationList", () => {
       review_log_id: null,
       title: "피드백 답변이 등록되었습니다.",
       type: NOTIFICATION_TYPES.FEEDBACK_REPLY,
-    } satisfies NotificationListItemType;
+    } satisfies UserNotificationListItemType;
     markNotificationAsReadActionMock.mockRejectedValue(
       new Error("read failed"),
     );

--- a/src/features/notifications/tests/NotificationList.test.tsx
+++ b/src/features/notifications/tests/NotificationList.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
   ADMIN_NOTIFICATION_TYPES,
@@ -8,6 +8,21 @@ import {
   NOTIFICATION_TYPES,
 } from "@/lib/constants/notifications";
 import { getNoteReviewRoute } from "@/lib/constants/routes";
+
+const { markNotificationAsReadActionMock, routerPushMock } = vi.hoisted(() => ({
+  markNotificationAsReadActionMock: vi.fn(),
+  routerPushMock: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: routerPushMock,
+  }),
+}));
+
+vi.mock("../actions", () => ({
+  markNotificationAsReadAction: markNotificationAsReadActionMock,
+}));
 
 import { NotificationList } from "../components/NotificationList";
 import type { NotificationListItemType } from "../schema";
@@ -33,6 +48,11 @@ function createNotificationItem(): NotificationListItemType {
 }
 
 describe("NotificationList", () => {
+  beforeEach(() => {
+    markNotificationAsReadActionMock.mockReset();
+    routerPushMock.mockReset();
+  });
+
   it("renders notification items with review links", () => {
     render(<NotificationList items={[createNotificationItem()]} />);
 
@@ -105,7 +125,7 @@ describe("NotificationList", () => {
     expect(screen.queryByText("복습 알림")).not.toBeInTheDocument();
   });
 
-  it("notifies navigation without marking linked notifications as read", async () => {
+  it("keeps review notifications unread until the review is completed", async () => {
     const user = userEvent.setup();
     const onItemNavigate = vi.fn();
 
@@ -121,12 +141,86 @@ describe("NotificationList", () => {
 
     await user.click(link);
 
-    expect(
-      screen.queryByRole("button", {
-        name: "복습할 시간이에요! 읽음 처리",
-      }),
-    ).not.toBeInTheDocument();
+    expect(markNotificationAsReadActionMock).not.toHaveBeenCalled();
     expect(onItemNavigate).toHaveBeenCalledOnce();
+    expect(routerPushMock).not.toHaveBeenCalled();
+  });
+
+  it("marks feedback reply notifications as read before navigation", async () => {
+    const user = userEvent.setup();
+    const onItemRead = vi.fn();
+    const onItemNavigate = vi.fn();
+    const item = {
+      ...createNotificationItem(),
+      body: "답변이 등록되었습니다.",
+      click_path: "/mypage?feedbackId=feedback-id",
+      note_id: null,
+      noteTitle: null,
+      review_log_id: null,
+      title: "피드백 답변이 등록되었습니다.",
+      type: NOTIFICATION_TYPES.FEEDBACK_REPLY,
+    } satisfies NotificationListItemType;
+    markNotificationAsReadActionMock.mockResolvedValue({
+      success: true,
+      updated: true,
+    });
+
+    render(
+      <NotificationList
+        items={[item]}
+        onItemRead={onItemRead}
+        onItemNavigate={onItemNavigate}
+      />,
+    );
+
+    await user.click(screen.getByRole("link"));
+
+    expect(markNotificationAsReadActionMock).toHaveBeenCalledWith(
+      NOTIFICATION_ID,
+    );
+    expect(onItemRead).toHaveBeenCalledWith(NOTIFICATION_ID);
+    expect(onItemNavigate).toHaveBeenCalledOnce();
+    expect(routerPushMock).toHaveBeenCalledWith(
+      "/mypage?feedbackId=feedback-id",
+    );
+  });
+
+  it("keeps navigation when marking a generic notification as read fails", async () => {
+    const user = userEvent.setup();
+    const onItemRead = vi.fn();
+    const onItemNavigate = vi.fn();
+    const item = {
+      ...createNotificationItem(),
+      body: "답변이 등록되었습니다.",
+      click_path: "/mypage?feedbackId=feedback-id",
+      note_id: null,
+      noteTitle: null,
+      review_log_id: null,
+      title: "피드백 답변이 등록되었습니다.",
+      type: NOTIFICATION_TYPES.FEEDBACK_REPLY,
+    } satisfies NotificationListItemType;
+    markNotificationAsReadActionMock.mockRejectedValue(
+      new Error("read failed"),
+    );
+
+    render(
+      <NotificationList
+        items={[item]}
+        onItemRead={onItemRead}
+        onItemNavigate={onItemNavigate}
+      />,
+    );
+
+    await user.click(screen.getByRole("link"));
+
+    expect(markNotificationAsReadActionMock).toHaveBeenCalledWith(
+      NOTIFICATION_ID,
+    );
+    expect(onItemRead).not.toHaveBeenCalled();
+    expect(onItemNavigate).toHaveBeenCalledOnce();
+    expect(routerPushMock).toHaveBeenCalledWith(
+      "/mypage?feedbackId=feedback-id",
+    );
   });
 
   it("does not mark already-read linked notifications again", async () => {
@@ -151,6 +245,7 @@ describe("NotificationList", () => {
 
     await user.click(link);
 
+    expect(markNotificationAsReadActionMock).not.toHaveBeenCalled();
     expect(onItemNavigate).toHaveBeenCalledOnce();
   });
 

--- a/src/features/notifications/tests/definitions.test.ts
+++ b/src/features/notifications/tests/definitions.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+
+import { buildFeedbackReplyNotificationDefinition } from "../definitions";
+
+describe("notification definitions", () => {
+  it("uses the support inquiry page for feedback reply notification clicks", () => {
+    const definition = buildFeedbackReplyNotificationDefinition({
+      feedbackId: "11111111-1111-4111-8111-111111111111",
+    });
+
+    expect(definition.clickPath).toBe("/mypage?section=support&tab=inquiry");
+  });
+});

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -17,12 +17,21 @@ const serwist = new Serwist({
 
 serwist.addEventListeners();
 
+const NOTIFICATION_READ_API_PATH = "/api/notifications/read";
+const REVIEW_NOTIFICATION_TYPE = "REVIEW";
+
+/**
+ * Returns an object record when the push data shape can be inspected.
+ */
 function getRecord(value: unknown): Record<string, unknown> | null {
   return typeof value === "object" && value !== null
     ? (value as Record<string, unknown>)
     : null;
 }
 
+/**
+ * Normalizes a web push payload into Notification API fields.
+ */
 function getPushPayload(data: PushMessageData | null) {
   if (!data) {
     return {
@@ -52,6 +61,9 @@ function getPushPayload(data: PushMessageData | null) {
   return { body, notificationData, tag, title };
 }
 
+/**
+ * Resolves a safe same-origin URL from notification click data.
+ */
 function getNotificationUrl(data: unknown) {
   const record = getRecord(data);
   const url = typeof record?.url === "string" ? record.url : "/";
@@ -66,6 +78,9 @@ function getNotificationUrl(data: unknown) {
   }
 }
 
+/**
+ * Checks whether a client is a same-origin browser window.
+ */
 function isSameOriginWindowClient(client: Client): client is WindowClient {
   return (
     client.type === "window" &&
@@ -73,6 +88,9 @@ function isSameOriginWindowClient(client: Client): client is WindowClient {
   );
 }
 
+/**
+ * Focuses an existing same-origin tab or opens a new one for the notification.
+ */
 async function openOrFocusNotificationUrl(url: string) {
   const windowClients = await self.clients.matchAll({
     type: "window",
@@ -93,6 +111,36 @@ async function openOrFocusNotificationUrl(url: string) {
   await self.clients.openWindow(url);
 }
 
+/**
+ * Marks a clicked non-review notification as read without blocking navigation.
+ */
+async function markNotificationReadOnClick(data: unknown) {
+  const record = getRecord(data);
+  const notificationId = record?.notificationId;
+  const type = record?.type;
+
+  if (
+    typeof notificationId !== "string" ||
+    typeof type !== "string" ||
+    type === REVIEW_NOTIFICATION_TYPE
+  ) {
+    return;
+  }
+
+  try {
+    await fetch(NOTIFICATION_READ_API_PATH, {
+      method: "POST",
+      credentials: "include",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ notificationId, type }),
+    });
+  } catch {
+    // 읽음 처리는 부가 작업이므로 실패해도 알림 대상 이동은 유지한다.
+  }
+}
+
 self.addEventListener("push", (event) => {
   const { body, notificationData, tag, title } = getPushPayload(event.data);
   const options: NotificationOptions = {
@@ -108,8 +156,14 @@ self.addEventListener("push", (event) => {
 });
 
 self.addEventListener("notificationclick", (event) => {
+  const notificationData = event.notification.data;
   const url = getNotificationUrl(event.notification.data);
 
   event.notification.close();
-  event.waitUntil(openOrFocusNotificationUrl(url));
+  event.waitUntil(
+    Promise.all([
+      markNotificationReadOnClick(notificationData),
+      openOrFocusNotificationUrl(url),
+    ]).then(() => undefined),
+  );
 });

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -93,6 +93,47 @@ export type Database = {
           },
         ];
       };
+      feedback_replies: {
+        Row: {
+          content: string;
+          created_at: string;
+          created_by: string;
+          feedback_id: string;
+          id: string;
+          image_paths: string[];
+          title: string;
+          updated_at: string;
+        };
+        Insert: {
+          content: string;
+          created_at?: string;
+          created_by: string;
+          feedback_id: string;
+          id?: string;
+          image_paths?: string[];
+          title: string;
+          updated_at?: string;
+        };
+        Update: {
+          content?: string;
+          created_at?: string;
+          created_by?: string;
+          feedback_id?: string;
+          id?: string;
+          image_paths?: string[];
+          title?: string;
+          updated_at?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "feedback_replies_feedback_id_fkey";
+            columns: ["feedback_id"];
+            isOneToOne: true;
+            referencedRelation: "feedbacks";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
       feedbacks: {
         Row: {
           category: string;
@@ -136,47 +177,6 @@ export type Database = {
             columns: ["note_id"];
             isOneToOne: false;
             referencedRelation: "notes";
-            referencedColumns: ["id"];
-          },
-        ];
-      };
-      feedback_replies: {
-        Row: {
-          content: string;
-          created_at: string;
-          created_by: string;
-          feedback_id: string;
-          id: string;
-          image_paths: string[];
-          title: string;
-          updated_at: string;
-        };
-        Insert: {
-          content: string;
-          created_at?: string;
-          created_by: string;
-          feedback_id: string;
-          id?: string;
-          image_paths?: string[];
-          title: string;
-          updated_at?: string;
-        };
-        Update: {
-          content?: string;
-          created_at?: string;
-          created_by?: string;
-          feedback_id?: string;
-          id?: string;
-          image_paths?: string[];
-          title?: string;
-          updated_at?: string;
-        };
-        Relationships: [
-          {
-            foreignKeyName: "feedback_replies_feedback_id_fkey";
-            columns: ["feedback_id"];
-            isOneToOne: true;
-            referencedRelation: "feedbacks";
             referencedColumns: ["id"];
           },
         ];
@@ -277,6 +277,44 @@ export type Database = {
           },
         ];
       };
+      operational_error_status_history: {
+        Row: {
+          changed_by: string | null;
+          created_at: string;
+          from_status: string | null;
+          id: string;
+          note: string | null;
+          operational_error_id: string;
+          to_status: string;
+        };
+        Insert: {
+          changed_by?: string | null;
+          created_at?: string;
+          from_status?: string | null;
+          id?: string;
+          note?: string | null;
+          operational_error_id: string;
+          to_status: string;
+        };
+        Update: {
+          changed_by?: string | null;
+          created_at?: string;
+          from_status?: string | null;
+          id?: string;
+          note?: string | null;
+          operational_error_id?: string;
+          to_status?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "operational_error_status_history_error_id_fkey";
+            columns: ["operational_error_id"];
+            isOneToOne: false;
+            referencedRelation: "operational_errors";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
       operational_errors: {
         Row: {
           actor_user_id: string | null;
@@ -346,44 +384,6 @@ export type Database = {
         };
         Relationships: [];
       };
-      operational_error_status_history: {
-        Row: {
-          changed_by: string | null;
-          created_at: string;
-          from_status: string | null;
-          id: string;
-          note: string | null;
-          operational_error_id: string;
-          to_status: string;
-        };
-        Insert: {
-          changed_by?: string | null;
-          created_at?: string;
-          from_status?: string | null;
-          id?: string;
-          note?: string | null;
-          operational_error_id: string;
-          to_status: string;
-        };
-        Update: {
-          changed_by?: string | null;
-          created_at?: string;
-          from_status?: string | null;
-          id?: string;
-          note?: string | null;
-          operational_error_id?: string;
-          to_status?: string;
-        };
-        Relationships: [
-          {
-            foreignKeyName: "operational_error_status_history_error_id_fkey";
-            columns: ["operational_error_id"];
-            isOneToOne: false;
-            referencedRelation: "operational_errors";
-            referencedColumns: ["id"];
-          },
-        ];
-      };
       profiles: {
         Row: {
           avatar_url: string | null;
@@ -411,33 +411,6 @@ export type Database = {
           nickname?: string;
           role?: string;
           updated_at?: string;
-        };
-        Relationships: [];
-      };
-      user_agreements: {
-        Row: {
-          created_at: string;
-          privacy_agreed_at: string;
-          source: string;
-          terms_agreed_at: string;
-          updated_at: string;
-          user_id: string;
-        };
-        Insert: {
-          created_at?: string;
-          privacy_agreed_at: string;
-          source: string;
-          terms_agreed_at: string;
-          updated_at?: string;
-          user_id: string;
-        };
-        Update: {
-          created_at?: string;
-          privacy_agreed_at?: string;
-          source?: string;
-          terms_agreed_at?: string;
-          updated_at?: string;
-          user_id?: string;
         };
         Relationships: [];
       };
@@ -521,6 +494,33 @@ export type Database = {
           },
         ];
       };
+      user_agreements: {
+        Row: {
+          created_at: string;
+          privacy_agreed_at: string;
+          source: string;
+          terms_agreed_at: string;
+          updated_at: string;
+          user_id: string;
+        };
+        Insert: {
+          created_at?: string;
+          privacy_agreed_at: string;
+          source: string;
+          terms_agreed_at: string;
+          updated_at?: string;
+          user_id: string;
+        };
+        Update: {
+          created_at?: string;
+          privacy_agreed_at?: string;
+          source?: string;
+          terms_agreed_at?: string;
+          updated_at?: string;
+          user_id?: string;
+        };
+        Relationships: [];
+      };
     };
     Views: {
       [_ in never]: never;
@@ -587,8 +587,16 @@ export type Database = {
         Args: { p_content: string; p_scheduled_at: string; p_title: string };
         Returns: string;
       };
+      delete_feedback_reply_with_notifications: {
+        Args: { p_feedback_id: string };
+        Returns: {
+          deleted_notification_count: number;
+          image_paths: string[];
+        }[];
+      };
       is_current_user_email_confirmed: { Args: never; Returns: boolean };
       kst_date: { Args: { ts: string }; Returns: string };
+      kst_day_start: { Args: { ts: string }; Returns: string };
       mark_notification_as_read: {
         Args: { p_notification_id: string };
         Returns: boolean;

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -601,6 +601,10 @@ export type Database = {
         Args: { p_notification_id: string };
         Returns: boolean;
       };
+      mark_all_admin_notifications_as_read: {
+        Args: { p_admin_user_id: string };
+        Returns: number;
+      };
       update_notification_time_of_day: {
         Args: { p_note_id: string; p_time?: string };
         Returns: undefined;

--- a/supabase/migrations/20260727102238_delete_feedback_reply_with_notifications.sql
+++ b/supabase/migrations/20260727102238_delete_feedback_reply_with_notifications.sql
@@ -1,0 +1,103 @@
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.mark_notification_as_read(p_notification_id uuid)
+RETURNS boolean
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_user_id uuid := auth.uid();
+  v_email_confirmed_at timestamptz;
+BEGIN
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'not authenticated';
+  END IF;
+
+  SELECT email_confirmed_at
+    INTO v_email_confirmed_at
+  FROM auth.users
+  WHERE id = v_user_id;
+
+  IF v_email_confirmed_at IS NULL THEN
+    RAISE EXCEPTION 'email not confirmed';
+  END IF;
+
+  UPDATE public.notifications
+  SET status = 'READ',
+      read_at = COALESCE(read_at, clock_timestamp())
+  WHERE id = p_notification_id
+    AND user_id = v_user_id
+    AND status = 'SENT'
+    AND type <> 'REVIEW';
+
+  RETURN FOUND;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.mark_notification_as_read(uuid)
+  FROM PUBLIC, anon, authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.mark_notification_as_read(uuid)
+  TO authenticated;
+
+CREATE OR REPLACE FUNCTION public.delete_feedback_reply_with_notifications(
+  p_feedback_id uuid
+)
+RETURNS TABLE (
+  image_paths text[],
+  deleted_notification_count integer
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_feedback_user_id uuid;
+  v_reply_id uuid;
+  v_image_paths text[];
+BEGIN
+  SELECT f.user_id
+    INTO v_feedback_user_id
+  FROM public.feedbacks AS f
+  WHERE f.id = p_feedback_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'feedback_not_found';
+  END IF;
+
+  SELECT fr.id, fr.image_paths
+    INTO v_reply_id, v_image_paths
+  FROM public.feedback_replies AS fr
+  WHERE fr.feedback_id = p_feedback_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'feedback_reply_not_found';
+  END IF;
+
+  DELETE FROM public.notifications AS n
+  WHERE n.user_id = v_feedback_user_id
+    AND n.type = 'FEEDBACK_REPLY'
+    AND n.metadata->>'feedbackId' = p_feedback_id::text;
+
+  GET DIAGNOSTICS deleted_notification_count = ROW_COUNT;
+
+  DELETE FROM public.feedback_replies AS fr
+  WHERE fr.id = v_reply_id;
+
+  UPDATE public.feedbacks AS f
+  SET status = 'OPEN'
+  WHERE f.id = p_feedback_id;
+
+  image_paths := COALESCE(v_image_paths, '{}'::text[]);
+  RETURN NEXT;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.delete_feedback_reply_with_notifications(uuid)
+  FROM PUBLIC, anon, authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.delete_feedback_reply_with_notifications(uuid)
+  TO service_role;
+
+COMMIT;

--- a/supabase/migrations/20260731000000_add_mark_all_admin_notifications_as_read_rpc.sql
+++ b/supabase/migrations/20260731000000_add_mark_all_admin_notifications_as_read_rpc.sql
@@ -1,0 +1,44 @@
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.mark_all_admin_notifications_as_read(
+  p_admin_user_id uuid
+)
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_inserted_count integer := 0;
+BEGIN
+  INSERT INTO public.admin_notification_reads (
+    event_id,
+    admin_user_id
+  )
+  SELECT
+    event.id,
+    p_admin_user_id
+  FROM public.admin_notification_events AS event
+  WHERE NOT EXISTS (
+    SELECT 1
+    FROM public.admin_notification_reads AS read
+    WHERE read.event_id = event.id
+      AND read.admin_user_id = p_admin_user_id
+  );
+
+  GET DIAGNOSTICS v_inserted_count = ROW_COUNT;
+
+  RETURN v_inserted_count;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.mark_all_admin_notifications_as_read(uuid)
+  FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.mark_all_admin_notifications_as_read(uuid)
+  FROM anon;
+REVOKE ALL ON FUNCTION public.mark_all_admin_notifications_as_read(uuid)
+  FROM authenticated;
+GRANT ALL ON FUNCTION public.mark_all_admin_notifications_as_read(uuid)
+  TO service_role;
+
+COMMIT;

--- a/supabase/tests/notifications/admin_notification_rpcs.sql
+++ b/supabase/tests/notifications/admin_notification_rpcs.sql
@@ -4,7 +4,7 @@
 
 BEGIN;
 
-SELECT plan(9);
+SELECT plan(13);
 
 SELECT set_config('test.admin_notification_rpc_admin_id', gen_random_uuid()::text, true);
 SELECT set_config('test.admin_notification_rpc_read_event_id', gen_random_uuid()::text, true);
@@ -52,6 +52,23 @@ VALUES (
   now()
 )
 ON CONFLICT (id) DO NOTHING;
+
+-- Isolate this test user from admin notification events that may already exist
+-- in the local database before this pgTAP file runs.
+INSERT INTO public.admin_notification_reads (
+  event_id,
+  admin_user_id
+)
+SELECT
+  event.id,
+  current_setting('test.admin_notification_rpc_admin_id')::uuid
+FROM public.admin_notification_events AS event
+WHERE event.id NOT IN (
+  current_setting('test.admin_notification_rpc_read_event_id')::uuid,
+  current_setting('test.admin_notification_rpc_error_event_id')::uuid,
+  current_setting('test.admin_notification_rpc_feedback_event_id')::uuid
+)
+ON CONFLICT (event_id, admin_user_id) DO NOTHING;
 
 INSERT INTO public.admin_notification_events (
   id,
@@ -188,6 +205,43 @@ SELECT is(
   ),
   1::bigint,
   $$list RPC should clamp non-positive limits to one row$$
+);
+
+SELECT ok(
+  to_regprocedure('public.mark_all_admin_notifications_as_read(uuid)') IS NOT NULL,
+  $$mark_all_admin_notifications_as_read should exist$$
+);
+
+SELECT is(
+  public.mark_all_admin_notifications_as_read(
+    current_setting('test.admin_notification_rpc_admin_id')::uuid
+  ),
+  2,
+  $$mark all RPC should insert read rows only for unread events$$
+);
+
+SELECT is(
+  (
+    SELECT count(*)::integer
+    FROM public.admin_notification_reads
+    WHERE admin_user_id =
+      current_setting('test.admin_notification_rpc_admin_id')::uuid
+      AND event_id IN (
+        current_setting('test.admin_notification_rpc_read_event_id')::uuid,
+        current_setting('test.admin_notification_rpc_error_event_id')::uuid,
+        current_setting('test.admin_notification_rpc_feedback_event_id')::uuid
+      )
+  ),
+  3,
+  $$mark all RPC should keep the existing read row and add only unread rows$$
+);
+
+SELECT is(
+  public.mark_all_admin_notifications_as_read(
+    current_setting('test.admin_notification_rpc_admin_id')::uuid
+  ),
+  0,
+  $$mark all RPC should be idempotent after all events are read$$
 );
 
 SELECT * FROM finish();

--- a/supabase/tests/notifications/delete_feedback_reply_with_notifications.sql
+++ b/supabase/tests/notifications/delete_feedback_reply_with_notifications.sql
@@ -1,0 +1,179 @@
+-- ==================================================
+-- notifications / delete_feedback_reply_with_notifications
+-- ==================================================
+
+BEGIN;
+
+SELECT plan(6);
+
+SELECT set_config('test.delete_reply_user_id', gen_random_uuid()::text, true);
+SELECT set_config('test.delete_reply_other_user_id', gen_random_uuid()::text, true);
+SELECT set_config('test.delete_reply_feedback_id', gen_random_uuid()::text, true);
+SELECT set_config('test.delete_reply_other_feedback_id', gen_random_uuid()::text, true);
+SELECT set_config('test.delete_reply_reply_id', gen_random_uuid()::text, true);
+SELECT set_config('test.delete_reply_notification_id', gen_random_uuid()::text, true);
+SELECT set_config('test.delete_reply_other_user_notification_id', gen_random_uuid()::text, true);
+SELECT set_config('test.delete_reply_other_type_notification_id', gen_random_uuid()::text, true);
+
+INSERT INTO auth.users (id, email, email_confirmed_at, raw_user_meta_data)
+VALUES
+  (
+    current_setting('test.delete_reply_user_id')::uuid,
+    'delete_reply_' || current_setting('test.delete_reply_user_id') || '@example.com',
+    now(),
+    '{}'::jsonb
+  ),
+  (
+    current_setting('test.delete_reply_other_user_id')::uuid,
+    'delete_reply_other_' || current_setting('test.delete_reply_other_user_id') || '@example.com',
+    now(),
+    '{}'::jsonb
+  )
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO public.feedbacks (id, user_id, category, title, content, status)
+VALUES
+  (
+    current_setting('test.delete_reply_feedback_id')::uuid,
+    current_setting('test.delete_reply_user_id')::uuid,
+    'ETC',
+    'feedback title',
+    'feedback content',
+    'RESOLVED'
+  ),
+  (
+    current_setting('test.delete_reply_other_feedback_id')::uuid,
+    current_setting('test.delete_reply_other_user_id')::uuid,
+    'ETC',
+    'other feedback title',
+    'other feedback content',
+    'RESOLVED'
+  );
+
+INSERT INTO public.feedback_replies (
+  id,
+  feedback_id,
+  title,
+  content,
+  image_paths,
+  created_by
+)
+VALUES (
+  current_setting('test.delete_reply_reply_id')::uuid,
+  current_setting('test.delete_reply_feedback_id')::uuid,
+  'reply title',
+  'reply content',
+  ARRAY['feedback/reply-a.png', 'feedback/reply-b.png'],
+  current_setting('test.delete_reply_other_user_id')::uuid
+);
+
+INSERT INTO public.notifications (
+  id,
+  user_id,
+  type,
+  title,
+  body,
+  status,
+  click_path,
+  metadata
+)
+VALUES
+  (
+    current_setting('test.delete_reply_notification_id')::uuid,
+    current_setting('test.delete_reply_user_id')::uuid,
+    'FEEDBACK_REPLY',
+    'reply notification',
+    'reply body',
+    'SENT',
+    '/mypage?section=support&tab=inquiry',
+    jsonb_build_object('feedbackId', current_setting('test.delete_reply_feedback_id'))
+  ),
+  (
+    current_setting('test.delete_reply_other_user_notification_id')::uuid,
+    current_setting('test.delete_reply_other_user_id')::uuid,
+    'FEEDBACK_REPLY',
+    'other user notification',
+    'other body',
+    'SENT',
+    '/mypage?section=support&tab=inquiry',
+    jsonb_build_object('feedbackId', current_setting('test.delete_reply_feedback_id'))
+  ),
+  (
+    current_setting('test.delete_reply_other_type_notification_id')::uuid,
+    current_setting('test.delete_reply_user_id')::uuid,
+    'SYSTEM',
+    'system notification',
+    'system body',
+    'SENT',
+    '/',
+    jsonb_build_object('feedbackId', current_setting('test.delete_reply_feedback_id'))
+  );
+
+SET LOCAL ROLE service_role;
+
+SELECT results_eq(
+  format(
+    $sql$
+      SELECT image_paths, deleted_notification_count
+      FROM public.delete_feedback_reply_with_notifications('%s'::uuid);
+    $sql$,
+    current_setting('test.delete_reply_feedback_id')
+  ),
+  $$VALUES (ARRAY['feedback/reply-a.png', 'feedback/reply-b.png']::text[], 1)$$,
+  $$RPC should return deleted reply image paths and notification count$$
+);
+
+RESET ROLE;
+
+SELECT is(
+  (
+    SELECT status
+    FROM public.feedbacks
+    WHERE id = current_setting('test.delete_reply_feedback_id')::uuid
+  ),
+  'OPEN',
+  $$RPC should reopen the feedback$$
+);
+
+SELECT is(
+  (
+    SELECT count(*)::integer
+    FROM public.feedback_replies
+    WHERE feedback_id = current_setting('test.delete_reply_feedback_id')::uuid
+  ),
+  0,
+  $$RPC should delete the reply row$$
+);
+
+SELECT is(
+  (
+    SELECT count(*)::integer
+    FROM public.notifications
+    WHERE id = current_setting('test.delete_reply_notification_id')::uuid
+  ),
+  0,
+  $$RPC should delete the matching FEEDBACK_REPLY notification$$
+);
+
+SELECT is(
+  (
+    SELECT count(*)::integer
+    FROM public.notifications
+    WHERE id = current_setting('test.delete_reply_other_user_notification_id')::uuid
+  ),
+  1,
+  $$RPC should not delete another user's notification$$
+);
+
+SELECT is(
+  (
+    SELECT count(*)::integer
+    FROM public.notifications
+    WHERE id = current_setting('test.delete_reply_other_type_notification_id')::uuid
+  ),
+  1,
+  $$RPC should not delete another notification type$$
+);
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/supabase/tests/notifications/mark_notification_as_read.sql
+++ b/supabase/tests/notifications/mark_notification_as_read.sql
@@ -4,13 +4,15 @@
 
 BEGIN;
 
-SELECT plan(6);
+SELECT plan(8);
 
 SELECT set_config('test.mark_read_user_a_id', gen_random_uuid()::text, true);
 SELECT set_config('test.mark_read_user_b_id', gen_random_uuid()::text, true);
 SELECT set_config('test.mark_read_unverified_user_id', gen_random_uuid()::text, true);
 SELECT set_config('test.mark_read_notification_a_id', gen_random_uuid()::text, true);
 SELECT set_config('test.mark_read_notification_b_id', gen_random_uuid()::text, true);
+SELECT set_config('test.mark_read_review_notification_id', gen_random_uuid()::text, true);
+SELECT set_config('test.mark_read_review_note_id', gen_random_uuid()::text, true);
 SELECT set_config('test.mark_read_notification_unverified_id', gen_random_uuid()::text, true);
 
 INSERT INTO auth.users (id, email, email_confirmed_at, raw_user_meta_data)
@@ -35,8 +37,16 @@ VALUES
   )
 ON CONFLICT (id) DO NOTHING;
 
+INSERT INTO public.notes (id, user_id, title, content)
+VALUES (
+  current_setting('test.mark_read_review_note_id')::uuid,
+  current_setting('test.mark_read_user_a_id')::uuid,
+  'review note',
+  'review note content'
+);
+
 INSERT INTO public.notifications (id, user_id, type, title, body, status,
-  click_path)
+  click_path, note_id)
 VALUES
   (
     current_setting('test.mark_read_notification_a_id')::uuid,
@@ -44,27 +54,40 @@ VALUES
     'SYSTEM',
     'a title',
     'a body',
-    'SENT'
-  ,
-  '/test'),
+    'SENT',
+    '/test',
+    NULL
+  ),
   (
     current_setting('test.mark_read_notification_b_id')::uuid,
     current_setting('test.mark_read_user_b_id')::uuid,
     'SYSTEM',
     'b title',
     'b body',
-    'SENT'
-  ,
-  '/test'),
+    'SENT',
+    '/test',
+    NULL
+  ),
+  (
+    current_setting('test.mark_read_review_notification_id')::uuid,
+    current_setting('test.mark_read_user_a_id')::uuid,
+    'REVIEW',
+    'review title',
+    'review body',
+    'SENT',
+    '/notes/' || current_setting('test.mark_read_review_note_id') || '/review',
+    current_setting('test.mark_read_review_note_id')::uuid
+  ),
   (
     current_setting('test.mark_read_notification_unverified_id')::uuid,
     current_setting('test.mark_read_unverified_user_id')::uuid,
     'SYSTEM',
     'unverified title',
     'unverified body',
-    'SENT'
-  ,
-  '/test');
+    'SENT',
+    '/test',
+    NULL
+  );
 
 SET LOCAL ROLE authenticated;
 SELECT set_config(
@@ -99,6 +122,23 @@ SELECT is(
   ),
   false,
   $$mark_notification_as_read should return false when the notification is already READ$$
+);
+
+SELECT is(
+  public.mark_notification_as_read(
+    current_setting('test.mark_read_review_notification_id')::uuid
+  ),
+  false,
+  $$mark_notification_as_read should return false for REVIEW notifications$$
+);
+
+SELECT ok(
+  (
+    SELECT status = 'SENT' AND read_at IS NULL
+    FROM public.notifications
+    WHERE id = current_setting('test.mark_read_review_notification_id')::uuid
+  ),
+  $$mark_notification_as_read should leave REVIEW notifications unread$$
 );
 
 SELECT is(


### PR DESCRIPTION
## 개요

피드백 답변 등록/수정 시 사용자에게 알림을 전달하고, 일반 사용자 알림과 관리자 알림을 분리해 각각 읽음 처리할 수 있도록 개선했습니다. 관리자 알림의 전체 읽음 처리는 DB RPC로 이동해 unread 이벤트만 원자적으로 처리하도록 최적화했습니다.

## PR 유형

- [x] 새로운 기능 추가
- [x] 버그 수정
- [x] UI 디자인 변경
- [x] 코드 리팩토링
- [x] 테스트 추가/수정
- [ ] 문서 수정
- [ ] 빌드/패키지 설정 변경

## 관련 이슈

closes #263

## 작업 내용

- 피드백 답변 최초 등록 시 사용자 알림을 생성하도록 추가
- 기존 답변 수정 시 관리자가 `사용자에게 알림 전송` 여부를 선택할 수 있도록 UI 추가
- 피드백 답변 삭제 시 관련 사용자 알림까지 함께 정리하는 DB RPC 추가
- 일반 알림 클릭 시 `REVIEW` 외 알림을 읽음 처리하도록 API/RPC/클라이언트 흐름 추가
- 서비스 워커 푸시 알림 클릭 시 일반 알림 읽음 처리 연동
- 사용자 알림 Bell과 관리자 알림 Bell을 분리
- 관리자 알림 목록/카운트 query key 및 읽음 처리 mutation 정리
- 관리자 알림 전체 읽음 처리를 `mark_all_admin_notifications_as_read` RPC로 이동
  - 전체 이벤트를 앱으로 조회하지 않고 DB에서 unread 이벤트만 `INSERT ... SELECT`
  - 이미 읽은 이벤트는 재처리하지 않도록 idempotent 처리
- 관련 Vitest 및 Supabase pgTAP 테스트 추가/수정

## 테스트 방법

- `npm exec vitest run src/features/admin/notifications/actions.test.ts`
  - 관리자 알림 개별/전체 읽음 처리 Server Action 검증
- `npm exec supabase test db -- --local supabase/tests/notifications/admin_notification_rpcs.sql`
  - 관리자 알림 unread count/list RPC 및 전체 읽음 RPC 검증
- `npm run type-check`
  - TypeScript 타입 검사 통과
- `git diff --check development...HEAD`
  - whitespace 문제 없음 확인


## 스크린샷 (FE 변경 시)

- 관리자 헤더에 일반 알림 Bell과 관리자 알림 Bell이 분리되어 표시됩니다.
- 관리자 피드백 답변 수정 폼에 `사용자에게 알림 전송` 체크박스가 추가되었습니다.

## 리뷰 요구사항 (선택)

- 일반 사용자 알림과 관리자 알림의 읽음 처리 경계가 의도대로 분리되어 있는지 확인 부탁드립니다.
- `mark_all_admin_notifications_as_read` RPC가 unread 이벤트만 처리하고 기존 read row를 재처리하지 않는지 확인 부탁드립니다.
- 피드백 답변 삭제 시 사용자 알림 정리 범위가 `FEEDBACK_REPLY + feedbackId metadata` 기준으로 충분한지 확인 부탁드립니다.

## 체크리스트

- [x] 코드 컨벤션 준수
- [x] 커밋 메시지 컨벤션 준수
- [ ] lint 통과
- [x] typecheck 통과
- [x] (DB 변경 시) migration 포함 및 로컬 재현 확인
- [x] (권한/RLS 영향 시) 정책 변경 요약 기재
- [x] UI 변경 시 스크린샷/짧은 설명 첨부
- [x] 셀프 리뷰 완료