### PR TITLE
fix: #289 - 헤더 반응형 레이아웃 줄바꿈 수정

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -25,7 +25,8 @@ export async function Header() {
 
   return (
     <header className="sticky top-0 z-50 border-b bg-background/80 backdrop-blur-sm">
-      <div className="flex justify-between md:grid md:grid-cols-3 items-center max-w-5xl mx-auto px-6 py-3.5">
+      {/* 가운데 열은 auto — 1fr 균등 분할 시 768~917px 구간에서 NotesNav가 줄바꿈됨 */}
+      <div className="flex justify-between md:grid md:grid-cols-[1fr_auto_1fr] items-center max-w-5xl mx-auto px-6 py-3.5">
         <Link href={ROUTES.HOME} className="flex items-center gap-2">
           <Image src="/favicon.svg" alt="딱다구리" width={28} height={28} />
           {/* font-jeju: 브랜드 폰트(JejuStoneWall), globals.css @font-face 참조 */}
@@ -69,13 +70,14 @@ export async function Header() {
 export function HeaderSkeleton() {
   return (
     <header className="sticky top-0 z-50 border-b bg-background/80 backdrop-blur-sm">
-      <div className="grid grid-cols-3 items-center max-w-5xl mx-auto px-6 py-3.5">
+      {/* 레이아웃 클래스는 Header와 동일하게 유지 — 로딩 → 렌더 전환 시 위치가 흔들리지 않도록 */}
+      <div className="flex justify-between md:grid md:grid-cols-[1fr_auto_1fr] items-center max-w-5xl mx-auto px-6 py-3.5">
         <div className="flex items-center gap-2">
           <div className="size-7 rounded bg-muted animate-pulse" />
           <div className="h-6 w-20 rounded bg-muted animate-pulse" />
         </div>
         <div />
-        <div className="flex justify-end gap-3">
+        <div className="flex justify-end gap-3 items-center">
           <div className="h-9 w-16 rounded bg-muted animate-pulse" />
           <div className="h-9 w-20 rounded bg-muted animate-pulse" />
         </div>

--- a/src/components/layout/NotesNav.tsx
+++ b/src/components/layout/NotesNav.tsx
@@ -16,7 +16,7 @@ export function NotesNav() {
   const isNotesToday = pathname === ROUTES.NOTES_TODAY;
 
   return (
-    <nav className="flex items-center gap-6">
+    <nav className="flex items-center gap-6 whitespace-nowrap">
       <Link
         href={ROUTES.NOTES}
         aria-current={isNotesList ? "page" : undefined}


### PR DESCRIPTION
## 개요

뷰포트 너비 **768px ~ 917px** 구간에서 헤더 내비게이션(`NotesNav`)의 링크 텍스트가 두 줄로 줄바꿈되면서 헤더 높이가 비정상적으로 커지는 문제를 수정합니다.

원인은 `Header.tsx`의 `md:grid-cols-3`입니다. 3열을 균등(1fr)으로 분할하기 때문에 768px에서 가운데 열 폭이 `(768 - 48(px-6 좌우 패딩)) / 3 = 240px`밖에 되지 않습니다. 반면 `NotesNav`는 "노트 목록 / 오늘의 복습 / + 새 노트" 3개 링크 + `gap-6`(24px × 2) + `+ 새 노트`의 좌우 패딩까지 합쳐 약 300px 이상이 필요합니다. 가운데 열이 필요 폭보다 좁아 각 링크가 줄바꿈되고, 그만큼 헤더 전체 높이가 늘어났습니다. 약 918px부터 가운데 열이 290px를 넘기면서 자연스럽게 해소됩니다.

가운데 열을 `auto`로 바꿔 콘텐츠 폭만큼만 차지하게 하고, 좌우 열이 `1fr`로 나머지를 균등하게 나눠 갖도록 해 **중앙 정렬은 그대로 유지**하면서 줄바꿈을 없앴습니다.

## PR 유형

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [x] UI 디자인 변경
- [ ] 코드 리팩토링
- [ ] 테스트 추가/수정
- [ ] 문서 수정
- [ ] 빌드/패키지 설정 변경

## 관련 이슈

closes #289

## 작업 내용

### `src/components/layout/Header.tsx`

- `Header`: 컨테이너의 `md:grid-cols-3` → `md:grid-cols-[1fr_auto_1fr]`로 변경했습니다. 가운데 열이 `NotesNav`의 실제 폭만큼만 차지하므로 768px에서도 줄바꿈이 발생하지 않습니다. 좌우가 동일하게 `1fr`이라 중앙 정렬은 유지됩니다. 변경 의도를 주석으로 남겼습니다.
- `HeaderSkeleton`: 레이아웃 클래스를 실제 `Header`와 동일하게(`flex justify-between md:grid md:grid-cols-[1fr_auto_1fr]`) 맞췄습니다. 기존에는 모든 너비에서 `grid grid-cols-3`이라 실제 헤더(`md` 미만에서 `flex justify-between`)와 배치가 달라, 로딩 → 렌더 전환 시 로고와 우측 아바타 위치가 미세하게 흔들렸습니다. 우측 블록에도 `items-center`를 추가해 정렬을 일치시켰습니다.

### `src/components/layout/NotesNav.tsx`

- `nav`에 `whitespace-nowrap`을 추가했습니다. 향후 메뉴 항목이 늘거나 가운데 열이 좁아지는 상황에서도 줄바꿈 대신 폭을 확보하도록 하는 안전장치입니다.

## 테스트 방법

1. `npm run dev` 실행 후 로그인한 상태로 `/notes`에 접속합니다.
2. 개발자 도구 반응형 모드에서 너비를 **768px**로 설정하고, 헤더의 "노트 목록 / 오늘의 복습 / + 새 노트"가 **한 줄**로 유지되며 헤더 높이가 늘어나지 않는지 확인합니다.
3. 너비를 **768 → 900 → 1024 → 1280px**으로 늘리며 헤더 높이가 일정하고 내비게이션이 계속 중앙에 정렬되는지 확인합니다.
4. 너비를 **767px 이하**로 줄여 내비게이션이 숨겨지고 아바타 드롭다운의 노트 메뉴로 대체되는 기존 동작이 그대로인지 확인합니다.
5. 새로고침 시 `HeaderSkeleton` → `Header` 전환 과정에서 로고·아바타 위치가 흔들리지 않는지 확인합니다.

**검증 완료 항목**

| 항목                     | 결과                          |
| ------------------------ | ----------------------------- |
| `npm run lint`           | 통과                          |
| `npx prettier --check .` | 통과                          |
| `npm run type-check`     | 통과                          |
| `npx vitest run`         | 212 파일 / 2014 테스트 통과   |
| `npm run build`          | 통과                          |

## 스크린샷 (FE 변경 시)
<img width="998" height="197" alt="스크린샷 2026-08-05 201620" src="https://github.com/user-attachments/assets/090f9c02-23f1-43ee-a559-12b5eaa55891" />
<img width="1172" height="173" alt="스크린샷 2026-08-05 201630" src="https://github.com/user-attachments/assets/baaf37be-a3f1-46d4-99ae-10455f25f264" />



## 리뷰 요구사항 (선택)

- `md:grid-cols-[1fr_auto_1fr]` 방식 외에, `NotesNav` 노출 브레이크포인트를 `lg:`로 올리고 768~1023px 구간은 아바타 드롭다운 메뉴(현재 `md:hidden`인 노트 메뉴)를 쓰게 하는 대안도 검토했습니다. 헤더는 단순해지지만 태블릿 구간에서 내비게이션이 한 단계 숨겨져 접근성이 떨어진다고 판단해 현재 방식을 택했습니다. 이 판단에 이견이 있으면 알려주세요.
- `HeaderSkeleton`의 레이아웃 클래스를 `Header`와 맞춘 것은 이번 이슈의 직접 원인은 아니지만, 같은 파일의 동일한 성격의 불일치라 함께 처리했습니다. 범위를 벗어난다고 보시면 분리하겠습니다.

## 체크리스트

- [x] 코드 컨벤션 준수
- [x] 커밋 메시지 컨벤션 준수
- [x] lint 통과
- [x] typecheck 통과
- [ ] (DB 변경 시) migration 포함 및 로컬 재현 확인 <!-- 해당 없음: DB 변경 없음 -->
- [ ] (권한/RLS 영향 시) 정책 변경 요약 기재 <!-- 해당 없음: 권한/RLS 영향 없음 -->
- [x] UI 변경 시 스크린샷/짧은 설명 첨부 <!-- 확인 필요: 스크린샷 첨부 후 체크 -->
- [x] 셀프 리뷰 완료
