### PR TITLE
feat: #291 - 노트 상세 페이지 breadcrumb 추가

### DIFF
--- a/src/app/(main)/notes/[noteId]/page.test.tsx
+++ b/src/app/(main)/notes/[noteId]/page.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { getNoteReviewRoute, ROUTES } from "@/lib/constants/routes";
@@ -172,6 +172,43 @@ describe("NoteDetailPage", () => {
     expect(
       screen.getByRole("button", { name: "노트 삭제" }),
     ).toBeInTheDocument();
+  });
+
+  it("renders a breadcrumb linking back to home and the notes list", async () => {
+    // 공백이 없어 줄바꿈으로 도망갈 수 없는 제목. truncate가 빠지면 breadcrumb 줄을 밀어버린다.
+    const longTitle =
+      "SupabaseRowLevelSecurityPolicyMigrationChecklistForNoteReviewSchedulingRpcAndPartialUniqueIndexes";
+    createClientMock.mockResolvedValue(createSupabaseMock("user-123"));
+    getNoteByIdMock.mockResolvedValue({
+      id: "note-123",
+      title: longTitle,
+      content: "note body",
+      next_review_at: "2026-03-29T00:00:00.000Z",
+      next_scheduled_at: "2026-03-29T09:00:00.000Z",
+      notification_time_of_day: "21:30:00",
+      review_round: 1,
+      created_at: "2026-03-29T00:00:00.000Z",
+      updated_at: "2026-03-29T01:00:00.000Z",
+      user_id: "user-123",
+    });
+
+    render(
+      await NoteDetailPage({ params: Promise.resolve({ noteId: "note-123" }) }),
+    );
+
+    const breadcrumb = screen.getByRole("navigation", { name: "breadcrumb" });
+    expect(
+      within(breadcrumb).getByRole("link", { name: "홈" }),
+    ).toHaveAttribute("href", ROUTES.HOME);
+    expect(
+      within(breadcrumb).getByRole("link", { name: "노트 목록" }),
+    ).toHaveAttribute("href", ROUTES.NOTES);
+
+    // 마지막 항목은 링크가 아닌 현재 위치이며, 잘린 제목 대신 title로 전체 제목을 노출한다.
+    const currentPage = within(breadcrumb).getByText(longTitle);
+    expect(currentPage).toHaveAttribute("aria-current", "page");
+    expect(currentPage).toHaveAttribute("title", longTitle);
+    expect(currentPage).toHaveClass("truncate");
   });
 
   it("shows '다음 예정' (not 'due now') when notification time is still in the future today", async () => {

--- a/src/app/(main)/notes/[noteId]/page.tsx
+++ b/src/app/(main)/notes/[noteId]/page.tsx
@@ -1,6 +1,15 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 import { notFound, redirect } from "next/navigation";
 
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "@/components/ui/breadcrumb";
 import { NoteDetailBody } from "@/features/notes/components/NoteDetailBody";
 import { ScrollToTopOnMount } from "@/features/notes/components/ScrollToTopOnMount";
 import { getNoteById } from "@/features/notes/queries";
@@ -78,6 +87,31 @@ export default async function NoteDetailPage({
   return (
     <div className="mx-auto w-full max-w-4xl px-6 py-10 md:px-12">
       <ScrollToTopOnMount />
+      <Breadcrumb className="mb-6">
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <BreadcrumbLink asChild>
+              <Link href={ROUTES.HOME}>홈</Link>
+            </BreadcrumbLink>
+          </BreadcrumbItem>
+          <BreadcrumbSeparator />
+          <BreadcrumbItem>
+            <BreadcrumbLink asChild>
+              <Link href={ROUTES.NOTES}>노트 목록</Link>
+            </BreadcrumbLink>
+          </BreadcrumbItem>
+          <BreadcrumbSeparator />
+          <BreadcrumbItem>
+            {/* 제목이 길면 breadcrumb가 여러 줄로 밀리므로 잘라내고 전체 제목은 title로 노출한다. */}
+            <BreadcrumbPage
+              className="max-w-[180px] truncate font-medium sm:max-w-xs"
+              title={note.title}
+            >
+              {note.title}
+            </BreadcrumbPage>
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>
       <NoteDetailBody
         noteId={note.id}
         title={note.title}


### PR DESCRIPTION
## 개요

노트 상세 페이지(`/notes/[noteId]`)에는 breadcrumb가 없어 현재 위치와 상위 경로를 알 수 없었습니다. 마이페이지에서 이미 쓰고 있는 `@/components/ui/breadcrumb`를 그대로 사용해 동일한 형태로 추가합니다.

경로 구성은 `홈 > 노트 목록 > {노트 제목}`이며, 마지막 항목은 링크가 없는 현재 위치입니다.

> 이 PR은 #292(revert)로 되돌린 변경을 리뷰 절차를 거쳐 다시 올리는 것입니다. 코드는 되돌리기 전과 동일하며(cherry-pick), base가 바뀌었으므로 CI 검증은 다시 수행했습니다.

## PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] UI 디자인 변경
- [ ] 코드 리팩토링
- [x] 테스트 추가/수정
- [ ] 문서 수정
- [ ] 빌드/패키지 설정 변경

## 관련 이슈

closes #291

## 작업 내용

### `src/app/(main)/notes/[noteId]/page.tsx`

- 서버 컴포넌트에 Breadcrumb를 추가했습니다. `ScrollToTopOnMount` 아래, `NoteDetailBody` 위에 배치하고 `mb-6`으로 간격을 줬습니다.
- `홈`은 `ROUTES.HOME`, `노트 목록`은 `ROUTES.NOTES`로 연결했습니다. 경로 문자열을 직접 쓰지 않고 상수를 사용합니다.
- 라벨 "노트 목록"은 헤더 `NotesNav`와 목록 페이지 `h1` 표기에 맞췄습니다.
- 마지막 항목은 `BreadcrumbPage`(링크 없음, `aria-current="page"`)로 노트 제목을 표시합니다.
- 제목은 최대 100자(`noteSchema`)까지 가능해 그대로 두면 breadcrumb가 여러 줄로 밀립니다. `max-w-[180px] truncate sm:max-w-xs`로 자르고 `title` 속성에 전체 제목을 넣어 hover로 확인할 수 있게 했습니다. 의도는 주석으로 남겼습니다.

### `src/app/(main)/notes/[noteId]/page.test.tsx`

- breadcrumb 렌더링 테스트 1건을 추가했습니다(총 2015건).
- `홈` → `/`, `노트 목록` → `/notes` href를 검증하고, 현재 위치 항목의 `aria-current="page"`·`title`(전체 제목)·`truncate` 클래스를 확인합니다.
- 노트 제목이 `h1`에도 같이 나오므로 `within(breadcrumb)`으로 스코프를 좁혔습니다.
- mock 제목은 **공백이 없는 긴 문자열**을 씁니다. 공백이 있으면 `flex-wrap`으로 줄바꿈되어 도망갈 수 있어, `truncate`가 빠졌을 때 실패하지 않기 때문입니다.

## 테스트 방법

1. 로그인한 상태로 노트 상세 페이지(`/notes/[noteId]`)에 접속합니다.
2. 상단에 `홈 > 노트 목록 > {노트 제목}`이 보이고, `홈`·`노트 목록` 클릭 시 각각 이동하는지 확인합니다.
3. 제목이 긴 노트로 확인합니다. 아래 문자열을 제목에 넣으면 말줄임 동작을 바로 볼 수 있습니다.

   ```text
   SupabaseRowLevelSecurityPolicyMigrationChecklistForNoteReviewSchedulingRpcAndPartialUniqueIndexes
   ```

4. 뷰포트 폭을 **360 / 390 / 640 / 1280px**으로 바꿔가며 breadcrumb가 한 줄로 유지되는지 확인합니다. 컨테이너가 `px-6`이라 콘텐츠 폭은 `뷰포트 - 48px`이고, 360px에서 약 296px을 차지해 한 줄에 들어갑니다. 320px 이하에서는 `flex-wrap`으로 줄바꿈되며 이는 정상 폴백입니다.
5. 노트 "수정" 모드로 전환해도 breadcrumb가 그대로 보이는지 확인합니다(마이페이지와 동일하게 페이지 레벨에 있으므로 유지됩니다).

**검증 완료 항목**

| 항목                     | 결과                        |
| ------------------------ | --------------------------- |
| `npm run lint`           | 통과                        |
| `npx prettier --check .` | 통과                        |
| `npm run type-check`     | 통과                        |
| `npx vitest run`         | 212 파일 / 2015 테스트 통과 |
| `npm run build`          | 통과                        |

## 스크린샷 (FE 변경 시)

<img width="977" height="443" alt="image" src="https://github.com/user-attachments/assets/f7c15159-a239-4919-9aad-b4e1ea23193e" />

## 리뷰 요구사항 (선택)

- 말줄임 폭 `max-w-[180px]`(모바일) / `sm:max-w-xs`(640px 이상)이 적절한지 봐주세요. 360px 기기에서 여유가 약 16px로 빠듯합니다. 더 보수적으로 가려면 `max-w-[140px]`로 줄일 수 있지만 제목이 더 일찍 잘립니다.
- 라벨을 "노트 목록"으로 했습니다. 헤더·목록 페이지 표기와 맞춘 것인데 다른 표현이 낫다면 알려주세요.
- 노트 수정 모드에서도 breadcrumb가 유지됩니다. 마이페이지와 동일한 동작이라 그대로 뒀는데, 수정 중에는 숨기는 편이 낫다는 의견이 있으면 반영하겠습니다.

## 체크리스트

- [x] 코드 컨벤션 준수
- [x] 커밋 메시지 컨벤션 준수
- [x] lint 통과
- [x] typecheck 통과
- [ ] (DB 변경 시) migration 포함 및 로컬 재현 확인 <!-- 해당 없음: DB 변경 없음 -->
- [ ] (권한/RLS 영향 시) 정책 변경 요약 기재 <!-- 해당 없음: 권한/RLS 영향 없음 -->
- [x] UI 변경 시 스크린샷/짧은 설명 첨부 <!-- 확인 필요: 스크린샷 첨부 후 체크 -->
- [x] 셀프 리뷰 완료
