### PR TITLE
ci: 누락 마이그레이션 복구 옵션 main 반영

### DIFF
--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -7,6 +7,12 @@ on:
     paths:
       - "supabase/migrations/**"
   workflow_dispatch:
+    inputs:
+      include_all:
+        description: "Apply out-of-order migrations missing from remote history"
+        required: true
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -38,4 +44,9 @@ jobs:
           SUPABASE_DB_PASSWORD: ${{ secrets.PROD_SUPABASE_DB_PASSWORD }}
         run: |
           supabase link --project-ref ${{ secrets.PROD_SUPABASE_PROJECT_REF }}
-          supabase db push
+          if [[ "${{ inputs.include_all }}" == "true" ]]; then
+            supabase db push --include-all --dry-run
+            supabase db push --include-all
+          else
+            supabase db push
+          fi


### PR DESCRIPTION
## 개요

운영 DB의 누락된 과거 마이그레이션을 안전하게 복구할 수 있도록, development에 반영된 수동 `--include-all` 실행 옵션을 main에 배포합니다. 자동 마이그레이션은 기존의 엄격한 순서 검증을 계속 유지합니다.

## PR 유형

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] UI 디자인 변경
- [ ] 코드 리팩토링
- [ ] 테스트 추가/수정
- [ ] 문서 수정
- [x] 빌드/패키지 설정 변경

## 관련 이슈

선행 PR #322

## 작업 내용

- `workflow_dispatch`에 기본값이 `false`인 `include_all` boolean 입력을 추가했습니다.
- 수동 실행에서 `include_all=true`를 선택한 경우 dry-run으로 적용 대상을 확인한 뒤 `supabase db push --include-all`을 실행합니다.
- main push 자동 실행과 일반 수동 실행은 기존의 `supabase db push`를 유지합니다.

## 테스트 방법

1. `npm run lint`
2. `npx prettier --check .`
3. `npm run type-check`
4. `npx vitest run` — 261개 파일, 2,593개 테스트 통과
5. `npm run build`
6. main 머지 후 `Migrate DB`를 수동 실행하고 `include_all=true`일 때 누락된 `20260727102238_delete_feedback_reply_with_notifications.sql`이 적용되는지 확인

## 스크린샷 (FE 변경 시)

해당 없음

## 리뷰 요구사항 (선택)

- push 기반 자동 실행에서는 항상 기존 `supabase db push`가 실행되는지 확인해 주세요.
- `--include-all`이 명시적인 수동 실행에서만 활성화되는지 확인해 주세요.
- 머지 후 `Migrate DB`를 `include_all=true`로 한 번 수동 실행해야 운영 마이그레이션 복구가 완료됩니다.

## 체크리스트

- [x] 코드 컨벤션 준수
- [x] 커밋 메시지 컨벤션 준수
- [x] lint 통과
- [x] typecheck 통과
- [ ] (DB 변경 시) migration 포함 및 로컬 재현 확인
- [ ] (권한/RLS 영향 시) 정책 변경 요약 기재
- [ ] UI 변경 시 스크린샷/짧은 설명 첨부
- [ ] 셀프 리뷰 완료
