### PR TITLE
test: #313 - Supabase SQL Test required check 검증용 임시 PR

### DIFF
--- a/.github/CI_313_REQUIRED_CHECK_TEST.md
+++ b/.github/CI_313_REQUIRED_CHECK_TEST.md
@@ -1,0 +1,5 @@
+# #313 Required Check 검증용 임시 PR
+
+`Supabase SQL Test`를 main·development required check로 승격한 뒤,
+merge queue/PR 이벤트에서 정상적으로 required check가 동작하는지 확인하기 위한 테스트 PR이다.
+검증이 끝나면 이 파일과 PR을 함께 정리한다.


### PR DESCRIPTION
## 목적

#313에서 `Supabase SQL Test`를 main·development required check로 승격했다.
PR 이벤트에서 해당 check가 정상적으로 required로 동작하는지 확인하기 위한 임시 검증용 PR이다.

검증 후 머지하지 않고 close + 브랜치 삭제 예정.