### PR TITLE
revert: #291 - 노트 상세 페이지 breadcrumb 되돌리기

### DIFF
--- a/src/app/(main)/notes/[noteId]/page.test.tsx
+++ b/src/app/(main)/notes/[noteId]/page.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, within } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { getNoteReviewRoute, ROUTES } from "@/lib/constants/routes";
@@ -172,43 +172,6 @@ describe("NoteDetailPage", () => {
     expect(
       screen.getByRole("button", { name: "노트 삭제" }),
     ).toBeInTheDocument();
-  });
-
-  it("renders a breadcrumb linking back to home and the notes list", async () => {
-    // 공백이 없어 줄바꿈으로 도망갈 수 없는 제목. truncate가 빠지면 breadcrumb 줄을 밀어버린다.
-    const longTitle =
-      "SupabaseRowLevelSecurityPolicyMigrationChecklistForNoteReviewSchedulingRpcAndPartialUniqueIndexes";
-    createClientMock.mockResolvedValue(createSupabaseMock("user-123"));
-    getNoteByIdMock.mockResolvedValue({
-      id: "note-123",
-      title: longTitle,
-      content: "note body",
-      next_review_at: "2026-03-29T00:00:00.000Z",
-      next_scheduled_at: "2026-03-29T09:00:00.000Z",
-      notification_time_of_day: "21:30:00",
-      review_round: 1,
-      created_at: "2026-03-29T00:00:00.000Z",
-      updated_at: "2026-03-29T01:00:00.000Z",
-      user_id: "user-123",
-    });
-
-    render(
-      await NoteDetailPage({ params: Promise.resolve({ noteId: "note-123" }) }),
-    );
-
-    const breadcrumb = screen.getByRole("navigation", { name: "breadcrumb" });
-    expect(
-      within(breadcrumb).getByRole("link", { name: "홈" }),
-    ).toHaveAttribute("href", ROUTES.HOME);
-    expect(
-      within(breadcrumb).getByRole("link", { name: "노트 목록" }),
-    ).toHaveAttribute("href", ROUTES.NOTES);
-
-    // 마지막 항목은 링크가 아닌 현재 위치이며, 잘린 제목 대신 title로 전체 제목을 노출한다.
-    const currentPage = within(breadcrumb).getByText(longTitle);
-    expect(currentPage).toHaveAttribute("aria-current", "page");
-    expect(currentPage).toHaveAttribute("title", longTitle);
-    expect(currentPage).toHaveClass("truncate");
   });
 
   it("shows '다음 예정' (not 'due now') when notification time is still in the future today", async () => {

--- a/src/app/(main)/notes/[noteId]/page.tsx
+++ b/src/app/(main)/notes/[noteId]/page.tsx
@@ -1,15 +1,6 @@
 import type { Metadata } from "next";
-import Link from "next/link";
 import { notFound, redirect } from "next/navigation";
 
-import {
-  Breadcrumb,
-  BreadcrumbItem,
-  BreadcrumbLink,
-  BreadcrumbList,
-  BreadcrumbPage,
-  BreadcrumbSeparator,
-} from "@/components/ui/breadcrumb";
 import { NoteDetailBody } from "@/features/notes/components/NoteDetailBody";
 import { ScrollToTopOnMount } from "@/features/notes/components/ScrollToTopOnMount";
 import { getNoteById } from "@/features/notes/queries";
@@ -87,31 +78,6 @@ export default async function NoteDetailPage({
   return (
     <div className="mx-auto w-full max-w-4xl px-6 py-10 md:px-12">
       <ScrollToTopOnMount />
-      <Breadcrumb className="mb-6">
-        <BreadcrumbList>
-          <BreadcrumbItem>
-            <BreadcrumbLink asChild>
-              <Link href={ROUTES.HOME}>홈</Link>
-            </BreadcrumbLink>
-          </BreadcrumbItem>
-          <BreadcrumbSeparator />
-          <BreadcrumbItem>
-            <BreadcrumbLink asChild>
-              <Link href={ROUTES.NOTES}>노트 목록</Link>
-            </BreadcrumbLink>
-          </BreadcrumbItem>
-          <BreadcrumbSeparator />
-          <BreadcrumbItem>
-            {/* 제목이 길면 breadcrumb가 여러 줄로 밀리므로 잘라내고 전체 제목은 title로 노출한다. */}
-            <BreadcrumbPage
-              className="max-w-[180px] truncate font-medium sm:max-w-xs"
-              title={note.title}
-            >
-              {note.title}
-            </BreadcrumbPage>
-          </BreadcrumbItem>
-        </BreadcrumbList>
-      </Breadcrumb>
       <NoteDetailBody
         noteId={note.id}
         title={note.title}


### PR DESCRIPTION
## 개요

#291(노트 상세 페이지 breadcrumb 추가) 커밋이 리뷰 없이 `development`에 직접 push된 상태라, 리뷰 절차를 밟기 위해 해당 변경을 되돌립니다.

`development`는 force-push가 보호 규칙(GH006)으로 막혀 있어 히스토리를 되감을 수 없고, 원 커밋 `14d406f`가 이미 `development`의 조상이라 그대로는 PR을 열 수 없습니다(diff 0). 따라서 revert 커밋으로 변경을 먼저 제거한 뒤, 별도 PR로 동일한 변경을 다시 올려 리뷰를 받습니다.

**이 PR은 기능 변경이 아니라 절차 복구용입니다.** 머지 직후 재적용 PR이 올라갑니다.

## PR 유형

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] UI 디자인 변경
- [ ] 코드 리팩토링
- [ ] 테스트 추가/수정
- [ ] 문서 수정
- [ ] 빌드/패키지 설정 변경

## 관련 이슈

#291

<!-- 이 PR에서는 이슈를 닫지 않습니다. 재적용 PR에서 closes 처리합니다. -->

## 작업 내용

`14d406f`를 `git revert`로 되돌린 커밋 1개이며, 추가 변경은 없습니다.

| 파일                                       | 변경                                                          |
| ------------------------------------------ | ------------------------------------------------------------- |
| `src/app/(main)/notes/[noteId]/page.tsx`      | breadcrumb(`홈 > 노트 목록 > 노트 제목`) 및 관련 import 제거  |
| `src/app/(main)/notes/[noteId]/page.test.tsx` | breadcrumb 렌더링 테스트 및 `within` import 제거              |

총 2 files changed, 1 insertion(+), 72 deletions(-) — `14d406f`의 정확한 역방향입니다.

## 테스트 방법

1. 로그인한 상태로 노트 상세 페이지(`/notes/[noteId]`)에 접속합니다.
2. 상단에 breadcrumb가 **보이지 않는지** 확인합니다.
3. 제목·복습 상태 메시지·백지 테스트 버튼·알림 시간 설정 등 나머지 요소가 이전과 동일하게 동작하는지 확인합니다.

**검증 완료 항목**

| 항목                     | 결과                        |
| ------------------------ | --------------------------- |
| `npm run lint`           | 통과                        |
| `npx prettier --check .` | 통과                        |
| `npm run type-check`     | 통과                        |
| `npx vitest run`         | 212 파일 / 2014 테스트 통과 |
| `npm run build`          | 통과                        |

## 스크린샷 (FE 변경 시)

노트 상세 페이지 상단의 `홈 > 노트 목록 > {노트 제목}` breadcrumb 한 줄이 사라집니다. 그 외 레이아웃 변화는 없습니다. (되돌리기 전 상태 = 현재 `development`)

## 리뷰 요구사항 (선택)

- 되돌리기가 목적이라 코드보다 **절차 판단**에 대한 확인을 부탁드립니다. 이 PR을 머지하고 재적용 PR로 리뷰받는 흐름이 맞는지, 아니면 이미 `development`에 들어간 상태를 그대로 두는 편이 나은지 의견 주세요.
- 이 PR 머지 후 곧바로 재적용 PR(`feat/291-breadcrumb-relanded`)을 올릴 예정입니다.
- 참고: 직접 push가 발생한 원인은 로컬 브랜치의 upstream이 `origin/development`로 잡혀 있었기 때문입니다(`git checkout -b <branch> origin/development`). `development`가 force-push는 막으면서 일반 push는 허용하는 설정이라 사고를 막아주는 장치가 없었는데, PR 필수 규칙 추가가 필요한지도 함께 봐주시면 좋겠습니다.

## 체크리스트

- [x] 코드 컨벤션 준수
- [x] 커밋 메시지 컨벤션 준수
- [x] lint 통과
- [x] typecheck 통과
- [ ] (DB 변경 시) migration 포함 및 로컬 재현 확인 <!-- 해당 없음: DB 변경 없음 -->
- [ ] (권한/RLS 영향 시) 정책 변경 요약 기재 <!-- 해당 없음: 권한/RLS 영향 없음 -->
- [x] UI 변경 시 스크린샷/짧은 설명 첨부
- [ ] 셀프 리뷰 완료
