### PR TITLE
fix: #294 - breadcrumb 구분자 크기 조정

### DIFF
--- a/src/components/ui/breadcrumb.tsx
+++ b/src/components/ui/breadcrumb.tsx
@@ -79,7 +79,7 @@ function BreadcrumbSeparator({
       data-slot="breadcrumb-separator"
       role="presentation"
       aria-hidden="true"
-      className={cn("[&>svg]:size-3.5", className)}
+      className={cn("[&>svg]:size-3", className)}
       {...props}
     >
       {children ?? <ChevronRightIcon />}


### PR DESCRIPTION
## 개요

breadcrumb 구분자(`>` 화살표)가 옆 텍스트와 어울리지 않고 어색하게 보이는 문제를 수정합니다.

원인은 크기 자체가 아니라 **크기와 선 굵기의 균형**이었습니다. lucide `ChevronRight`는 24 viewBox에서 path(`m9 18 6-6-6-6`)가 세로로 절반만 차지해 실제 보이는 화살표가 박스의 절반뿐인데, stroke는 박스 크기에 비례해 굵어집니다. 기존 `size-3.5`(14px) + 기본 stroke 2 조합은 화살표는 7px로 작으면서 선은 1.17px로 굵어, 구분자가 뒤로 물러나지도 또렷하지도 않은 어정쩡한 상태였습니다.

박스를 `size-3`(12px)으로 줄여 선 두께가 정확히 **1.0px**로 떨어지게 했습니다. 구분자가 자연스럽게 뒤로 물러나면서도 어느 디스플레이에서든 또렷하게 렌더됩니다.

## PR 유형

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [x] UI 디자인 변경
- [ ] 코드 리팩토링
- [ ] 테스트 추가/수정
- [ ] 문서 수정
- [ ] 빌드/패키지 설정 변경

## 관련 이슈

closes #294

## 작업 내용

### `src/components/ui/breadcrumb.tsx`

`BreadcrumbSeparator`의 아이콘 크기를 `[&>svg]:size-3.5` → `[&>svg]:size-3`으로 변경했습니다. 변경은 이 한 줄이 전부입니다.

SVG의 `stroke-width`는 viewBox(24 단위) 기준이라 화면상 두께는 `strokeWidth × (박스 px ÷ 24)`로 계산됩니다.

| 설정                      | 실제 선 두께 | 비고                                  |
| ------------------------- | ------------ | ------------------------------------- |
| `size-3.5` + stroke 2 (기존) | 1.17px       | 반픽셀에 걸쳐 흐릿하고 굵게 보임      |
| **`size-3` + stroke 2 (변경)** | **1.0px**    | DPR 1·2 모두 물리 픽셀에 정확히 일치 |

`strokeWidth` prop은 쓰지 않았습니다. lucide 기본값이 2이고, 12px 박스에서 그대로 1.0px로 떨어지므로 추가 설정 없이 원본 shadcn 형태를 유지합니다.

**영향 범위** — 공용 컴포넌트라 breadcrumb를 쓰는 화면 전체에 적용됩니다.

| 화면       | 파일                                                       |
| ---------- | ---------------------------------------------------------- |
| 마이페이지 | `src/app/(main)/mypage/page.tsx`                           |
| 관리자     | `src/features/admin/components/layout/AdminBreadcrumb.tsx` |
| 노트 상세  | `src/app/(main)/notes/[noteId]/page.tsx` (#291 / PR #293에서 추가 중) |

노트 상세 breadcrumb는 아직 `development`에 없습니다. #293이 머지되면 이 변경이 함께 적용됩니다. 두 PR은 파일이 겹치지 않아 충돌하지 않습니다.

## 테스트 방법

1. 로그인 후 마이페이지(`/mypage`)에 접속합니다.
2. 상단 breadcrumb `홈 > 마이페이지 > 학습 통계`의 구분자가 텍스트와 자연스럽게 어울리는지 확인합니다.
3. 관리자 페이지(`/admin/users` 등)의 breadcrumb에도 동일하게 반영됐는지 확인합니다.
4. 가능하면 일반 해상도(DPR 1) 모니터와 고해상도(DPR 2) 화면 양쪽에서 선이 흐릿하지 않은지 확인합니다.

**검증 완료 항목**

| 항목                     | 결과                        |
| ------------------------ | --------------------------- |
| `npm run lint`           | 통과                        |
| `npx prettier --check .` | 통과                        |
| `npm run type-check`     | 통과                        |
| `npx vitest run`         | 212 파일 / 2014 테스트 통과 |
| `npm run build`          | 통과                        |

## 스크린샷 (FE 변경 시)

<!-- TODO: 마이페이지 breadcrumb 수정 전/후 스크린샷 첨부 -->

## 리뷰 요구사항 (선택)

- 후보로 16px + `strokeWidth 1.5`(실제 1.0px), 18px, 24px + 음수 마진, 문자 구분자(`/`, `>`)를 모두 실물로 비교한 뒤 현재 조합을 택했습니다. 24px은 stroke가 2px로 굵어져 부담스러웠고, 문자 구분자는 breadcrumb 톤과 맞지 않았습니다.
- 12px은 기존(14px)보다 오히려 작지만, 선이 얇아지면서 "작아서 어색하다"는 인상이 해소됐습니다. 구분자가 텍스트보다 작고 연하게 물러나는 것은 shadcn·Vercel·GitHub 등에서도 동일한 방향입니다.
- 공용 컴포넌트(shadcn/ui 기반)를 직접 수정했습니다. 화면별 override 대신 공용 값을 바꾼 이유는 세 화면의 breadcrumb 모양을 일치시키기 위해서입니다.

## 체크리스트

- [x] 코드 컨벤션 준수
- [x] 커밋 메시지 컨벤션 준수
- [x] lint 통과
- [x] typecheck 통과
- [ ] (DB 변경 시) migration 포함 및 로컬 재현 확인 <!-- 해당 없음: DB 변경 없음 -->
- [ ] (권한/RLS 영향 시) 정책 변경 요약 기재 <!-- 해당 없음: 권한/RLS 영향 없음 -->
- [ ] UI 변경 시 스크린샷/짧은 설명 첨부 <!-- 확인 필요: 스크린샷 첨부 후 체크 -->
- [ ] 셀프 리뷰 완료
